### PR TITLE
Update to Go v1.22.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sebrandon1/go-quay
 
-go 1.22.5
+go 1.22.6
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2360