### PR TITLE
Add 'search' API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The following APIs are covered by the repo. Each API links to the corresponding 
 | [RepositoryNotification](https://docs.quay.io/api/swagger/#RepositoryNotification) | No      | No      |                                                                                                                                                                                                                     |
 | [RepoToken](https://docs.quay.io/api/swagger/#RepoToken)              | No      | No      |                                                                                                                                                                                                                     |
 | [Robot](https://docs.quay.io/api/swagger/#Robot)                  | Yes     | Yes     | /api/v1/user/robots, /api/v1/user/robots/{robot_shortname}, /api/v1/user/robots/{robot_shortname}/regenerate, /api/v1/user/robots/{robot_shortname}/permissions |
-| [Search](https://docs.quay.io/api/swagger/#Search)                 | No      | No      |                                                                                                                                                                                                                     |
+| [Search](https://docs.quay.io/api/swagger/#Search)                 | Yes     | Yes     | /api/v1/find/repositories, /api/v1/find/all |
 | [SecScan](https://docs.quay.io/api/swagger/#SecScan)                | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/security |
 | [Tag](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--tag-get)                    | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/tag, /api/v1/repository/{namespace}/{repository}/tag/{tag}, /api/v1/repository/{namespace}/{repository}/tag/{tag}/history |
 | [Team](https://docs.quay.io/api/swagger/#Team)                   | No      | No      |                                                                                                                                                                                                                     |
@@ -438,6 +438,41 @@ Manage user-level robot accounts for CI/CD automation and automated workflows.
   --name deploybot \
   --token YOUR_TOKEN
 ```
+
+### Search API
+
+Search for repositories, users, organizations, and other entities on Quay.io.
+
+📖 **API Reference:** [Search endpoints in Swagger](https://docs.quay.io/api/swagger/#Search)
+
+#### Search for repositories
+```bash
+# Basic repository search
+./go-quay get search repositories \
+  --query "nginx" \
+  --token YOUR_TOKEN
+
+# Search with pagination
+./go-quay get search repositories \
+  -q "python" \
+  --page 2 \
+  -t YOUR_TOKEN
+```
+
+#### Search all entity types
+```bash
+# Search for repositories, users, organizations, teams, and robots
+./go-quay get search all \
+  --query "redhat" \
+  --token YOUR_TOKEN
+```
+
+**Entity Types in Results:**
+- `repository`: Container image repository
+- `user`: User account
+- `organization`: Organization
+- `team`: Team within an organization
+- `robot`: Robot account
 
 ### User API
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ func init() {
 	getCmd.AddCommand(manifestCmd)
 	getCmd.AddCommand(secscanCmd)
 	getCmd.AddCommand(robotCmd)
+	getCmd.AddCommand(searchCmd)
 }
 
 // Execute executes the root command.

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sebrandon1/go-quay/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	searchQuery string
+	searchPage  int
+)
+
+// searchCmd represents the search command group
+var searchCmd = &cobra.Command{
+	Use:   "search",
+	Short: "Search for repositories and entities on Quay.io",
+	Long: `Commands for searching repositories, users, organizations, and other entities.
+
+Available commands:
+  repositories - Search for repositories
+  all          - Search all entity types`,
+}
+
+// Search Repositories
+var searchReposCmd = &cobra.Command{
+	Use:   "repositories",
+	Short: "Search for repositories",
+	Long:  `Search for repositories on Quay.io by name or description.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		result, err := client.SearchRepositories(searchQuery, searchPage)
+		if err != nil {
+			fmt.Printf("Error searching repositories: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Repository search results for: %s\n", searchQuery)
+		printJSON(result)
+	},
+}
+
+// Search All
+var searchAllCmd = &cobra.Command{
+	Use:   "all",
+	Short: "Search all entity types",
+	Long: `Search for all entity types including repositories, users, organizations, teams, and robots.
+
+Results include a 'kind' field indicating the entity type:
+  - repository: Container image repository
+  - user: User account
+  - organization: Organization
+  - team: Team within an organization
+  - robot: Robot account`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		result, err := client.SearchAll(searchQuery)
+		if err != nil {
+			fmt.Printf("Error searching: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Search results for: %s\n", searchQuery)
+		printJSON(result)
+	},
+}
+
+func init() {
+	// Add subcommands to search command
+	searchCmd.AddCommand(searchReposCmd)
+	searchCmd.AddCommand(searchAllCmd)
+
+	// Global search flags
+	searchCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
+	searchCmd.PersistentFlags().StringVarP(&searchQuery, "query", "q", "", "Search query")
+	if err := searchCmd.MarkPersistentFlagRequired("token"); err != nil {
+		fmt.Printf("Error marking token flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	if err := searchCmd.MarkPersistentFlagRequired("query"); err != nil {
+		fmt.Printf("Error marking query flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Repositories command specific flags
+	searchReposCmd.Flags().IntVarP(&searchPage, "page", "p", 0, "Page number for pagination (starts at 1)")
+}

--- a/lib/search.go
+++ b/lib/search.go
@@ -1,0 +1,57 @@
+/*
+Package lib provides Quay.io API client functionality.
+
+This file covers SEARCH operations:
+
+Search:
+  - GET /api/v1/find/repositories - SearchRepositories()
+  - GET /api/v1/find/all          - SearchAll()
+
+Search operations provide discovery capabilities for finding repositories,
+users, organizations, teams, and robots across Quay.io.
+*/
+package lib
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// SearchRepositories searches for repositories matching the query
+func (c *Client) SearchRepositories(query string, page int) (*SearchRepositoryResult, error) {
+	params := url.Values{}
+	params.Add("query", query)
+	if page > 0 {
+		params.Add("page", fmt.Sprintf("%d", page))
+	}
+
+	req, err := newRequest("GET", fmt.Sprintf("%s/find/repositories?%s", QuayURL, params.Encode()), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create search repositories request: %w", err)
+	}
+
+	var result SearchRepositoryResult
+	if err := c.get(req, &result); err != nil {
+		return nil, fmt.Errorf("failed to search repositories: %w", err)
+	}
+
+	return &result, nil
+}
+
+// SearchAll searches for all entity types (repositories, users, organizations, teams, robots)
+func (c *Client) SearchAll(query string) (*SearchAllResult, error) {
+	params := url.Values{}
+	params.Add("query", query)
+
+	req, err := newRequest("GET", fmt.Sprintf("%s/find/all?%s", QuayURL, params.Encode()), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create search all request: %w", err)
+	}
+
+	var result SearchAllResult
+	if err := c.get(req, &result); err != nil {
+		return nil, fmt.Errorf("failed to search all: %w", err)
+	}
+
+	return &result, nil
+}

--- a/lib/search_test.go
+++ b/lib/search_test.go
@@ -1,0 +1,278 @@
+package lib
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	httpGetSearch   = "GET"
+	testSearchQuery = "quay"
+)
+
+func TestSearchRepositories(t *testing.T) {
+	mockResult := SearchRepositoryResult{
+		Results: []SearchRepository{
+			{
+				Namespace:   testSearchQuery,
+				Name:        testSearchQuery,
+				Description: "Quay container registry",
+				IsPublic:    true,
+				Kind:        "image",
+				Popularity:  100.5,
+				Score:       0.95,
+			},
+			{
+				Namespace:   "redhat",
+				Name:        "quay-operator",
+				Description: "Quay Operator for OpenShift",
+				IsPublic:    true,
+				Kind:        "image",
+				Popularity:  50.2,
+				Score:       0.85,
+			},
+		},
+		HasAdditional: true,
+		Page:          1,
+		StartIndex:    0,
+	}
+
+	mockResponseJSON, _ := json.Marshal(mockResult)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetSearch {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/find/repositories" {
+			t.Errorf("Expected path /api/v1/find/repositories, got %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("query") != testSearchQuery {
+			t.Errorf("Expected query '%s', got '%s'", testSearchQuery, r.URL.Query().Get("query"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	result, err := client.SearchRepositories(testSearchQuery, 0)
+	if err != nil {
+		t.Fatalf("SearchRepositories failed: %v", err)
+	}
+
+	if len(result.Results) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(result.Results))
+	}
+	if result.Results[0].Namespace != testSearchQuery {
+		t.Errorf("Expected namespace '%s', got '%s'", testSearchQuery, result.Results[0].Namespace)
+	}
+	if result.Results[0].Name != testSearchQuery {
+		t.Errorf("Expected name '%s', got '%s'", testSearchQuery, result.Results[0].Name)
+	}
+	if !result.HasAdditional {
+		t.Error("Expected HasAdditional to be true")
+	}
+}
+
+func TestSearchRepositoriesWithPage(t *testing.T) {
+	mockResult := SearchRepositoryResult{
+		Results:       []SearchRepository{},
+		HasAdditional: false,
+		Page:          2,
+		StartIndex:    10,
+	}
+
+	mockResponseJSON, _ := json.Marshal(mockResult)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("page") != "2" {
+			t.Errorf("Expected page '2', got '%s'", r.URL.Query().Get("page"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	result, err := client.SearchRepositories("test", 2)
+	if err != nil {
+		t.Fatalf("SearchRepositories failed: %v", err)
+	}
+
+	if result.Page != 2 {
+		t.Errorf("Expected page 2, got %d", result.Page)
+	}
+}
+
+func TestSearchAll(t *testing.T) {
+	mockResult := SearchAllResult{
+		Results: []SearchEntity{
+			{
+				Name:        "quay",
+				Description: "Quay container registry",
+				Kind:        "repository",
+				Score:       0.95,
+				Avatar: Avatar{
+					Name:  "quay",
+					Hash:  "abc123",
+					Kind:  "org",
+					Color: "#ff0000",
+				},
+			},
+			{
+				Name:        "quayuser",
+				Description: "Quay developer",
+				Kind:        "user",
+				Score:       0.75,
+			},
+			{
+				Name:        "redhat",
+				Description: "Red Hat organization",
+				Kind:        "organization",
+				Score:       0.85,
+			},
+		},
+	}
+
+	mockResponseJSON, _ := json.Marshal(mockResult)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetSearch {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/find/all" {
+			t.Errorf("Expected path /api/v1/find/all, got %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("query") != testSearchQuery {
+			t.Errorf("Expected query '%s', got '%s'", testSearchQuery, r.URL.Query().Get("query"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	result, err := client.SearchAll(testSearchQuery)
+	if err != nil {
+		t.Fatalf("SearchAll failed: %v", err)
+	}
+
+	if len(result.Results) != 3 {
+		t.Errorf("Expected 3 results, got %d", len(result.Results))
+	}
+
+	// Verify we got different entity types
+	kinds := make(map[string]bool)
+	for _, r := range result.Results {
+		kinds[r.Kind] = true
+	}
+	if !kinds["repository"] {
+		t.Error("Expected to find repository in results")
+	}
+	if !kinds["user"] {
+		t.Error("Expected to find user in results")
+	}
+	if !kinds["organization"] {
+		t.Error("Expected to find organization in results")
+	}
+}
+
+func TestSearchErrorHandling(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error": "Internal server error"}`))
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Test SearchRepositories error
+	_, err = client.SearchRepositories("test", 0)
+	if err == nil {
+		t.Error("Expected error for failed request, got nil")
+	}
+
+	// Test SearchAll error
+	_, err = client.SearchAll("test")
+	if err == nil {
+		t.Error("Expected error for failed request, got nil")
+	}
+}
+
+func TestSearchEmptyResults(t *testing.T) {
+	mockResult := SearchRepositoryResult{
+		Results:       []SearchRepository{},
+		HasAdditional: false,
+		Page:          1,
+		StartIndex:    0,
+	}
+
+	mockResponseJSON, _ := json.Marshal(mockResult)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	result, err := client.SearchRepositories("nonexistent-repo-xyz", 0)
+	if err != nil {
+		t.Fatalf("SearchRepositories failed: %v", err)
+	}
+
+	if len(result.Results) != 0 {
+		t.Errorf("Expected 0 results, got %d", len(result.Results))
+	}
+	if result.HasAdditional {
+		t.Error("Expected HasAdditional to be false for empty results")
+	}
+}

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -518,7 +518,42 @@ type StarredRepositories struct {
 
 // Search and Discovery Structures
 
-// SearchResult represents a repository search result
+// SearchRepository represents a repository in search results
+type SearchRepository struct {
+	Namespace   string  `json:"namespace,omitempty"`
+	Name        string  `json:"name,omitempty"`
+	Description string  `json:"description,omitempty"`
+	IsPublic    bool    `json:"is_public,omitempty"`
+	Kind        string  `json:"kind,omitempty"`
+	Popularity  float64 `json:"popularity,omitempty"`
+	Score       float64 `json:"score,omitempty"`
+	Href        string  `json:"href,omitempty"`
+}
+
+// SearchRepositoryResult represents the response for repository search
+type SearchRepositoryResult struct {
+	Results       []SearchRepository `json:"results,omitempty"`
+	HasAdditional bool               `json:"has_additional,omitempty"`
+	Page          int                `json:"page,omitempty"`
+	StartIndex    int                `json:"start_index,omitempty"`
+}
+
+// SearchEntity represents a generic entity in search results (user, org, team, robot)
+type SearchEntity struct {
+	Name        string  `json:"name,omitempty"`
+	Description string  `json:"description,omitempty"`
+	Kind        string  `json:"kind,omitempty"`
+	Score       float64 `json:"score,omitempty"`
+	Href        string  `json:"href,omitempty"`
+	Avatar      Avatar  `json:"avatar,omitempty"`
+}
+
+// SearchAllResult represents the response for searching all entities
+type SearchAllResult struct {
+	Results []SearchEntity `json:"results,omitempty"`
+}
+
+// SearchResult represents a repository search result (legacy)
 type SearchResult struct {
 	Repositories []struct {
 		Namespace   string `json:"namespace,omitempty"`


### PR DESCRIPTION
Adding support for the `search` API.

**New Search API functionality:**

* Added a new `search` command group to the CLI with `repositories` and `all` subcommands for searching repositories and all entity types, respectively. (`cmd/search.go`, `cmd/root.go`) [[1]](diffhunk://#diff-c090fedae21f4dd5aaeeca3e95faefc0fcdde22f01489ea7514c035ccc298d7bR1-R99) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR29)
* Implemented `SearchRepositories` and `SearchAll` methods in the client library to interact with the corresponding Quay.io API endpoints. (`lib/search.go`)
* Defined new data structures for search results, including `SearchRepository`, `SearchRepositoryResult`, `SearchEntity`, and `SearchAllResult`. (`lib/structs.go`)

**Documentation updates:**

* Updated the `README.md` to document the new Search API support, including usage examples and the list of covered endpoints. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L29-R29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R442-R476)

**Testing:**

* Added comprehensive unit tests for the new search functionality, covering successful searches, pagination, error handling, and empty results. (`lib/search_test.go`)