### PR TITLE
Refactor: Update functions get and newRequest to be public

### DIFF
--- a/lib/client.go
+++ b/lib/client.go
@@ -21,7 +21,7 @@ func NewClient(bearerToken string) (*Client, error) {
 	}, nil
 }
 
-func (c *Client) get(req *http.Request, v interface{}) error {
+func (c *Client) Get(req *http.Request, v interface{}) error {
 	req.Header.Set("Authorization", "Bearer "+c.BearerToken)
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}
@@ -37,6 +37,6 @@ func decodeJSON(r io.Reader, v interface{}) error {
 	return json.NewDecoder(r).Decode(v)
 }
 
-func newRequest(method, url string, body io.Reader) (*http.Request, error) {
+func NewRequest(method, url string, body io.Reader) (*http.Request, error) {
 	return http.NewRequest(method, url, body)
 }

--- a/lib/logs.go
+++ b/lib/logs.go
@@ -95,7 +95,7 @@ type OrganizationLogs struct {
 // GetAggregatedLogs returns the aggregated logs for a repository
 func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate string) (*AggregatedLogs, error) {
 	// Get new request
-	req, err := newRequest("GET", QuayURL+"/repository/"+namespace+"/"+repository+"/aggregatelogs", nil)
+	req, err := NewRequest("GET", QuayURL+"/repository/"+namespace+"/"+repository+"/aggregatelogs", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate str
 	req.URL.RawQuery = decoded
 
 	var logs AggregatedLogs
-	err = c.get(req, &logs)
+	err = c.Get(req, &logs)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,7 @@ func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate str
 // GetLogs returns the logs for a repository
 func (c *Client) GetLogs(namespace, repository, next_page string) (*Logs, error) {
 	// Get new request
-	req, err := newRequest("GET", QuayURL+"/repository/"+namespace+"/"+repository+"/logs", nil)
+	req, err := NewRequest("GET", QuayURL+"/repository/"+namespace+"/"+repository+"/logs", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func (c *Client) GetLogs(namespace, repository, next_page string) (*Logs, error)
 	}
 
 	var logs Logs
-	err = c.get(req, &logs)
+	err = c.Get(req, &logs)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (c *Client) GetLogs(namespace, repository, next_page string) (*Logs, error)
 // GetOrganizationLogs returns the logs for an organization
 func (c *Client) GetOrganizationLogs(namespace, next_page string) (*OrganizationLogs, error) {
 	// Get new request
-	req, err := newRequest("GET", QuayURL+"/organization/"+namespace+"/logs", nil)
+	req, err := NewRequest("GET", QuayURL+"/organization/"+namespace+"/logs", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func (c *Client) GetOrganizationLogs(namespace, next_page string) (*Organization
 	}
 
 	var logs OrganizationLogs
-	err = c.get(req, &logs)
+	err = c.Get(req, &logs)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/repository.go
+++ b/lib/repository.go
@@ -54,24 +54,24 @@ type RepositoryWithTags struct {
 // GetRepository returns a repository with tags information baked in
 func (c *Client) GetRepository(namespace, repository string) (RepositoryWithTags, error) {
 	// Note: For some reason the API does not return tags in an array but as a map
-	req, err := newRequest("GET", "https://quay.io/api/v1/repository/"+namespace+"/"+repository, nil)
+	req, err := NewRequest("GET", "https://quay.io/api/v1/repository/"+namespace+"/"+repository, nil)
 	if err != nil {
 		return RepositoryWithTags{}, err
 	}
 
 	var repo Repository
-	err = c.get(req, &repo)
+	err = c.Get(req, &repo)
 	if err != nil {
 		return RepositoryWithTags{}, err
 	}
 
-	req, err = newRequest("GET", "https://quay.io/api/v1/repository/"+namespace+"/"+repository+"/tag", nil)
+	req, err = NewRequest("GET", "https://quay.io/api/v1/repository/"+namespace+"/"+repository+"/tag", nil)
 	if err != nil {
 		return RepositoryWithTags{}, err
 	}
 
 	var tags RepositoryTags
-	err = c.get(req, &tags)
+	err = c.Get(req, &tags)
 	if err != nil {
 		return RepositoryWithTags{}, err
 	}


### PR DESCRIPTION
This PR updates the visibility of the get and newRequest functions, changing them from private to public. 

**Changes:**

- get function is now Get

- newRequest function is now NewRequest