### PR TITLE
Update Go to v1.23.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sebrandon1/go-quay
 
-go 1.23.4
+go 1.23.5
 
 require github.com/spf13/cobra v1.8.1
 


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2704