### PR TITLE
Update golangci-lint-action to v7

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -22,6 +22,4 @@ jobs:
       run: make vet
 
     - name: Run GolangCI-Lint
-      uses: golangci/golangci-lint-action@v6
-      with:
-        version: v1.64
+      uses: golangci/golangci-lint-action@v7

--- a/lib/client.go
+++ b/lib/client.go
@@ -35,7 +35,12 @@ func (c *Client) get(req *http.Request, v interface{}) error {
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
-	defer resp.Body.Close()
+	func() {
+		err := resp.Body.Close()
+		if err != nil {
+			fmt.Println("error closing response body:", err)
+		}
+	}()
 	return decodeJSON(resp.Body, v)
 }
 


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2875