### PR TITLE
Update Go to 1.25.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sebrandon1/go-quay
 
-go 1.25.1
+go 1.25.2
 
 require github.com/spf13/cobra v1.10.1
 


### PR DESCRIPTION
This PR updates the Go version to 1.25.2.

Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3273