### PR TITLE
Add 'SecScan' path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,20 @@ The following APIs are covered by the repo. Each API links to the corresponding 
 | [Error](https://docs.quay.io/api/swagger/#Error)                  | No      | No      |                                                                                                                                                                                                                     |
 | [Messages](https://docs.quay.io/api/swagger/#Messages)               | No      | No      |                                                                                                                                                                                                                     |
 | [Logs](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--aggregatelogs-get)                   | Partial | Partial | /api/v1/repository/{namespace}/{repository}/aggregatelogs, /api/v1/repository/{namespace}/{repository}/logs, /api/v1/organization/{orgname}/logs |
-| [Manifest](https://docs.quay.io/api/swagger/#Manifest)               | **Yes** | **Yes** | **/api/v1/repository/{namespace}/{repository}/manifest/{manifestref}**, **/api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/labels**, **/api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/labels/{labelid}** |
+| [Manifest](https://docs.quay.io/api/swagger/#Manifest)               | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}, /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/labels, /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/labels/{labelid} |
 | [Organization](https://docs.quay.io/api/swagger/#operation--api-v1-organization--orgname--get)           | Yes     | Yes     | /api/v1/organization/{orgname}, /api/v1/organization/{orgname}/members, /api/v1/organization/{orgname}/teams, /api/v1/organization/{orgname}/team/{teamname}, /api/v1/organization/{orgname}/robots, /api/v1/organization/{orgname}/quota, /api/v1/organization/{orgname}/autoprunepolicy, /api/v1/organization/{orgname}/applications |
-| [Permission](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--permissions-get)             | **Yes** | **Yes** | **/api/v1/repository/{namespace}/{repository}/permissions**, **/api/v1/repository/{namespace}/{repository}/permissions/{username}** |
+| [Permission](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--permissions-get)             | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/permissions, /api/v1/repository/{namespace}/{repository}/permissions/{username} |
 | [Prototype](https://docs.quay.io/api/swagger/#Prototype)              | No      | No      |                                                                                                                                                                                                                     |
-| [Repository](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--get)             | **Yes** | **Yes** | /api/v1/repository/{namespace}/{repository}, /api/v1/repository/{namespace}/{repository}/tag, **/api/v1/repository**, **/api/v1/repository/{namespace}/{repository}** (CRUD) |
+| [Repository](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--get)             | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}, /api/v1/repository/{namespace}/{repository}/tag, /api/v1/repository, /api/v1/repository/{namespace}/{repository} (CRUD) |
 | [RepositoryNotification](https://docs.quay.io/api/swagger/#RepositoryNotification) | No      | No      |                                                                                                                                                                                                                     |
 | [RepoToken](https://docs.quay.io/api/swagger/#RepoToken)              | No      | No      |                                                                                                                                                                                                                     |
 | [Robot](https://docs.quay.io/api/swagger/#Robot)                  | No      | No      |                                                                                                                                                                                                                     |
 | [Search](https://docs.quay.io/api/swagger/#Search)                 | No      | No      |                                                                                                                                                                                                                     |
-| [SecScan](https://docs.quay.io/api/swagger/#SecScan)                | No      | No      |                                                                                                                                                                                                                     |
-| [Tag](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--tag-get)                    | **Yes** | **Yes** | /api/v1/repository/{namespace}/{repository}/tag, **/api/v1/repository/{namespace}/{repository}/tag/{tag}**, **/api/v1/repository/{namespace}/{repository}/tag/{tag}/history** |
+| [SecScan](https://docs.quay.io/api/swagger/#SecScan)                | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/security |
+| [Tag](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--tag-get)                    | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/tag, /api/v1/repository/{namespace}/{repository}/tag/{tag}, /api/v1/repository/{namespace}/{repository}/tag/{tag}/history |
 | [Team](https://docs.quay.io/api/swagger/#Team)                   | No      | No      |                                                                                                                                                                                                                     |
 | [Trigger](https://docs.quay.io/api/swagger/#Trigger)                | No      | No      |                                                                                                                                                                                                                     |
-| [User](https://docs.quay.io/api/swagger/#operation--api-v1-user-get)                   | **Yes** | **Yes** | **/api/v1/user**, **/api/v1/user/starred**, **/api/v1/repository/{namespace}/{repository}/star** | 
+| [User](https://docs.quay.io/api/swagger/#operation--api-v1-user-get)                   | Yes     | Yes     | /api/v1/user, /api/v1/user/starred, /api/v1/repository/{namespace}/{repository}/star | 
 
 ## Authentication
 
@@ -346,6 +346,45 @@ Inspect and manage container image manifests, including layers, configuration, a
   --label-id label-123 \
   --token YOUR_TOKEN
 ```
+
+### Security Scan (SecScan) API
+
+Retrieve security vulnerability information for container images.
+
+📖 **API Reference:** [SecScan endpoints in Swagger](https://docs.quay.io/api/swagger/#SecScan)
+
+#### Get security scan results for a manifest
+```bash
+# Get security scan with vulnerability details
+./go-quay get secscan info \
+  --namespace myorg \
+  --repository myrepo \
+  --manifest sha256:abc123def456... \
+  --token YOUR_TOKEN
+
+# Get security scan without vulnerability details (faster)
+./go-quay get secscan info \
+  -n myorg \
+  -r myrepo \
+  -m sha256:abc123def456... \
+  --vulnerabilities=false \
+  -t YOUR_TOKEN
+```
+
+**Scan Status Values:**
+- `scanned`: Scan completed successfully, results available
+- `queued`: Scan is queued and pending
+- `scanning`: Scan is currently in progress
+- `unsupported`: Image type is not supported for scanning
+- `failed`: Scan failed
+
+**Vulnerability Severity Levels:**
+- `Critical`: Severe vulnerabilities requiring immediate attention
+- `High`: Important vulnerabilities to address soon
+- `Medium`: Moderate risk vulnerabilities
+- `Low`: Minor vulnerabilities
+- `Negligible`: Minimal impact vulnerabilities
+- `Unknown`: Severity not determined
 
 ### User API
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ func init() {
 	getCmd.AddCommand(tagCmd)
 	getCmd.AddCommand(userCmd)
 	getCmd.AddCommand(manifestCmd)
+	getCmd.AddCommand(secscanCmd)
 }
 
 // Execute executes the root command.

--- a/cmd/secscan.go
+++ b/cmd/secscan.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sebrandon1/go-quay/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	secScanManifestRef     string
+	includeVulnerabilities bool
+)
+
+// secscanCmd represents the secscan command group
+var secscanCmd = &cobra.Command{
+	Use:   "secscan",
+	Short: "Security scanning commands for container images",
+	Long: `Commands for retrieving security scan information for container images.
+
+Security scanning provides vulnerability information including CVE details,
+severity levels, affected packages, and available fixes.
+
+Available commands:
+  info - Get security scan results for a manifest`,
+}
+
+// SecScan Info
+var secscanInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Get security scan results for a manifest",
+	Long: `Get security scan results for a specific manifest including vulnerability information.
+
+The scan status can be:
+  - scanned: Scan completed successfully
+  - queued: Scan is queued and pending
+  - scanning: Scan is currently in progress
+  - unsupported: Image type is not supported for scanning
+  - failed: Scan failed`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		security, err := client.GetManifestSecurity(namespace, repository, secScanManifestRef, includeVulnerabilities)
+		if err != nil {
+			fmt.Printf("Error getting security scan: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Security scan for %s/%s@%s\n", namespace, repository, secScanManifestRef)
+		printJSON(security)
+	},
+}
+
+func init() {
+	// Add subcommands to secscan command
+	secscanCmd.AddCommand(secscanInfoCmd)
+
+	// Global secscan flags (repository context)
+	secscanCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
+	secscanCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
+	secscanCmd.PersistentFlags().StringVarP(&secScanManifestRef, "manifest", "m", "", "Manifest reference (digest like sha256:...)")
+	secscanCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
+
+	// Mark global flags as required
+	if err := secscanCmd.MarkPersistentFlagRequired("namespace"); err != nil {
+		fmt.Printf("Error marking namespace flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	if err := secscanCmd.MarkPersistentFlagRequired("repository"); err != nil {
+		fmt.Printf("Error marking repository flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	if err := secscanCmd.MarkPersistentFlagRequired("manifest"); err != nil {
+		fmt.Printf("Error marking manifest flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	if err := secscanCmd.MarkPersistentFlagRequired("token"); err != nil {
+		fmt.Printf("Error marking token flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Info command specific flags
+	secscanInfoCmd.Flags().BoolVarP(&includeVulnerabilities, "vulnerabilities", "V", true, "Include vulnerability details in the response")
+}

--- a/lib/secscan.go
+++ b/lib/secscan.go
@@ -1,0 +1,38 @@
+/*
+Package lib provides Quay.io API client functionality.
+
+This file covers SECURITY SCAN operations:
+
+Security Scanning:
+  - GET /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/security - GetManifestSecurity()
+
+Security scan operations provide access to vulnerability information for
+container images, including CVE details, severity levels, and fix versions.
+*/
+package lib
+
+import (
+	"fmt"
+)
+
+// GetManifestSecurity retrieves security scan information for a specific manifest
+func (c *Client) GetManifestSecurity(namespace, repository, manifestRef string, vulnerabilities bool) (*SecurityScan, error) {
+	url := fmt.Sprintf("%s/repository/%s/%s/manifest/%s/security", QuayURL, namespace, repository, manifestRef)
+
+	// Add query parameter to include vulnerabilities
+	if vulnerabilities {
+		url += "?vulnerabilities=true"
+	}
+
+	req, err := newRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get manifest security request: %w", err)
+	}
+
+	var securityScan SecurityScan
+	if err := c.get(req, &securityScan); err != nil {
+		return nil, fmt.Errorf("failed to get manifest security: %w", err)
+	}
+
+	return &securityScan, nil
+}

--- a/lib/secscan_test.go
+++ b/lib/secscan_test.go
@@ -1,0 +1,258 @@
+package lib
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	testSecScanManifestRef = "sha256:abc123def456789"
+	httpGetSecScan         = "GET"
+)
+
+func TestGetManifestSecurity(t *testing.T) {
+	mockSecurityScan := SecurityScan{
+		Status: "scanned",
+		Data: &SecurityData{
+			Layer: &SecurityLayer{
+				Name:             "sha256:abc123",
+				NamespaceName:    "centos:8",
+				IndexedByVersion: 4,
+				Features: []SecurityFeature{
+					{
+						Name:          "openssl",
+						Version:       "1.1.1k",
+						VersionFormat: "rpm",
+						NamespaceName: "centos:8",
+						AddedBy:       "sha256:layer1",
+						Vulnerabilities: []SecurityVulnerability{
+							{
+								Name:          "CVE-2021-3712",
+								NamespaceName: "centos:8",
+								Description:   "OpenSSL vulnerability in ASN.1 parsing",
+								Link:          "https://access.redhat.com/security/cve/CVE-2021-3712",
+								Severity:      "Medium",
+								FixedBy:       "1.1.1k-5",
+							},
+						},
+					},
+					{
+						Name:          "curl",
+						Version:       "7.61.1",
+						VersionFormat: "rpm",
+						NamespaceName: "centos:8",
+						AddedBy:       "sha256:layer2",
+					},
+				},
+			},
+		},
+	}
+
+	mockResponseJSON, _ := json.Marshal(mockSecurityScan)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetSecScan {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/testorg/testrepo/manifest/" + testSecScanManifestRef + "/security"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		// Check for vulnerabilities query parameter
+		if r.URL.Query().Get("vulnerabilities") != "true" {
+			t.Errorf("Expected vulnerabilities=true query parameter")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	securityScan, err := client.GetManifestSecurity("testorg", "testrepo", testSecScanManifestRef, true)
+	if err != nil {
+		t.Fatalf("GetManifestSecurity failed: %v", err)
+	}
+
+	if securityScan.Status != "scanned" {
+		t.Errorf("Expected status 'scanned', got '%s'", securityScan.Status)
+	}
+	if securityScan.Data == nil {
+		t.Fatal("Expected Data to be non-nil")
+	}
+	if securityScan.Data.Layer == nil {
+		t.Fatal("Expected Layer to be non-nil")
+	}
+	if len(securityScan.Data.Layer.Features) != 2 {
+		t.Errorf("Expected 2 features, got %d", len(securityScan.Data.Layer.Features))
+	}
+
+	// Check first feature with vulnerability
+	feature := securityScan.Data.Layer.Features[0]
+	if feature.Name != "openssl" {
+		t.Errorf("Expected feature name 'openssl', got '%s'", feature.Name)
+	}
+	if len(feature.Vulnerabilities) != 1 {
+		t.Errorf("Expected 1 vulnerability, got %d", len(feature.Vulnerabilities))
+	}
+	if feature.Vulnerabilities[0].Name != "CVE-2021-3712" {
+		t.Errorf("Expected vulnerability 'CVE-2021-3712', got '%s'", feature.Vulnerabilities[0].Name)
+	}
+	if feature.Vulnerabilities[0].Severity != "Medium" {
+		t.Errorf("Expected severity 'Medium', got '%s'", feature.Vulnerabilities[0].Severity)
+	}
+}
+
+func TestGetManifestSecurityWithoutVulnerabilities(t *testing.T) {
+	mockSecurityScan := SecurityScan{
+		Status: "scanned",
+		Data: &SecurityData{
+			Layer: &SecurityLayer{
+				Name:             "sha256:abc123",
+				IndexedByVersion: 4,
+			},
+		},
+	}
+
+	mockResponseJSON, _ := json.Marshal(mockSecurityScan)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetSecScan {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+
+		// Check that vulnerabilities query parameter is NOT present
+		if r.URL.Query().Get("vulnerabilities") == "true" {
+			t.Errorf("Did not expect vulnerabilities=true query parameter")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	securityScan, err := client.GetManifestSecurity("testorg", "testrepo", testSecScanManifestRef, false)
+	if err != nil {
+		t.Fatalf("GetManifestSecurity failed: %v", err)
+	}
+
+	if securityScan.Status != "scanned" {
+		t.Errorf("Expected status 'scanned', got '%s'", securityScan.Status)
+	}
+}
+
+func TestGetManifestSecurityQueued(t *testing.T) {
+	// Test when scan is still queued/in progress
+	mockSecurityScan := SecurityScan{
+		Status: "queued",
+	}
+
+	mockResponseJSON, _ := json.Marshal(mockSecurityScan)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	securityScan, err := client.GetManifestSecurity("testorg", "testrepo", testSecScanManifestRef, true)
+	if err != nil {
+		t.Fatalf("GetManifestSecurity failed: %v", err)
+	}
+
+	if securityScan.Status != "queued" {
+		t.Errorf("Expected status 'queued', got '%s'", securityScan.Status)
+	}
+	if securityScan.Data != nil {
+		t.Error("Expected Data to be nil for queued scan")
+	}
+}
+
+func TestGetManifestSecurityErrorHandling(t *testing.T) {
+	// Test 404 error for non-existent manifest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error": "Manifest not found"}`))
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetManifestSecurity("testorg", "testrepo", "nonexistent", true)
+	if err == nil {
+		t.Error("Expected error for non-existent manifest, got nil")
+	}
+}
+
+func TestGetManifestSecurityUnsupported(t *testing.T) {
+	// Test when security scanning is not supported for the image
+	mockSecurityScan := SecurityScan{
+		Status: "unsupported",
+	}
+
+	mockResponseJSON, _ := json.Marshal(mockSecurityScan)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	securityScan, err := client.GetManifestSecurity("testorg", "testrepo", testSecScanManifestRef, true)
+	if err != nil {
+		t.Fatalf("GetManifestSecurity failed: %v", err)
+	}
+
+	if securityScan.Status != "unsupported" {
+		t.Errorf("Expected status 'unsupported', got '%s'", securityScan.Status)
+	}
+}

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -580,6 +580,49 @@ type AddManifestLabelRequest struct {
 	MediaType string `json:"media_type,omitempty"`
 }
 
+// Security Scan Structures
+
+// SecurityScan represents the security scan result for an image
+type SecurityScan struct {
+	Status string        `json:"status,omitempty"`
+	Data   *SecurityData `json:"data,omitempty"`
+}
+
+// SecurityData contains the detailed security scan information
+type SecurityData struct {
+	Layer *SecurityLayer `json:"Layer,omitempty"`
+}
+
+// SecurityLayer represents the scanned layer information
+type SecurityLayer struct {
+	Name             string            `json:"Name,omitempty"`
+	ParentName       string            `json:"ParentName,omitempty"`
+	NamespaceName    string            `json:"NamespaceName,omitempty"`
+	IndexedByVersion int               `json:"IndexedByVersion,omitempty"`
+	Features         []SecurityFeature `json:"Features,omitempty"`
+}
+
+// SecurityFeature represents a package/feature found in the image
+type SecurityFeature struct {
+	Name            string                  `json:"Name,omitempty"`
+	VersionFormat   string                  `json:"VersionFormat,omitempty"`
+	NamespaceName   string                  `json:"NamespaceName,omitempty"`
+	AddedBy         string                  `json:"AddedBy,omitempty"`
+	Version         string                  `json:"Version,omitempty"`
+	Vulnerabilities []SecurityVulnerability `json:"Vulnerabilities,omitempty"`
+}
+
+// SecurityVulnerability represents a vulnerability found in a feature
+type SecurityVulnerability struct {
+	Name          string                 `json:"Name,omitempty"`
+	NamespaceName string                 `json:"NamespaceName,omitempty"`
+	Description   string                 `json:"Description,omitempty"`
+	Link          string                 `json:"Link,omitempty"`
+	Severity      string                 `json:"Severity,omitempty"`
+	Metadata      map[string]interface{} `json:"Metadata,omitempty"`
+	FixedBy       string                 `json:"FixedBy,omitempty"`
+}
+
 // Error Response Structure
 
 // QuayError represents a Quay API error response


### PR DESCRIPTION
Adds support for the `SecScan` API path.

**Security Scan (SecScan) API Integration**

- Added a new CLI command group `secscan` with an `info` subcommand to retrieve security scan results for a specific manifest, including options for vulnerability details. (`cmd/secscan.go` [[1]](diffhunk://#diff-0c3550adf8344f4e75e1f6eb6be60d5b8520ed34981fee1581945748fdf04f81R1-R89) `cmd/root.go` [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR27)
- Updated the documentation to describe the new Security Scan API support, usage examples, scan status values, and vulnerability severity levels. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R34) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R350-R388)

**API Client and Data Structures**

- Implemented the `GetManifestSecurity` method in the API client to call the `/repository/{namespace}/{repository}/manifest/{manifestref}/security` endpoint, supporting optional inclusion of vulnerability details. (`lib/secscan.go` [lib/secscan.goR1-R38](diffhunk://#diff-e3c1ce6903efb6ceb38b55b6f7266ef5012fc4a99f7e365685a06e94119dc949R1-R38))
- Defined new data structures (`SecurityScan`, `SecurityData`, `SecurityLayer`, `SecurityFeature`, `SecurityVulnerability`) to represent the security scan results and related details. (`lib/structs.go` [lib/structs.goR583-R625](diffhunk://#diff-37c858023db9e57dada7117d3836f304d0ebbc5737a4b8c44b28d4927f86fc94R583-R625))

**Testing**

- Added a comprehensive test suite for the security scan API client, covering successful retrievals (with/without vulnerabilities), error handling, queued/unsupported scan statuses, and response validation. (`lib/secscan_test.go` [lib/secscan_test.goR1-R258](diffhunk://#diff-b4b8599e9e202e9079a0764977340c1493fcceb2c4f947d2859f3167fa85f672R1-R258))