### PR TITLE
Add 'manifest' API path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following APIs are covered by the repo. Each API links to the corresponding 
 | [Error](https://docs.quay.io/api/swagger/#Error)                  | No      | No      |                                                                                                                                                                                                                     |
 | [Messages](https://docs.quay.io/api/swagger/#Messages)               | No      | No      |                                                                                                                                                                                                                     |
 | [Logs](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--aggregatelogs-get)                   | Partial | Partial | /api/v1/repository/{namespace}/{repository}/aggregatelogs, /api/v1/repository/{namespace}/{repository}/logs, /api/v1/organization/{orgname}/logs |
-| [Manifest](https://docs.quay.io/api/swagger/#Manifest)               | No      | No      |                                                                                                                                                                                                                     |
+| [Manifest](https://docs.quay.io/api/swagger/#Manifest)               | **Yes** | **Yes** | **/api/v1/repository/{namespace}/{repository}/manifest/{manifestref}**, **/api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/labels**, **/api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/labels/{labelid}** |
 | [Organization](https://docs.quay.io/api/swagger/#operation--api-v1-organization--orgname--get)           | Yes     | Yes     | /api/v1/organization/{orgname}, /api/v1/organization/{orgname}/members, /api/v1/organization/{orgname}/teams, /api/v1/organization/{orgname}/team/{teamname}, /api/v1/organization/{orgname}/robots, /api/v1/organization/{orgname}/quota, /api/v1/organization/{orgname}/autoprunepolicy, /api/v1/organization/{orgname}/applications |
 | [Permission](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--permissions-get)             | **Yes** | **Yes** | **/api/v1/repository/{namespace}/{repository}/permissions**, **/api/v1/repository/{namespace}/{repository}/permissions/{username}** |
 | [Prototype](https://docs.quay.io/api/swagger/#Prototype)              | No      | No      |                                                                                                                                                                                                                     |
@@ -264,6 +264,86 @@ Comprehensive tag management with detailed metadata, history, and operations.
   --repository myrepo \
   --tag latest \
   --manifest sha256:abc123... \
+  --token YOUR_TOKEN
+```
+
+### Manifest API
+
+Inspect and manage container image manifests, including layers, configuration, and labels.
+
+📖 **API Reference:** [Manifest endpoints in Swagger](https://docs.quay.io/api/swagger/#Manifest)
+
+#### Get manifest information
+```bash
+# Get detailed manifest info by digest
+./go-quay get manifest info \
+  --namespace myorg \
+  --repository myrepo \
+  --manifest sha256:abc123def456... \
+  --token YOUR_TOKEN
+```
+
+#### Delete a manifest
+```bash
+# Delete manifest (requires confirmation)
+./go-quay get manifest delete \
+  --namespace myorg \
+  --repository myrepo \
+  --manifest sha256:abc123def456... \
+  --confirm \
+  --token YOUR_TOKEN
+```
+
+**Note:** Manifest deletion is irreversible and will remove all tags pointing to this manifest.
+
+#### List manifest labels
+```bash
+./go-quay get manifest labels \
+  --namespace myorg \
+  --repository myrepo \
+  --manifest sha256:abc123def456... \
+  --token YOUR_TOKEN
+```
+
+#### Get a specific label
+```bash
+./go-quay get manifest label \
+  --namespace myorg \
+  --repository myrepo \
+  --manifest sha256:abc123def456... \
+  --label-id label-123 \
+  --token YOUR_TOKEN
+```
+
+#### Add a label to a manifest
+```bash
+# Add a simple label
+./go-quay get manifest add-label \
+  --namespace myorg \
+  --repository myrepo \
+  --manifest sha256:abc123def456... \
+  --key "environment" \
+  --value "production" \
+  --token YOUR_TOKEN
+
+# Add a label with custom media type
+./go-quay get manifest add-label \
+  -n myorg \
+  -r myrepo \
+  -m sha256:abc123def456... \
+  -k "config" \
+  -v '{"setting": "value"}' \
+  --media-type "application/json" \
+  -t YOUR_TOKEN
+```
+
+#### Remove a label from a manifest
+```bash
+./go-quay get manifest remove-label \
+  --namespace myorg \
+  --repository myrepo \
+  --manifest sha256:abc123def456... \
+  --label-id label-123 \
   --token YOUR_TOKEN
 ```
 

--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -1,0 +1,239 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sebrandon1/go-quay/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	manifestRef             string
+	labelID                 string
+	labelKey                string
+	labelValue              string
+	labelMediaType          string
+	confirmManifestDeletion bool
+)
+
+// manifestCmd represents the manifest command group
+var manifestCmd = &cobra.Command{
+	Use:   "manifest",
+	Short: "Container image manifest management commands",
+	Long: `Commands for managing container image manifests including inspection, labels, and deletion.
+
+Available commands:
+  info     - Get detailed manifest information
+  delete   - Delete a manifest
+  labels   - List manifest labels
+  label    - Get a specific manifest label
+  add-label    - Add a label to a manifest
+  remove-label - Remove a label from a manifest`,
+}
+
+// Manifest Info
+var manifestInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Get detailed manifest information",
+	Long:  `Get detailed information about a specific manifest including layers, config, and metadata.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		manifest, err := client.GetManifest(namespace, repository, manifestRef)
+		if err != nil {
+			fmt.Printf("Error getting manifest information: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Manifest information for %s/%s@%s\n", namespace, repository, manifestRef)
+		printJSON(manifest)
+	},
+}
+
+// Manifest Delete
+var manifestDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a manifest",
+	Long:  `Delete a specific manifest from the repository. This action cannot be undone.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirmManifestDeletion {
+			fmt.Printf("Are you sure you want to delete manifest %s/%s@%s? This action cannot be undone.\n", namespace, repository, manifestRef)
+			fmt.Print("Use --confirm to proceed with deletion.\n")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.DeleteManifest(namespace, repository, manifestRef)
+		if err != nil {
+			fmt.Printf("Error deleting manifest: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully deleted manifest %s/%s@%s\n", namespace, repository, manifestRef)
+	},
+}
+
+// Manifest Labels (list all)
+var manifestLabelsCmd = &cobra.Command{
+	Use:   "labels",
+	Short: "List manifest labels",
+	Long:  `List all labels associated with a specific manifest.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		labels, err := client.GetManifestLabels(namespace, repository, manifestRef)
+		if err != nil {
+			fmt.Printf("Error getting manifest labels: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Labels for manifest %s/%s@%s\n", namespace, repository, manifestRef)
+		printJSON(labels)
+	},
+}
+
+// Manifest Label (get specific)
+var manifestLabelCmd = &cobra.Command{
+	Use:   "label",
+	Short: "Get a specific manifest label",
+	Long:  `Get detailed information about a specific label on a manifest.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		label, err := client.GetManifestLabel(namespace, repository, manifestRef, labelID)
+		if err != nil {
+			fmt.Printf("Error getting manifest label: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Label %s for manifest %s/%s@%s\n", labelID, namespace, repository, manifestRef)
+		printJSON(label)
+	},
+}
+
+// Add Manifest Label
+var manifestAddLabelCmd = &cobra.Command{
+	Use:   "add-label",
+	Short: "Add a label to a manifest",
+	Long:  `Add a new label with a key-value pair to a specific manifest.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		label, err := client.AddManifestLabel(namespace, repository, manifestRef, labelKey, labelValue, labelMediaType)
+		if err != nil {
+			fmt.Printf("Error adding manifest label: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully added label to manifest %s/%s@%s\n", namespace, repository, manifestRef)
+		printJSON(label)
+	},
+}
+
+// Remove Manifest Label
+var manifestRemoveLabelCmd = &cobra.Command{
+	Use:   "remove-label",
+	Short: "Remove a label from a manifest",
+	Long:  `Remove a specific label from a manifest by its label ID.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.DeleteManifestLabel(namespace, repository, manifestRef, labelID)
+		if err != nil {
+			fmt.Printf("Error removing manifest label: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully removed label %s from manifest %s/%s@%s\n", labelID, namespace, repository, manifestRef)
+	},
+}
+
+func init() {
+	// Add subcommands to manifest command
+	manifestCmd.AddCommand(manifestInfoCmd)
+	manifestCmd.AddCommand(manifestDeleteCmd)
+	manifestCmd.AddCommand(manifestLabelsCmd)
+	manifestCmd.AddCommand(manifestLabelCmd)
+	manifestCmd.AddCommand(manifestAddLabelCmd)
+	manifestCmd.AddCommand(manifestRemoveLabelCmd)
+
+	// Global manifest flags (repository context)
+	manifestCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
+	manifestCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
+	manifestCmd.PersistentFlags().StringVarP(&manifestRef, "manifest", "m", "", "Manifest reference (digest like sha256:...)")
+	manifestCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
+
+	// Mark global flags as required
+	if err := manifestCmd.MarkPersistentFlagRequired("namespace"); err != nil {
+		fmt.Printf("Error marking namespace flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	if err := manifestCmd.MarkPersistentFlagRequired("repository"); err != nil {
+		fmt.Printf("Error marking repository flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	if err := manifestCmd.MarkPersistentFlagRequired("manifest"); err != nil {
+		fmt.Printf("Error marking manifest flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	if err := manifestCmd.MarkPersistentFlagRequired("token"); err != nil {
+		fmt.Printf("Error marking token flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Delete command specific flags
+	manifestDeleteCmd.Flags().BoolVar(&confirmManifestDeletion, "confirm", false, "Confirm manifest deletion")
+
+	// Label command specific flags (for getting a specific label)
+	manifestLabelCmd.Flags().StringVarP(&labelID, "label-id", "l", "", "Label ID")
+	if err := manifestLabelCmd.MarkFlagRequired("label-id"); err != nil {
+		fmt.Printf("Error marking label-id flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Add label command specific flags
+	manifestAddLabelCmd.Flags().StringVarP(&labelKey, "key", "k", "", "Label key")
+	manifestAddLabelCmd.Flags().StringVarP(&labelValue, "value", "v", "", "Label value")
+	manifestAddLabelCmd.Flags().StringVar(&labelMediaType, "media-type", "", "Label media type (optional, defaults to text/plain)")
+	if err := manifestAddLabelCmd.MarkFlagRequired("key"); err != nil {
+		fmt.Printf("Error marking key flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	if err := manifestAddLabelCmd.MarkFlagRequired("value"); err != nil {
+		fmt.Printf("Error marking value flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Remove label command specific flags
+	manifestRemoveLabelCmd.Flags().StringVarP(&labelID, "label-id", "l", "", "Label ID to remove")
+	if err := manifestRemoveLabelCmd.MarkFlagRequired("label-id"); err != nil {
+		fmt.Printf("Error marking label-id flag as required: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ func init() {
 	getCmd.AddCommand(permissionsCmd)
 	getCmd.AddCommand(tagCmd)
 	getCmd.AddCommand(userCmd)
+	getCmd.AddCommand(manifestCmd)
 }
 
 // Execute executes the root command.

--- a/lib/manifest.go
+++ b/lib/manifest.go
@@ -1,0 +1,120 @@
+/*
+Package lib provides Quay.io API client functionality.
+
+This file covers MANIFEST operations:
+
+Manifest Management:
+  - GET    /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}                - GetManifest()
+  - DELETE /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}                - DeleteManifest()
+
+Manifest Labels:
+  - GET    /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/labels         - GetManifestLabels()
+  - POST   /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/labels         - AddManifestLabel()
+  - GET    /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/labels/{labelid} - GetManifestLabel()
+  - DELETE /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/labels/{labelid} - DeleteManifestLabel()
+
+Manifest operations provide access to container image manifests, their layers,
+configuration, and labels for inspection and management.
+*/
+package lib
+
+import (
+	"fmt"
+)
+
+// GetManifest retrieves detailed information about a specific manifest
+func (c *Client) GetManifest(namespace, repository, manifestRef string) (*Manifest, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/manifest/%s", QuayURL, namespace, repository, manifestRef), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get manifest request: %w", err)
+	}
+
+	var manifest Manifest
+	if err := c.get(req, &manifest); err != nil {
+		return nil, fmt.Errorf("failed to get manifest: %w", err)
+	}
+
+	return &manifest, nil
+}
+
+// DeleteManifest deletes a specific manifest from a repository
+func (c *Client) DeleteManifest(namespace, repository, manifestRef string) error {
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/manifest/%s", QuayURL, namespace, repository, manifestRef), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete manifest request: %w", err)
+	}
+
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to delete manifest: %w", err)
+	}
+
+	return nil
+}
+
+// GetManifestLabels retrieves all labels for a specific manifest
+func (c *Client) GetManifestLabels(namespace, repository, manifestRef string) (*ManifestLabels, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/manifest/%s/labels", QuayURL, namespace, repository, manifestRef), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get manifest labels request: %w", err)
+	}
+
+	var labels ManifestLabels
+	if err := c.get(req, &labels); err != nil {
+		return nil, fmt.Errorf("failed to get manifest labels: %w", err)
+	}
+
+	return &labels, nil
+}
+
+// AddManifestLabel adds a label to a specific manifest
+func (c *Client) AddManifestLabel(namespace, repository, manifestRef, key, value, mediaType string) (*ManifestLabel, error) {
+	addReq := AddManifestLabelRequest{
+		Key:   key,
+		Value: value,
+	}
+
+	if mediaType != "" {
+		addReq.MediaType = mediaType
+	}
+
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/manifest/%s/labels", QuayURL, namespace, repository, manifestRef), addReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create add manifest label request: %w", err)
+	}
+
+	var label ManifestLabel
+	if err := c.post(req, &label); err != nil {
+		return nil, fmt.Errorf("failed to add manifest label: %w", err)
+	}
+
+	return &label, nil
+}
+
+// GetManifestLabel retrieves a specific label from a manifest
+func (c *Client) GetManifestLabel(namespace, repository, manifestRef, labelID string) (*ManifestLabel, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/manifest/%s/labels/%s", QuayURL, namespace, repository, manifestRef, labelID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get manifest label request: %w", err)
+	}
+
+	var label ManifestLabel
+	if err := c.get(req, &label); err != nil {
+		return nil, fmt.Errorf("failed to get manifest label: %w", err)
+	}
+
+	return &label, nil
+}
+
+// DeleteManifestLabel deletes a specific label from a manifest
+func (c *Client) DeleteManifestLabel(namespace, repository, manifestRef, labelID string) error {
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/manifest/%s/labels/%s", QuayURL, namespace, repository, manifestRef, labelID), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete manifest label request: %w", err)
+	}
+
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to delete manifest label: %w", err)
+	}
+
+	return nil
+}

--- a/lib/manifest_test.go
+++ b/lib/manifest_test.go
@@ -1,0 +1,371 @@
+package lib
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	testManifestRef    = "sha256:abc123def456789"
+	testLabelID        = "label-123"
+	httpGetManifest    = "GET"
+	httpPostManifest   = "POST"
+	httpDeleteManifest = "DELETE"
+)
+
+func TestGetManifest(t *testing.T) {
+	mockManifest := Manifest{
+		Digest:         testManifestRef,
+		SchemaVersion:  2,
+		MediaType:      "application/vnd.docker.distribution.manifest.v2+json",
+		Size:           1024000,
+		IsManifestList: false,
+		Layers: []ManifestLayer{
+			{
+				MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+				Size:      512000,
+				Digest:    "sha256:layer1digest",
+				Index:     0,
+			},
+			{
+				MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+				Size:      512000,
+				Digest:    "sha256:layer2digest",
+				Index:     1,
+			},
+		},
+		Config: ManifestConfig{
+			MediaType: "application/vnd.docker.container.image.v1+json",
+			Size:      1500,
+			Digest:    "sha256:configdigest",
+		},
+	}
+
+	mockResponseJSON, _ := json.Marshal(mockManifest)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetManifest {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repository/testorg/testrepo/manifest/"+testManifestRef {
+			t.Errorf("Expected path /api/v1/repository/testorg/testrepo/manifest/%s, got %s", testManifestRef, r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	manifest, err := client.GetManifest("testorg", "testrepo", testManifestRef)
+	if err != nil {
+		t.Fatalf("GetManifest failed: %v", err)
+	}
+
+	if manifest.Digest != testManifestRef {
+		t.Errorf("Expected manifest digest '%s', got '%s'", testManifestRef, manifest.Digest)
+	}
+	if manifest.SchemaVersion != 2 {
+		t.Errorf("Expected schema version 2, got %d", manifest.SchemaVersion)
+	}
+	if len(manifest.Layers) != 2 {
+		t.Errorf("Expected 2 layers, got %d", len(manifest.Layers))
+	}
+	if manifest.Config.Digest != "sha256:configdigest" {
+		t.Errorf("Expected config digest 'sha256:configdigest', got '%s'", manifest.Config.Digest)
+	}
+}
+
+func TestDeleteManifest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpDeleteManifest {
+			t.Errorf("Expected DELETE request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repository/testorg/testrepo/manifest/"+testManifestRef {
+			t.Errorf("Expected path /api/v1/repository/testorg/testrepo/manifest/%s, got %s", testManifestRef, r.URL.Path)
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.DeleteManifest("testorg", "testrepo", testManifestRef)
+	if err != nil {
+		t.Fatalf("DeleteManifest failed: %v", err)
+	}
+}
+
+func TestGetManifestLabels(t *testing.T) {
+	mockLabels := ManifestLabels{
+		Labels: []ManifestLabel{
+			{
+				ID:         "label-1",
+				Key:        "version",
+				Value:      "1.0.0",
+				SourceType: "api",
+				MediaType:  "text/plain",
+			},
+			{
+				ID:         "label-2",
+				Key:        "maintainer",
+				Value:      "test@example.com",
+				SourceType: "api",
+				MediaType:  "text/plain",
+			},
+		},
+	}
+
+	mockResponseJSON, _ := json.Marshal(mockLabels)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetManifest {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repository/testorg/testrepo/manifest/"+testManifestRef+"/labels" {
+			t.Errorf("Expected path /api/v1/repository/testorg/testrepo/manifest/%s/labels, got %s", testManifestRef, r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	labels, err := client.GetManifestLabels("testorg", "testrepo", testManifestRef)
+	if err != nil {
+		t.Fatalf("GetManifestLabels failed: %v", err)
+	}
+
+	if len(labels.Labels) != 2 {
+		t.Errorf("Expected 2 labels, got %d", len(labels.Labels))
+	}
+	if labels.Labels[0].Key != "version" {
+		t.Errorf("Expected first label key 'version', got '%s'", labels.Labels[0].Key)
+	}
+	if labels.Labels[1].Value != "test@example.com" {
+		t.Errorf("Expected second label value 'test@example.com', got '%s'", labels.Labels[1].Value)
+	}
+}
+
+func TestAddManifestLabel(t *testing.T) {
+	mockLabel := ManifestLabel{
+		ID:         "new-label-123",
+		Key:        "environment",
+		Value:      "production",
+		SourceType: "api",
+		MediaType:  "text/plain",
+	}
+
+	mockResponseJSON, _ := json.Marshal(mockLabel)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpPostManifest {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repository/testorg/testrepo/manifest/"+testManifestRef+"/labels" {
+			t.Errorf("Expected path /api/v1/repository/testorg/testrepo/manifest/%s/labels, got %s", testManifestRef, r.URL.Path)
+		}
+
+		// Verify request body
+		var req AddManifestLabelRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("Failed to decode request body: %v", err)
+		}
+
+		if req.Key != "environment" {
+			t.Errorf("Expected key 'environment', got '%s'", req.Key)
+		}
+		if req.Value != "production" {
+			t.Errorf("Expected value 'production', got '%s'", req.Value)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	label, err := client.AddManifestLabel("testorg", "testrepo", testManifestRef, "environment", "production", "text/plain")
+	if err != nil {
+		t.Fatalf("AddManifestLabel failed: %v", err)
+	}
+
+	if label.Key != "environment" {
+		t.Errorf("Expected label key 'environment', got '%s'", label.Key)
+	}
+	if label.Value != "production" {
+		t.Errorf("Expected label value 'production', got '%s'", label.Value)
+	}
+	if label.ID != "new-label-123" {
+		t.Errorf("Expected label ID 'new-label-123', got '%s'", label.ID)
+	}
+}
+
+func TestGetManifestLabel(t *testing.T) {
+	mockLabel := ManifestLabel{
+		ID:         testLabelID,
+		Key:        "version",
+		Value:      "2.0.0",
+		SourceType: "api",
+		MediaType:  "text/plain",
+	}
+
+	mockResponseJSON, _ := json.Marshal(mockLabel)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetManifest {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/testorg/testrepo/manifest/" + testManifestRef + "/labels/" + testLabelID
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	label, err := client.GetManifestLabel("testorg", "testrepo", testManifestRef, testLabelID)
+	if err != nil {
+		t.Fatalf("GetManifestLabel failed: %v", err)
+	}
+
+	if label.ID != testLabelID {
+		t.Errorf("Expected label ID '%s', got '%s'", testLabelID, label.ID)
+	}
+	if label.Key != "version" {
+		t.Errorf("Expected label key 'version', got '%s'", label.Key)
+	}
+}
+
+func TestDeleteManifestLabel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpDeleteManifest {
+			t.Errorf("Expected DELETE request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/testorg/testrepo/manifest/" + testManifestRef + "/labels/" + testLabelID
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.DeleteManifestLabel("testorg", "testrepo", testManifestRef, testLabelID)
+	if err != nil {
+		t.Fatalf("DeleteManifestLabel failed: %v", err)
+	}
+}
+
+func TestManifestErrorHandling(t *testing.T) {
+	// Test 404 error for non-existent manifest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error": "Manifest not found"}`))
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Test GetManifest error
+	_, err = client.GetManifest("testorg", "testrepo", "nonexistent")
+	if err == nil {
+		t.Error("Expected error for non-existent manifest, got nil")
+	}
+
+	// Test DeleteManifest error
+	err = client.DeleteManifest("testorg", "testrepo", "nonexistent")
+	if err == nil {
+		t.Error("Expected error for non-existent manifest, got nil")
+	}
+
+	// Test GetManifestLabels error
+	_, err = client.GetManifestLabels("testorg", "testrepo", "nonexistent")
+	if err == nil {
+		t.Error("Expected error for non-existent manifest, got nil")
+	}
+
+	// Test AddManifestLabel error
+	_, err = client.AddManifestLabel("testorg", "testrepo", "nonexistent", "key", "value", "")
+	if err == nil {
+		t.Error("Expected error for non-existent manifest, got nil")
+	}
+
+	// Test GetManifestLabel error
+	_, err = client.GetManifestLabel("testorg", "testrepo", "nonexistent", "labelid")
+	if err == nil {
+		t.Error("Expected error for non-existent manifest label, got nil")
+	}
+
+	// Test DeleteManifestLabel error
+	err = client.DeleteManifestLabel("testorg", "testrepo", "nonexistent", "labelid")
+	if err == nil {
+		t.Error("Expected error for non-existent manifest label, got nil")
+	}
+}

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -529,6 +529,57 @@ type SearchResult struct {
 	} `json:"repositories,omitempty"`
 }
 
+// Manifest Structures
+
+// Manifest represents a container image manifest
+type Manifest struct {
+	Digest         string          `json:"digest,omitempty"`
+	SchemaVersion  int             `json:"schemaVersion,omitempty"`
+	MediaType      string          `json:"mediaType,omitempty"`
+	Size           int64           `json:"size,omitempty"`
+	Layers         []ManifestLayer `json:"layers,omitempty"`
+	Config         ManifestConfig  `json:"config,omitempty"`
+	IsManifestList bool            `json:"is_manifest_list,omitempty"`
+	ManifestData   string          `json:"manifest_data,omitempty"`
+}
+
+// ManifestLayer represents a layer in a manifest
+type ManifestLayer struct {
+	MediaType string `json:"mediaType,omitempty"`
+	Size      int64  `json:"size,omitempty"`
+	Digest    string `json:"digest,omitempty"`
+	Index     int    `json:"index,omitempty"`
+	Command   string `json:"command,omitempty"`
+}
+
+// ManifestConfig represents the config of a manifest
+type ManifestConfig struct {
+	MediaType string `json:"mediaType,omitempty"`
+	Size      int64  `json:"size,omitempty"`
+	Digest    string `json:"digest,omitempty"`
+}
+
+// ManifestLabel represents a label on a manifest
+type ManifestLabel struct {
+	ID         string `json:"id,omitempty"`
+	Key        string `json:"key,omitempty"`
+	Value      string `json:"value,omitempty"`
+	SourceType string `json:"source_type,omitempty"`
+	MediaType  string `json:"media_type,omitempty"`
+}
+
+// ManifestLabels represents the response for manifest labels
+type ManifestLabels struct {
+	Labels []ManifestLabel `json:"labels,omitempty"`
+}
+
+// AddManifestLabelRequest represents the request to add a label to a manifest
+type AddManifestLabelRequest struct {
+	Key       string `json:"key"`
+	Value     string `json:"value"`
+	MediaType string `json:"media_type,omitempty"`
+}
+
 // Error Response Structure
 
 // QuayError represents a Quay API error response


### PR DESCRIPTION
Adds support for the `manifest` API path.

**Manifest management features:**

* Adds a new `manifest` command group to the CLI, supporting manifest inspection, deletion, and label management, including adding, listing, retrieving, and removing labels. [[1]](diffhunk://#diff-e14e01db982c1f023b278ccc590d5b2f7ced798de2babbdadafe008946c4cd9dR1-R240) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR26)
* Implements client library methods for manifest operations in `lib/manifest.go`, providing functions to get, delete, and manage labels on manifests.

**Documentation updates:**

* Updates the API coverage table in `README.md` to indicate full support for the Manifest API and lists the specific supported endpoints.
* Adds detailed usage instructions and examples for all new manifest-related CLI commands to the `README.md`.