### PR TITLE
Various improvements

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -23,3 +23,6 @@ jobs:
 
     - name: Run GolangCI-Lint
       uses: golangci/golangci-lint-action@v7
+
+    - name: Run 'make test'
+      run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,38 @@
+version: "2"
+linters:
+  enable:
+    - goconst
+    - gocritic
+    - gocyclo
+    - misspell
+    - unparam
+  settings:
+    gocyclo:
+      min-complexity: 15
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - errcheck
+        path: _test.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,11 @@ build:
 
 lint:
 	golangci-lint run ./...
+
+test:
+	go test ./... -v
+
+clean:
+	rm -f $(APP_NAME)
+
+.PHONY: vet build lint test clean

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,8 +4,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-
-
 var rootCmd = &cobra.Command{
 	Use:   "quay",
 	Short: "Quay CLI interacts with Quay.io API",

--- a/lib/logs.go
+++ b/lib/logs.go
@@ -1,7 +1,7 @@
 package lib
 
 import (
-	"net/url"
+	"fmt"
 )
 
 const (
@@ -95,54 +95,39 @@ type OrganizationLogs struct {
 // GetAggregatedLogs returns the aggregated logs for a repository
 func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate string) (*AggregatedLogs, error) {
 	// Get new request
-	req, err := newRequest("GET", QuayURL+"/repository/"+namespace+"/"+repository+"/aggregatelogs", nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/aggregatelogs", QuayURL, namespace, repository), nil)
 	if err != nil {
 		return nil, err
 	}
-
-	// Set the bearer token
-	req.Header.Add("Authorization", "Bearer "+c.BearerToken)
 
 	// set the query parameters for starttime and endtime
 	q := req.URL.Query()
 	q.Add("starttime", startDate)
 	q.Add("endtime", endDate)
-
-	decoded, err := url.QueryUnescape(q.Encode())
-	if err != nil {
-		return nil, err
-	}
-	req.URL.RawQuery = decoded
+	req.URL.RawQuery = q.Encode()
 
 	var logs AggregatedLogs
-	err = c.get(req, &logs)
-	if err != nil {
+	if err := c.get(req, &logs); err != nil {
 		return nil, err
 	}
 	return &logs, nil
 }
 
 // GetLogs returns the logs for a repository
-func (c *Client) GetLogs(namespace, repository, next_page string) (*Logs, error) {
-	// Get new request
-	req, err := newRequest("GET", QuayURL+"/repository/"+namespace+"/"+repository+"/logs", nil)
+func (c *Client) GetLogs(namespace, repository, nextPage string) (*Logs, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/logs", QuayURL, namespace, repository), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	// Set the bearer token
-	req.Header.Add("Authorization", "Bearer "+c.BearerToken)
-
-	// set the query parameters for next_page
-	if next_page != "" {
+	if nextPage != "" {
 		q := req.URL.Query()
-		q.Add("next_page", next_page)
+		q.Add("next_page", nextPage)
 		req.URL.RawQuery = q.Encode()
 	}
 
 	var logs Logs
-	err = c.get(req, &logs)
-	if err != nil {
+	if err := c.get(req, &logs); err != nil {
 		return nil, err
 	}
 	return &logs, nil


### PR DESCRIPTION
This pull request introduces several improvements and new features across the codebase, focusing on enhancing HTTP client functionality, improving error handling, adding testing and linting capabilities, and cleaning up unused imports. Below is a summary of the most important changes grouped by theme:

### HTTP Client Enhancements:
* Introduced a configurable `HTTPClient` with a 10-second timeout to the `Client` struct in `lib/client.go`, replacing the creation of a new HTTP client for each request. This improves efficiency and consistency. [[1]](diffhunk://#diff-cfd520368f63222743636086df520e6b3f69fcd3692f74d0745bd02806ff8c69R9-R14) [[2]](diffhunk://#diff-cfd520368f63222743636086df520e6b3f69fcd3692f74d0745bd02806ff8c69R24-R57)

### Error Handling Improvements:
* Enhanced error messages in `GetAggregatedLogs`, `GetLogs`, and `GetRepository` methods by including detailed context (e.g., request URLs and response bodies) to aid debugging. [[1]](diffhunk://#diff-4a7abe81adfdc6827e2852637e6db23dc41a9b7a389786a10489151b75eea815L98-R130) [[2]](diffhunk://#diff-e71ecc11d1e8dee8681270dae5f59a2df3b067fc650224998b79d54a54a382c6L56-R81)

### Testing and Linting:
* Added a `test` target to the `Makefile` for running Go tests and integrated it into the GitHub Actions workflow. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R11-R18) [[2]](diffhunk://#diff-d129ccdb52a4a787e853ce5bb5f1b2959db2facc988e9ec5d123d4a91e4e6669R26-R28)
* Introduced a `.golangci.yml` configuration file to enable and configure several linters, including `goconst`, `gocritic`, and `misspell`.

### Code Cleanup:
* Removed unused imports, such as `net/url` in `lib/logs.go` and extra blank lines in `cmd/root.go`. [[1]](diffhunk://#diff-4a7abe81adfdc6827e2852637e6db23dc41a9b7a389786a10489151b75eea815L4-R4) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL7-L8)

### Refactoring:
* Consolidated URL formatting using `fmt.Sprintf` in `lib/logs.go` and `lib/repository.go` to improve readability and maintainability. [[1]](diffhunk://#diff-4a7abe81adfdc6827e2852637e6db23dc41a9b7a389786a10489151b75eea815L98-R130) [[2]](diffhunk://#diff-e71ecc11d1e8dee8681270dae5f59a2df3b067fc650224998b79d54a54a382c6L56-R81)