### PR TITLE
Shore up the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,18 @@ The following APIs are covered by the repo:
 | Discovery              | No      | No      |                                                                                                                                                                                                                     |
 | Error                  | No      | No      |                                                                                                                                                                                                                     |
 | Messages               | No      | No      |                                                                                                                                                                                                                     |
-| Logs                   | Partial | Partial | /api/v1/repository/{repository}/aggregatelogs |
+| Logs                   | Partial | Partial | /api/v1/repository/{namespace}/{repository}/aggregatelogs, /api/v1/repository/{namespace}/{repository}/logs, /api/v1/organization/{orgname}/logs |
 | Manifest               | No      | No      |                                                                                                                                                                                                                     |
-| Organization           | No      | No      |                                                                                                                                                                                                                     |
+| Organization           | Yes     | Yes     | /api/v1/organization/{orgname}, /api/v1/organization/{orgname}/members, /api/v1/organization/{orgname}/teams, /api/v1/organization/{orgname}/team/{teamname}, /api/v1/organization/{orgname}/robots, /api/v1/organization/{orgname}/quota, /api/v1/organization/{orgname}/autoprunepolicy, /api/v1/organization/{orgname}/applications |
 | Permission             | No      | No      |                                                                                                                                                                                                                     |
 | Prototype              | No      | No      |                                                                                                                                                                                                                     |
-| Repository             | Partial | Partial | /api/v1/repository/{repository}                                                                                                 |
+| Repository             | Partial | Partial | /api/v1/repository/{namespace}/{repository}, /api/v1/repository/{namespace}/{repository}/tag                                   |
 | RepositoryNotification | No      | No      |                                                                                                                                                                                                                     |
 | RepoToken              | No      | No      |                                                                                                                                                                                                                     |
 | Robot                  | No      | No      |                                                                                                                                                                                                                     |
 | Search                 | No      | No      |                                                                                                                                                                                                                     |
 | SecScan                | No      | No      |                                                                                                                                                                                                                     |
-| Tag                    | Partial | Partial | /api/v1/repository/{repository}/tag                                                                                                                   |
+| Tag                    | Partial | Partial | /api/v1/repository/{namespace}/{repository}/tag (included in Repository API)                                                                       |
 | Team                   | No      | No      |                                                                                                                                                                                                                     |
 | Trigger                | No      | No      |                                                                                                                                                                                                                     |
 | User                   | No      | No      | 
@@ -115,3 +115,68 @@ This returns comprehensive repository information including:
 - Repository metadata (description, visibility, permissions)
 - All repository tags with details (size, last modified, expiration)
 - Organization and user permissions
+
+### Organization API
+
+The organization API provides comprehensive management of organizations, teams, members, robots, and related settings.
+
+#### Get organization information
+```bash
+./go-quay get organization info \
+  --organization ORG_NAME \
+  --token YOUR_TOKEN
+```
+
+#### Manage organization members
+```bash
+# List all members
+./go-quay get organization members \
+  -o myorg \
+  -t YOUR_TOKEN
+```
+
+#### Manage teams
+```bash
+# List all teams in an organization
+./go-quay get organization teams \
+  -o myorg \
+  -t YOUR_TOKEN
+
+# Get specific team information
+./go-quay get organization team \
+  -o myorg \
+  --team TEAM_NAME \
+  -t YOUR_TOKEN
+
+# Get team members
+./go-quay get organization team-members \
+  -o myorg \
+  --team TEAM_NAME \
+  -t YOUR_TOKEN
+```
+
+#### Manage robot accounts
+```bash
+# List organization robot accounts
+./go-quay get organization robots \
+  -o myorg \
+  -t YOUR_TOKEN
+```
+
+#### Get organization quota and policies
+```bash
+# Get organization quota information
+./go-quay get organization quota \
+  -o myorg \
+  -t YOUR_TOKEN
+
+# Get auto-prune policies
+./go-quay get organization auto-prune \
+  -o myorg \
+  -t YOUR_TOKEN
+
+# Get OAuth applications
+./go-quay get organization applications \
+  -o myorg \
+  -t YOUR_TOKEN
+```


### PR DESCRIPTION
This pull request updates the `README.md` to provide more complete documentation of the API endpoints and usage examples, with a particular focus on organization-related APIs. The main improvements include expanding the list of covered API endpoints, clarifying the scope of partial support for certain APIs, and adding detailed usage instructions for organization management commands.

**API documentation improvements:**

* Expanded the list of covered endpoints for the `Logs`, `Organization`, `Repository`, and `Tag` APIs to include more specific and accurate paths, reflecting broader API coverage.
* Updated the `Organization` API status from "No" to "Yes" for both read and write operations, indicating full support and listing all relevant endpoints.
* Clarified that the `Tag` API is included within the `Repository` API and updated the endpoint paths for consistency.

**Usage examples and instructions:**

* Added a new "Organization API" section with detailed command-line usage examples for managing organizations, teams, members, robot accounts, quotas, auto-prune policies, and OAuth applications using `go-quay`.
* Provided step-by-step instructions for common organization management tasks, including listing members and teams, retrieving team information, and managing robots and policies.