### PR TITLE
Add 'robot' path

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following APIs are covered by the repo. Each API links to the corresponding 
 | [Repository](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--get)             | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}, /api/v1/repository/{namespace}/{repository}/tag, /api/v1/repository, /api/v1/repository/{namespace}/{repository} (CRUD) |
 | [RepositoryNotification](https://docs.quay.io/api/swagger/#RepositoryNotification) | No      | No      |                                                                                                                                                                                                                     |
 | [RepoToken](https://docs.quay.io/api/swagger/#RepoToken)              | No      | No      |                                                                                                                                                                                                                     |
-| [Robot](https://docs.quay.io/api/swagger/#Robot)                  | No      | No      |                                                                                                                                                                                                                     |
+| [Robot](https://docs.quay.io/api/swagger/#Robot)                  | Yes     | Yes     | /api/v1/user/robots, /api/v1/user/robots/{robot_shortname}, /api/v1/user/robots/{robot_shortname}/regenerate, /api/v1/user/robots/{robot_shortname}/permissions |
 | [Search](https://docs.quay.io/api/swagger/#Search)                 | No      | No      |                                                                                                                                                                                                                     |
 | [SecScan](https://docs.quay.io/api/swagger/#SecScan)                | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/security |
 | [Tag](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--tag-get)                    | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/tag, /api/v1/repository/{namespace}/{repository}/tag/{tag}, /api/v1/repository/{namespace}/{repository}/tag/{tag}/history |
@@ -385,6 +385,59 @@ Retrieve security vulnerability information for container images.
 - `Low`: Minor vulnerabilities
 - `Negligible`: Minimal impact vulnerabilities
 - `Unknown`: Severity not determined
+
+### Robot API
+
+Manage user-level robot accounts for CI/CD automation and automated workflows.
+
+📖 **API Reference:** [Robot endpoints in Swagger](https://docs.quay.io/api/swagger/#Robot)
+
+#### List all robot accounts
+```bash
+./go-quay get robot list \
+  --token YOUR_TOKEN
+```
+
+#### Get robot account details
+```bash
+./go-quay get robot info \
+  --name deploybot \
+  --token YOUR_TOKEN
+```
+
+#### Create a new robot account
+```bash
+./go-quay get robot create \
+  --name mybot \
+  --description "CI/CD automation robot" \
+  --token YOUR_TOKEN
+```
+
+**Note:** Save the token from the response - it will not be shown again!
+
+#### Delete a robot account
+```bash
+./go-quay get robot delete \
+  --name oldbot \
+  --confirm \
+  --token YOUR_TOKEN
+```
+
+#### Regenerate robot token
+```bash
+./go-quay get robot regenerate \
+  --name deploybot \
+  --token YOUR_TOKEN
+```
+
+**Note:** The old token will be invalidated immediately.
+
+#### Get robot permissions
+```bash
+./go-quay get robot permissions \
+  --name deploybot \
+  --token YOUR_TOKEN
+```
 
 ### User API
 

--- a/cmd/robot.go
+++ b/cmd/robot.go
@@ -1,0 +1,232 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sebrandon1/go-quay/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	robotShortname     string
+	robotDescription   string
+	confirmRobotDelete bool
+)
+
+// robotCmd represents the robot command group
+var robotCmd = &cobra.Command{
+	Use:   "robot",
+	Short: "User robot account management commands",
+	Long: `Commands for managing user-level robot accounts.
+
+Robot accounts provide automated access credentials for CI/CD pipelines
+and other automated workflows. These are tied to your user account.
+
+Available commands:
+  list       - List all robot accounts
+  info       - Get robot account details
+  create     - Create a new robot account
+  delete     - Delete a robot account
+  regenerate - Regenerate robot token
+  permissions - Get robot repository permissions`,
+}
+
+// Robot List
+var robotListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all robot accounts",
+	Long:  `List all robot accounts associated with your user account.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		robots, err := client.GetUserRobotAccounts()
+		if err != nil {
+			fmt.Printf("Error getting robot accounts: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("User robot accounts:")
+		printJSON(robots)
+	},
+}
+
+// Robot Info
+var robotInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Get robot account details",
+	Long:  `Get detailed information about a specific robot account including its token.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		robot, err := client.GetUserRobotAccount(robotShortname)
+		if err != nil {
+			fmt.Printf("Error getting robot account: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Robot account: %s\n", robotShortname)
+		printJSON(robot)
+	},
+}
+
+// Robot Create
+var robotCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new robot account",
+	Long:  `Create a new robot account with the specified name and description.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		robot, err := client.CreateUserRobotAccount(robotShortname, robotDescription, nil)
+		if err != nil {
+			fmt.Printf("Error creating robot account: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully created robot account: %s\n", robotShortname)
+		fmt.Println("IMPORTANT: Save the token below - it will not be shown again!")
+		printJSON(robot)
+	},
+}
+
+// Robot Delete
+var robotDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a robot account",
+	Long:  `Delete a robot account. This action cannot be undone.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirmRobotDelete {
+			fmt.Printf("Are you sure you want to delete robot account '%s'? This action cannot be undone.\n", robotShortname)
+			fmt.Println("Use --confirm to proceed with deletion.")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.DeleteUserRobotAccount(robotShortname)
+		if err != nil {
+			fmt.Printf("Error deleting robot account: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully deleted robot account: %s\n", robotShortname)
+	},
+}
+
+// Robot Regenerate
+var robotRegenerateCmd = &cobra.Command{
+	Use:   "regenerate",
+	Short: "Regenerate robot token",
+	Long:  `Regenerate the token for a robot account. The old token will be invalidated.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		robot, err := client.RegenerateUserRobotToken(robotShortname)
+		if err != nil {
+			fmt.Printf("Error regenerating robot token: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully regenerated token for robot: %s\n", robotShortname)
+		fmt.Println("IMPORTANT: Save the new token below - it will not be shown again!")
+		printJSON(robot)
+	},
+}
+
+// Robot Permissions
+var robotPermissionsCmd = &cobra.Command{
+	Use:   "permissions",
+	Short: "Get robot repository permissions",
+	Long:  `Get the repository permissions assigned to a robot account.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		permissions, err := client.GetUserRobotPermissions(robotShortname)
+		if err != nil {
+			fmt.Printf("Error getting robot permissions: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Permissions for robot: %s\n", robotShortname)
+		printJSON(permissions)
+	},
+}
+
+func init() {
+	// Add subcommands to robot command
+	robotCmd.AddCommand(robotListCmd)
+	robotCmd.AddCommand(robotInfoCmd)
+	robotCmd.AddCommand(robotCreateCmd)
+	robotCmd.AddCommand(robotDeleteCmd)
+	robotCmd.AddCommand(robotRegenerateCmd)
+	robotCmd.AddCommand(robotPermissionsCmd)
+
+	// Global robot flags
+	robotCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
+	if err := robotCmd.MarkPersistentFlagRequired("token"); err != nil {
+		fmt.Printf("Error marking token flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Info command flags
+	robotInfoCmd.Flags().StringVarP(&robotShortname, "name", "n", "", "Robot short name (without username prefix)")
+	if err := robotInfoCmd.MarkFlagRequired("name"); err != nil {
+		fmt.Printf("Error marking name flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create command flags
+	robotCreateCmd.Flags().StringVarP(&robotShortname, "name", "n", "", "Robot short name (without username prefix)")
+	robotCreateCmd.Flags().StringVarP(&robotDescription, "description", "d", "", "Robot description")
+	if err := robotCreateCmd.MarkFlagRequired("name"); err != nil {
+		fmt.Printf("Error marking name flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Delete command flags
+	robotDeleteCmd.Flags().StringVarP(&robotShortname, "name", "n", "", "Robot short name (without username prefix)")
+	robotDeleteCmd.Flags().BoolVar(&confirmRobotDelete, "confirm", false, "Confirm robot deletion")
+	if err := robotDeleteCmd.MarkFlagRequired("name"); err != nil {
+		fmt.Printf("Error marking name flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Regenerate command flags
+	robotRegenerateCmd.Flags().StringVarP(&robotShortname, "name", "n", "", "Robot short name (without username prefix)")
+	if err := robotRegenerateCmd.MarkFlagRequired("name"); err != nil {
+		fmt.Printf("Error marking name flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Permissions command flags
+	robotPermissionsCmd.Flags().StringVarP(&robotShortname, "name", "n", "", "Robot short name (without username prefix)")
+	if err := robotPermissionsCmd.MarkFlagRequired("name"); err != nil {
+		fmt.Printf("Error marking name flag as required: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ func init() {
 	getCmd.AddCommand(userCmd)
 	getCmd.AddCommand(manifestCmd)
 	getCmd.AddCommand(secscanCmd)
+	getCmd.AddCommand(robotCmd)
 }
 
 // Execute executes the root command.

--- a/lib/robot.go
+++ b/lib/robot.go
@@ -1,0 +1,115 @@
+/*
+Package lib provides Quay.io API client functionality.
+
+This file covers USER ROBOT ACCOUNT operations:
+
+Robot Account Management:
+  - GET    /api/v1/user/robots                                  - GetUserRobotAccounts()
+  - GET    /api/v1/user/robots/{robot_shortname}                - GetUserRobotAccount()
+  - PUT    /api/v1/user/robots/{robot_shortname}                - CreateUserRobotAccount()
+  - DELETE /api/v1/user/robots/{robot_shortname}                - DeleteUserRobotAccount()
+  - POST   /api/v1/user/robots/{robot_shortname}/regenerate     - RegenerateUserRobotToken()
+  - GET    /api/v1/user/robots/{robot_shortname}/permissions    - GetUserRobotPermissions()
+
+User robot accounts provide automated access credentials for CI/CD pipelines
+and other automated workflows tied to a user account rather than an organization.
+*/
+package lib
+
+import (
+	"fmt"
+)
+
+// GetUserRobotAccounts retrieves all robot accounts for the authenticated user
+func (c *Client) GetUserRobotAccounts() (*RobotAccounts, error) {
+	req, err := newRequest("GET", QuayURL+"/user/robots", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get user robots request: %w", err)
+	}
+
+	var robots RobotAccounts
+	if err := c.get(req, &robots); err != nil {
+		return nil, fmt.Errorf("failed to get user robots: %w", err)
+	}
+
+	return &robots, nil
+}
+
+// GetUserRobotAccount retrieves a specific robot account for the authenticated user
+func (c *Client) GetUserRobotAccount(robotShortname string) (*RobotAccount, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/user/robots/%s", QuayURL, robotShortname), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get user robot request: %w", err)
+	}
+
+	var robot RobotAccount
+	if err := c.get(req, &robot); err != nil {
+		return nil, fmt.Errorf("failed to get user robot: %w", err)
+	}
+
+	return &robot, nil
+}
+
+// CreateUserRobotAccount creates a new robot account for the authenticated user
+func (c *Client) CreateUserRobotAccount(robotShortname, description string, unstructured map[string]interface{}) (*RobotAccount, error) {
+	createReq := CreateRobotRequest{
+		Description:  description,
+		Unstructured: unstructured,
+	}
+
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/user/robots/%s", QuayURL, robotShortname), createReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create user robot request: %w", err)
+	}
+
+	var robot RobotAccount
+	if err := c.put(req, &robot); err != nil {
+		return nil, fmt.Errorf("failed to create user robot: %w", err)
+	}
+
+	return &robot, nil
+}
+
+// DeleteUserRobotAccount deletes a robot account for the authenticated user
+func (c *Client) DeleteUserRobotAccount(robotShortname string) error {
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/user/robots/%s", QuayURL, robotShortname), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete user robot request: %w", err)
+	}
+
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to delete user robot: %w", err)
+	}
+
+	return nil
+}
+
+// RegenerateUserRobotToken regenerates the token for a user's robot account
+func (c *Client) RegenerateUserRobotToken(robotShortname string) (*RobotAccount, error) {
+	req, err := newRequest("POST", fmt.Sprintf("%s/user/robots/%s/regenerate", QuayURL, robotShortname), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create regenerate user robot token request: %w", err)
+	}
+
+	var robot RobotAccount
+	if err := c.post(req, &robot); err != nil {
+		return nil, fmt.Errorf("failed to regenerate user robot token: %w", err)
+	}
+
+	return &robot, nil
+}
+
+// GetUserRobotPermissions retrieves the repository permissions for a user's robot account
+func (c *Client) GetUserRobotPermissions(robotShortname string) (*RobotPermissions, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/user/robots/%s/permissions", QuayURL, robotShortname), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get user robot permissions request: %w", err)
+	}
+
+	var permissions RobotPermissions
+	if err := c.get(req, &permissions); err != nil {
+		return nil, fmt.Errorf("failed to get user robot permissions: %w", err)
+	}
+
+	return &permissions, nil
+}

--- a/lib/robot_test.go
+++ b/lib/robot_test.go
@@ -1,0 +1,352 @@
+package lib
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	testRobotShortname = "deploybot"
+	httpGetRobot       = "GET"
+	httpPutRobot       = "PUT"
+	httpPostRobot      = "POST"
+	httpDeleteRobot    = "DELETE"
+	roleWrite          = "write"
+)
+
+func TestGetUserRobotAccounts(t *testing.T) {
+	mockRobots := RobotAccounts{
+		Robots: []RobotAccount{
+			{
+				Name:        "testuser+deploybot",
+				Description: "Deployment robot",
+				Created:     "2024-01-15T10:30:00Z",
+			},
+			{
+				Name:        "testuser+cibot",
+				Description: "CI/CD robot",
+				Created:     "2024-01-10T08:00:00Z",
+			},
+		},
+	}
+
+	mockResponseJSON, _ := json.Marshal(mockRobots)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetRobot {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/user/robots" {
+			t.Errorf("Expected path /api/v1/user/robots, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	robots, err := client.GetUserRobotAccounts()
+	if err != nil {
+		t.Fatalf("GetUserRobotAccounts failed: %v", err)
+	}
+
+	if len(robots.Robots) != 2 {
+		t.Errorf("Expected 2 robots, got %d", len(robots.Robots))
+	}
+	if robots.Robots[0].Name != "testuser+deploybot" {
+		t.Errorf("Expected robot name 'testuser+deploybot', got '%s'", robots.Robots[0].Name)
+	}
+}
+
+func TestGetUserRobotAccount(t *testing.T) {
+	mockRobot := RobotAccount{
+		Name:        "testuser+deploybot",
+		Description: "Deployment robot",
+		Token:       "secret-token-123",
+		Created:     "2024-01-15T10:30:00Z",
+	}
+
+	mockResponseJSON, _ := json.Marshal(mockRobot)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetRobot {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/user/robots/" + testRobotShortname
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	robot, err := client.GetUserRobotAccount(testRobotShortname)
+	if err != nil {
+		t.Fatalf("GetUserRobotAccount failed: %v", err)
+	}
+
+	if robot.Name != "testuser+deploybot" {
+		t.Errorf("Expected robot name 'testuser+deploybot', got '%s'", robot.Name)
+	}
+	if robot.Token != "secret-token-123" {
+		t.Errorf("Expected token 'secret-token-123', got '%s'", robot.Token)
+	}
+}
+
+func TestCreateUserRobotAccount(t *testing.T) {
+	mockRobot := RobotAccount{
+		Name:        "testuser+newbot",
+		Description: "New automation robot",
+		Token:       "new-secret-token",
+		Created:     "2024-01-20T14:00:00Z",
+	}
+
+	mockResponseJSON, _ := json.Marshal(mockRobot)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpPutRobot {
+			t.Errorf("Expected PUT request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/user/robots/newbot" {
+			t.Errorf("Expected path /api/v1/user/robots/newbot, got %s", r.URL.Path)
+		}
+
+		// Verify request body
+		var req CreateRobotRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("Failed to decode request body: %v", err)
+		}
+		if req.Description != "New automation robot" {
+			t.Errorf("Expected description 'New automation robot', got '%s'", req.Description)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	robot, err := client.CreateUserRobotAccount("newbot", "New automation robot", nil)
+	if err != nil {
+		t.Fatalf("CreateUserRobotAccount failed: %v", err)
+	}
+
+	if robot.Name != "testuser+newbot" {
+		t.Errorf("Expected robot name 'testuser+newbot', got '%s'", robot.Name)
+	}
+	if robot.Token != "new-secret-token" {
+		t.Errorf("Expected token 'new-secret-token', got '%s'", robot.Token)
+	}
+}
+
+func TestDeleteUserRobotAccount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpDeleteRobot {
+			t.Errorf("Expected DELETE request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/user/robots/" + testRobotShortname
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.DeleteUserRobotAccount(testRobotShortname)
+	if err != nil {
+		t.Fatalf("DeleteUserRobotAccount failed: %v", err)
+	}
+}
+
+func TestRegenerateUserRobotToken(t *testing.T) {
+	mockRobot := RobotAccount{
+		Name:        "testuser+deploybot",
+		Description: "Deployment robot",
+		Token:       "regenerated-token-456",
+		Created:     "2024-01-15T10:30:00Z",
+	}
+
+	mockResponseJSON, _ := json.Marshal(mockRobot)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpPostRobot {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/user/robots/" + testRobotShortname + "/regenerate"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	robot, err := client.RegenerateUserRobotToken(testRobotShortname)
+	if err != nil {
+		t.Fatalf("RegenerateUserRobotToken failed: %v", err)
+	}
+
+	if robot.Token != "regenerated-token-456" {
+		t.Errorf("Expected token 'regenerated-token-456', got '%s'", robot.Token)
+	}
+}
+
+func TestGetUserRobotPermissions(t *testing.T) {
+	mockPermissions := RobotPermissions{
+		Permissions: []RobotPermission{
+			{
+				Repository: Repository{Name: "myrepo"},
+				Role:       roleWrite,
+			},
+			{
+				Repository: Repository{Name: "otherrepo"},
+				Role:       "read",
+			},
+		},
+	}
+
+	mockResponseJSON, _ := json.Marshal(mockPermissions)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetRobot {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/user/robots/" + testRobotShortname + "/permissions"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	permissions, err := client.GetUserRobotPermissions(testRobotShortname)
+	if err != nil {
+		t.Fatalf("GetUserRobotPermissions failed: %v", err)
+	}
+
+	if len(permissions.Permissions) != 2 {
+		t.Errorf("Expected 2 permissions, got %d", len(permissions.Permissions))
+	}
+	if permissions.Permissions[0].Role != roleWrite {
+		t.Errorf("Expected role 'write', got '%s'", permissions.Permissions[0].Role)
+	}
+}
+
+func TestUserRobotErrorHandling(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error": "Robot not found"}`))
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Test GetUserRobotAccounts error
+	_, err = client.GetUserRobotAccounts()
+	if err == nil {
+		t.Error("Expected error for failed request, got nil")
+	}
+
+	// Test GetUserRobotAccount error
+	_, err = client.GetUserRobotAccount("nonexistent")
+	if err == nil {
+		t.Error("Expected error for non-existent robot, got nil")
+	}
+
+	// Test CreateUserRobotAccount error
+	_, err = client.CreateUserRobotAccount("badbot", "desc", nil)
+	if err == nil {
+		t.Error("Expected error for failed create, got nil")
+	}
+
+	// Test DeleteUserRobotAccount error
+	err = client.DeleteUserRobotAccount("nonexistent")
+	if err == nil {
+		t.Error("Expected error for non-existent robot, got nil")
+	}
+
+	// Test RegenerateUserRobotToken error
+	_, err = client.RegenerateUserRobotToken("nonexistent")
+	if err == nil {
+		t.Error("Expected error for non-existent robot, got nil")
+	}
+
+	// Test GetUserRobotPermissions error
+	_, err = client.GetUserRobotPermissions("nonexistent")
+	if err == nil {
+		t.Error("Expected error for non-existent robot, got nil")
+	}
+}


### PR DESCRIPTION
Add support for the `robot` path.

**Robot account management support:**

* Added a new `robot` command group to the CLI (`cmd/robot.go`) with subcommands to list, get info, create, delete, regenerate token, and view permissions for user robot accounts. Each subcommand handles API interaction and user prompts as needed.
* Registered the new `robot` command group under the main `get` command in the CLI entrypoint (`cmd/root.go`).

**API client enhancements:**

* Implemented new methods in the API client (`lib/robot.go`) to support all user robot account operations: listing, retrieving, creating, deleting, regenerating tokens, and fetching permissions.

**Testing:**

* Added a comprehensive test suite (`lib/robot_test.go`) covering all user robot API client methods, including success cases and error handling.

**Documentation:**

* Updated the `README.md` to document robot account API support, list the endpoints, and provide usage examples for each CLI command. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R389-R441)