### PR TITLE
Add 'team' API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following APIs are covered by the repo. Each API links to the corresponding 
 | [Search](https://docs.quay.io/api/swagger/#Search)                 | Yes     | Yes     | /api/v1/find/repositories, /api/v1/find/all |
 | [SecScan](https://docs.quay.io/api/swagger/#SecScan)                | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/security |
 | [Tag](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--tag-get)                    | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/tag, /api/v1/repository/{namespace}/{repository}/tag/{tag}, /api/v1/repository/{namespace}/{repository}/tag/{tag}/history |
-| [Team](https://docs.quay.io/api/swagger/#Team)                   | No      | No      |                                                                                                                                                                                                                     |
+| [Team](https://docs.quay.io/api/swagger/#Team)                   | Yes     | Yes     | /api/v1/organization/{orgname}/team/{teamname}, /api/v1/organization/{orgname}/team/{teamname}/members, /api/v1/organization/{orgname}/team/{teamname}/permissions |
 | [Trigger](https://docs.quay.io/api/swagger/#Trigger)                | No      | No      |                                                                                                                                                                                                                     |
 | [User](https://docs.quay.io/api/swagger/#operation--api-v1-user-get)                   | Yes     | Yes     | /api/v1/user, /api/v1/user/starred, /api/v1/repository/{namespace}/{repository}/star | 
 
@@ -473,6 +473,116 @@ Search for repositories, users, organizations, and other entities on Quay.io.
 - `organization`: Organization
 - `team`: Team within an organization
 - `robot`: Robot account
+
+### Team API
+
+Manage teams within an organization, including team members and repository permissions.
+
+📖 **API Reference:** [Team endpoints in Swagger](https://docs.quay.io/api/swagger/#Team)
+
+#### List teams in an organization
+```bash
+./go-quay get team list \
+  --organization myorg \
+  --token YOUR_TOKEN
+```
+
+#### Get team information
+```bash
+./go-quay get team info \
+  --organization myorg \
+  --name developers \
+  --token YOUR_TOKEN
+```
+
+#### Create a new team
+```bash
+# Create a team with member role
+./go-quay get team create \
+  --organization myorg \
+  --name developers \
+  --description "Development team" \
+  --role member \
+  --token YOUR_TOKEN
+```
+
+**Team Roles:**
+- `member`: Inherits default permissions
+- `creator`: Can create new repositories
+- `admin`: Full administrative access
+
+#### Update team settings
+```bash
+./go-quay get team update \
+  --organization myorg \
+  --name developers \
+  --description "Updated description" \
+  --role creator \
+  --token YOUR_TOKEN
+```
+
+#### Delete a team
+```bash
+./go-quay get team delete \
+  --organization myorg \
+  --name developers \
+  --confirm \
+  --token YOUR_TOKEN
+```
+
+#### Manage team members
+```bash
+# List team members
+./go-quay get team members \
+  --organization myorg \
+  --name developers \
+  --token YOUR_TOKEN
+
+# Add a member to a team
+./go-quay get team add-member \
+  --organization myorg \
+  --name developers \
+  --member username \
+  --token YOUR_TOKEN
+
+# Remove a member from a team
+./go-quay get team remove-member \
+  --organization myorg \
+  --name developers \
+  --member username \
+  --confirm \
+  --token YOUR_TOKEN
+```
+
+#### Manage team repository permissions
+```bash
+# List team repository permissions
+./go-quay get team permissions \
+  --organization myorg \
+  --name developers \
+  --token YOUR_TOKEN
+
+# Set repository permission for a team
+./go-quay get team set-permission \
+  --organization myorg \
+  --name developers \
+  --repository myrepo \
+  --role write \
+  --token YOUR_TOKEN
+
+# Remove repository permission from a team
+./go-quay get team remove-permission \
+  --organization myorg \
+  --name developers \
+  --repository myrepo \
+  --confirm \
+  --token YOUR_TOKEN
+```
+
+**Permission Roles:**
+- `read`: Pull images
+- `write`: Pull and push images
+- `admin`: Full administrative access
 
 ### User API
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,7 @@ func init() {
 	getCmd.AddCommand(secscanCmd)
 	getCmd.AddCommand(robotCmd)
 	getCmd.AddCommand(searchCmd)
+	getCmd.AddCommand(teamCmd)
 }
 
 // Execute executes the root command.

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -1,0 +1,420 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sebrandon1/go-quay/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	teamCmdOrgname        string
+	teamCmdName           string
+	teamCmdDescription    string
+	teamCmdRole           string
+	teamCmdMemberName     string
+	teamCmdRepository     string
+	teamCmdPermissionRole string
+	confirmTeamDelete     bool
+	confirmTeamMemberDel  bool
+	confirmTeamPermDel    bool
+)
+
+// teamCmd represents the team command group
+var teamCmd = &cobra.Command{
+	Use:   "team",
+	Short: "Organization team management commands",
+	Long: `Commands for managing teams within an organization.
+
+Teams allow you to organize members and manage repository permissions at scale.
+
+Available commands:
+  list         - List all teams in an organization
+  info         - Get team details
+  create       - Create a new team
+  update       - Update team settings
+  delete       - Delete a team
+  members      - List team members
+  add-member   - Add a member to a team
+  remove-member - Remove a member from a team
+  permissions  - List team repository permissions
+  set-permission - Set repository permission for team
+  remove-permission - Remove repository permission from team`,
+}
+
+// Team List
+var teamListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all teams in an organization",
+	Long:  `List all teams within the specified organization.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		teams, err := client.GetTeams(teamCmdOrgname)
+		if err != nil {
+			fmt.Printf("Error getting teams: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Teams in organization '%s':\n", teamCmdOrgname)
+		printJSON(teams)
+	},
+}
+
+// Team Info
+var teamCmdInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Get team details",
+	Long:  `Get detailed information about a specific team.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		team, err := client.GetTeam(teamCmdOrgname, teamCmdName)
+		if err != nil {
+			fmt.Printf("Error getting team: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Team: %s/%s\n", teamCmdOrgname, teamCmdName)
+		printJSON(team)
+	},
+}
+
+// Team Create
+var teamCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new team",
+	Long: `Create a new team within an organization.
+
+Roles:
+  - member: Inherits default permissions
+  - creator: Can create new repositories
+  - admin: Full administrative access`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		team, err := client.CreateTeam(teamCmdOrgname, teamCmdName, teamCmdDescription, teamCmdRole)
+		if err != nil {
+			fmt.Printf("Error creating team: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully created team: %s/%s\n", teamCmdOrgname, teamCmdName)
+		printJSON(team)
+	},
+}
+
+// Team Update
+var teamUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update team settings",
+	Long:  `Update team description and role.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		team, err := client.UpdateTeam(teamCmdOrgname, teamCmdName, teamCmdDescription, teamCmdRole)
+		if err != nil {
+			fmt.Printf("Error updating team: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully updated team: %s/%s\n", teamCmdOrgname, teamCmdName)
+		printJSON(team)
+	},
+}
+
+// Team Delete
+var teamDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a team",
+	Long:  `Delete a team from an organization. This action cannot be undone.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirmTeamDelete {
+			fmt.Printf("Are you sure you want to delete team '%s/%s'? This action cannot be undone.\n", teamCmdOrgname, teamCmdName)
+			fmt.Println("Use --confirm to proceed with deletion.")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.DeleteTeam(teamCmdOrgname, teamCmdName)
+		if err != nil {
+			fmt.Printf("Error deleting team: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully deleted team: %s/%s\n", teamCmdOrgname, teamCmdName)
+	},
+}
+
+// Team Members
+var teamCmdMembersCmd = &cobra.Command{
+	Use:   "members",
+	Short: "List team members",
+	Long:  `List all members of a specific team.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		members, err := client.GetTeamMembers(teamCmdOrgname, teamCmdName)
+		if err != nil {
+			fmt.Printf("Error getting team members: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Members of team '%s/%s':\n", teamCmdOrgname, teamCmdName)
+		printJSON(members)
+	},
+}
+
+// Team Add Member
+var teamAddMemberCmd = &cobra.Command{
+	Use:   "add-member",
+	Short: "Add a member to a team",
+	Long:  `Add a user or robot account to a team.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.AddTeamMember(teamCmdOrgname, teamCmdName, teamCmdMemberName)
+		if err != nil {
+			fmt.Printf("Error adding team member: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully added '%s' to team '%s/%s'\n", teamCmdMemberName, teamCmdOrgname, teamCmdName)
+	},
+}
+
+// Team Remove Member
+var teamRemoveMemberCmd = &cobra.Command{
+	Use:   "remove-member",
+	Short: "Remove a member from a team",
+	Long:  `Remove a user or robot account from a team.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirmTeamMemberDel {
+			fmt.Printf("Are you sure you want to remove '%s' from team '%s/%s'?\n", teamCmdMemberName, teamCmdOrgname, teamCmdName)
+			fmt.Println("Use --confirm to proceed with removal.")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.RemoveTeamMember(teamCmdOrgname, teamCmdName, teamCmdMemberName)
+		if err != nil {
+			fmt.Printf("Error removing team member: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully removed '%s' from team '%s/%s'\n", teamCmdMemberName, teamCmdOrgname, teamCmdName)
+	},
+}
+
+// Team Permissions
+var teamPermissionsCmd = &cobra.Command{
+	Use:   "permissions",
+	Short: "List team repository permissions",
+	Long:  `List all repository permissions for a team.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		permissions, err := client.GetTeamPermissions(teamCmdOrgname, teamCmdName)
+		if err != nil {
+			fmt.Printf("Error getting team permissions: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Repository permissions for team '%s/%s':\n", teamCmdOrgname, teamCmdName)
+		printJSON(permissions)
+	},
+}
+
+// Team Set Permission
+var teamSetPermissionCmd = &cobra.Command{
+	Use:   "set-permission",
+	Short: "Set repository permission for team",
+	Long: `Set repository permission for a team.
+
+Permission roles:
+  - read: Pull images
+  - write: Pull and push images
+  - admin: Full administrative access`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.SetTeamRepositoryPermission(teamCmdOrgname, teamCmdName, teamCmdRepository, teamCmdPermissionRole)
+		if err != nil {
+			fmt.Printf("Error setting team permission: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully set '%s' permission for team '%s/%s' on repository '%s'\n",
+			teamCmdPermissionRole, teamCmdOrgname, teamCmdName, teamCmdRepository)
+	},
+}
+
+// Team Remove Permission
+var teamRemovePermissionCmd = &cobra.Command{
+	Use:   "remove-permission",
+	Short: "Remove repository permission from team",
+	Long:  `Remove repository permission from a team.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirmTeamPermDel {
+			fmt.Printf("Are you sure you want to remove permissions for team '%s/%s' on repository '%s'?\n",
+				teamCmdOrgname, teamCmdName, teamCmdRepository)
+			fmt.Println("Use --confirm to proceed with removal.")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.RemoveTeamRepositoryPermission(teamCmdOrgname, teamCmdName, teamCmdRepository)
+		if err != nil {
+			fmt.Printf("Error removing team permission: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully removed permissions for team '%s/%s' on repository '%s'\n",
+			teamCmdOrgname, teamCmdName, teamCmdRepository)
+	},
+}
+
+func init() {
+	// Add subcommands to team command
+	teamCmd.AddCommand(teamListCmd)
+	teamCmd.AddCommand(teamCmdInfoCmd)
+	teamCmd.AddCommand(teamCreateCmd)
+	teamCmd.AddCommand(teamUpdateCmd)
+	teamCmd.AddCommand(teamDeleteCmd)
+	teamCmd.AddCommand(teamCmdMembersCmd)
+	teamCmd.AddCommand(teamAddMemberCmd)
+	teamCmd.AddCommand(teamRemoveMemberCmd)
+	teamCmd.AddCommand(teamPermissionsCmd)
+	teamCmd.AddCommand(teamSetPermissionCmd)
+	teamCmd.AddCommand(teamRemovePermissionCmd)
+
+	initTeamGlobalFlags()
+	initTeamCmdFlags()
+	initTeamMemberCmdFlags()
+	initTeamPermissionCmdFlags()
+}
+
+func initTeamGlobalFlags() {
+	teamCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
+	teamCmd.PersistentFlags().StringVarP(&teamCmdOrgname, "organization", "o", "", "Organization name")
+	markTeamFlagRequired(teamCmd.MarkPersistentFlagRequired("token"))
+	markTeamFlagRequired(teamCmd.MarkPersistentFlagRequired("organization"))
+}
+
+func initTeamCmdFlags() {
+	// Info command flags
+	teamCmdInfoCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
+	markTeamFlagRequired(teamCmdInfoCmd.MarkFlagRequired("name"))
+
+	// Create command flags
+	teamCreateCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
+	teamCreateCmd.Flags().StringVarP(&teamCmdDescription, "description", "d", "", "Team description")
+	teamCreateCmd.Flags().StringVarP(&teamCmdRole, "role", "r", "member", "Team role (member, creator, admin)")
+	markTeamFlagRequired(teamCreateCmd.MarkFlagRequired("name"))
+
+	// Update command flags
+	teamUpdateCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
+	teamUpdateCmd.Flags().StringVarP(&teamCmdDescription, "description", "d", "", "Team description")
+	teamUpdateCmd.Flags().StringVarP(&teamCmdRole, "role", "r", "", "Team role (member, creator, admin)")
+	markTeamFlagRequired(teamUpdateCmd.MarkFlagRequired("name"))
+
+	// Delete command flags
+	teamDeleteCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
+	teamDeleteCmd.Flags().BoolVar(&confirmTeamDelete, "confirm", false, "Confirm team deletion")
+	markTeamFlagRequired(teamDeleteCmd.MarkFlagRequired("name"))
+}
+
+func initTeamMemberCmdFlags() {
+	// Members command flags
+	teamCmdMembersCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
+	markTeamFlagRequired(teamCmdMembersCmd.MarkFlagRequired("name"))
+
+	// Add member command flags
+	teamAddMemberCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
+	teamAddMemberCmd.Flags().StringVarP(&teamCmdMemberName, "member", "m", "", "Member name (username or robot)")
+	markTeamFlagRequired(teamAddMemberCmd.MarkFlagRequired("name"))
+	markTeamFlagRequired(teamAddMemberCmd.MarkFlagRequired("member"))
+
+	// Remove member command flags
+	teamRemoveMemberCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
+	teamRemoveMemberCmd.Flags().StringVarP(&teamCmdMemberName, "member", "m", "", "Member name (username or robot)")
+	teamRemoveMemberCmd.Flags().BoolVar(&confirmTeamMemberDel, "confirm", false, "Confirm member removal")
+	markTeamFlagRequired(teamRemoveMemberCmd.MarkFlagRequired("name"))
+	markTeamFlagRequired(teamRemoveMemberCmd.MarkFlagRequired("member"))
+}
+
+func initTeamPermissionCmdFlags() {
+	// Permissions command flags
+	teamPermissionsCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
+	markTeamFlagRequired(teamPermissionsCmd.MarkFlagRequired("name"))
+
+	// Set permission command flags
+	teamSetPermissionCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
+	teamSetPermissionCmd.Flags().StringVarP(&teamCmdRepository, "repository", "R", "", "Repository name")
+	teamSetPermissionCmd.Flags().StringVarP(&teamCmdPermissionRole, "role", "r", "", "Permission role (read, write, admin)")
+	markTeamFlagRequired(teamSetPermissionCmd.MarkFlagRequired("name"))
+	markTeamFlagRequired(teamSetPermissionCmd.MarkFlagRequired("repository"))
+	markTeamFlagRequired(teamSetPermissionCmd.MarkFlagRequired("role"))
+
+	// Remove permission command flags
+	teamRemovePermissionCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
+	teamRemovePermissionCmd.Flags().StringVarP(&teamCmdRepository, "repository", "R", "", "Repository name")
+	teamRemovePermissionCmd.Flags().BoolVar(&confirmTeamPermDel, "confirm", false, "Confirm permission removal")
+	markTeamFlagRequired(teamRemovePermissionCmd.MarkFlagRequired("name"))
+	markTeamFlagRequired(teamRemovePermissionCmd.MarkFlagRequired("repository"))
+}
+
+func markTeamFlagRequired(err error) {
+	if err != nil {
+		fmt.Printf("Error marking flag as required: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/lib/repository_test.go
+++ b/lib/repository_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	testRepoPath = "/api/v1/repository/testorg/testrepo"
-	testTagPath  = "/api/v1/repository/testorg/testrepo/tag"
-	httpGetRepo  = "GET"
+	testRepoPath       = "/api/v1/repository/testorg/testrepo"
+	testTagPath        = "/api/v1/repository/testorg/testrepo/tag"
+	httpGetRepo        = "GET"
+	updatedDescription = "Updated description"
 )
 
 func TestCreateRepository(t *testing.T) {
@@ -87,7 +88,7 @@ func TestUpdateRepository(t *testing.T) {
 	mockRepo := Repository{
 		Namespace:   "testorg",
 		Name:        "testrepo",
-		Description: "Updated description",
+		Description: updatedDescription,
 		IsPublic:    true,
 	}
 
@@ -106,7 +107,7 @@ func TestUpdateRepository(t *testing.T) {
 			t.Errorf("Failed to decode request body: %v", err)
 		}
 
-		if req.Description != "Updated description" {
+		if req.Description != updatedDescription {
 			t.Errorf("Expected description 'Updated description', got '%s'", req.Description)
 		}
 		if req.Visibility != "public" {
@@ -128,12 +129,12 @@ func TestUpdateRepository(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	repo, err := client.UpdateRepository("testorg", "testrepo", "Updated description", "public")
+	repo, err := client.UpdateRepository("testorg", "testrepo", updatedDescription, "public")
 	if err != nil {
 		t.Fatalf("UpdateRepository failed: %v", err)
 	}
 
-	if repo.Description != "Updated description" {
+	if repo.Description != updatedDescription {
 		t.Errorf("Expected description 'Updated description', got '%s'", repo.Description)
 	}
 }

--- a/lib/team_test.go
+++ b/lib/team_test.go
@@ -1,0 +1,487 @@
+package lib
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	httpGetTeam    = "GET"
+	httpPutTeam    = "PUT"
+	httpDeleteTeam = "DELETE"
+
+	testOrgName    = "test-org"
+	testTeamName   = "developers"
+	testMemberName = "testuser"
+	testRepoName   = "test-repo"
+	roleAdmin      = "admin"
+	roleMember     = "member"
+	roleRead       = "read"
+)
+
+func TestGetTeams(t *testing.T) {
+	mockResponse := struct {
+		Teams []Team `json:"teams"`
+	}{
+		Teams: []Team{
+			{Name: testTeamName, Description: "Dev team", Role: roleMember, MemberCount: 5},
+			{Name: "admins", Description: "Admin team", Role: roleAdmin, MemberCount: 2},
+		},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetTeam {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/organization/" + testOrgName + "/teams"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	teams, err := client.GetTeams(testOrgName)
+	if err != nil {
+		t.Fatalf("GetTeams returned error: %v", err)
+	}
+
+	if len(teams) != 2 {
+		t.Errorf("Expected 2 teams, got %d", len(teams))
+	}
+	if teams[0].Name != testTeamName {
+		t.Errorf("Expected first team name %s, got %s", testTeamName, teams[0].Name)
+	}
+	if teams[1].Name != "admins" {
+		t.Errorf("Expected second team name 'admins', got %s", teams[1].Name)
+	}
+}
+
+func TestGetTeam(t *testing.T) {
+	mockResponse := Team{
+		Name:        testTeamName,
+		Description: "Development team",
+		Role:        roleMember,
+		MemberCount: 5,
+		RepoCount:   3,
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetTeam {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	team, err := client.GetTeam(testOrgName, testTeamName)
+	if err != nil {
+		t.Fatalf("GetTeam returned error: %v", err)
+	}
+
+	if team.Name != testTeamName {
+		t.Errorf("Expected team name %s, got %s", testTeamName, team.Name)
+	}
+	if team.Description != "Development team" {
+		t.Errorf("Expected description 'Development team', got %s", team.Description)
+	}
+	if team.Role != roleMember {
+		t.Errorf("Expected role %s, got %s", roleMember, team.Role)
+	}
+}
+
+func TestCreateTeam(t *testing.T) {
+	mockResponse := Team{
+		Name:        testTeamName,
+		Description: "New team",
+		Role:        roleMember,
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpPutTeam {
+			t.Errorf("Expected PUT request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	team, err := client.CreateTeam(testOrgName, testTeamName, "New team", roleMember)
+	if err != nil {
+		t.Fatalf("CreateTeam returned error: %v", err)
+	}
+
+	if team.Name != testTeamName {
+		t.Errorf("Expected team name %s, got %s", testTeamName, team.Name)
+	}
+	if team.Description != "New team" {
+		t.Errorf("Expected description 'New team', got %s", team.Description)
+	}
+}
+
+func TestUpdateTeam(t *testing.T) {
+	mockResponse := Team{
+		Name:        testTeamName,
+		Description: "Updated description",
+		Role:        roleAdmin,
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpPutTeam {
+			t.Errorf("Expected PUT request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	team, err := client.UpdateTeam(testOrgName, testTeamName, "Updated description", roleAdmin)
+	if err != nil {
+		t.Fatalf("UpdateTeam returned error: %v", err)
+	}
+
+	if team.Name != testTeamName {
+		t.Errorf("Expected team name %s, got %s", testTeamName, team.Name)
+	}
+	if team.Description != "Updated description" {
+		t.Errorf("Expected description 'Updated description', got %s", team.Description)
+	}
+	if team.Role != roleAdmin {
+		t.Errorf("Expected role %s, got %s", roleAdmin, team.Role)
+	}
+}
+
+func TestDeleteTeam(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpDeleteTeam {
+			t.Errorf("Expected DELETE request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.DeleteTeam(testOrgName, testTeamName)
+	if err != nil {
+		t.Fatalf("DeleteTeam returned error: %v", err)
+	}
+}
+
+func TestGetTeamMembers(t *testing.T) {
+	mockResponse := TeamMembers{
+		Members: []TeamMember{
+			{Name: testMemberName, Kind: "user", IsRobot: false},
+			{Name: "robot+builder", Kind: "robot", IsRobot: true},
+		},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetTeam {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName + "/members"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	members, err := client.GetTeamMembers(testOrgName, testTeamName)
+	if err != nil {
+		t.Fatalf("GetTeamMembers returned error: %v", err)
+	}
+
+	if len(members.Members) != 2 {
+		t.Errorf("Expected 2 members, got %d", len(members.Members))
+	}
+	if members.Members[0].Name != testMemberName {
+		t.Errorf("Expected first member name %s, got %s", testMemberName, members.Members[0].Name)
+	}
+	if members.Members[0].IsRobot {
+		t.Errorf("Expected first member to not be a robot")
+	}
+	if !members.Members[1].IsRobot {
+		t.Errorf("Expected second member to be a robot")
+	}
+}
+
+func TestAddTeamMember(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpPutTeam {
+			t.Errorf("Expected PUT request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName + "/members/" + testMemberName
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.AddTeamMember(testOrgName, testTeamName, testMemberName)
+	if err != nil {
+		t.Fatalf("AddTeamMember returned error: %v", err)
+	}
+}
+
+func TestRemoveTeamMember(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpDeleteTeam {
+			t.Errorf("Expected DELETE request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName + "/members/" + testMemberName
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.RemoveTeamMember(testOrgName, testTeamName, testMemberName)
+	if err != nil {
+		t.Fatalf("RemoveTeamMember returned error: %v", err)
+	}
+}
+
+func TestGetTeamPermissions(t *testing.T) {
+	mockResponse := TeamPermissions{
+		Permissions: []TeamPermission{
+			{Repository: Repository{Name: testRepoName}, Role: roleRead},
+			{Repository: Repository{Name: "another-repo"}, Role: "write"},
+		},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetTeam {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName + "/permissions"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	perms, err := client.GetTeamPermissions(testOrgName, testTeamName)
+	if err != nil {
+		t.Fatalf("GetTeamPermissions returned error: %v", err)
+	}
+
+	if len(perms.Permissions) != 2 {
+		t.Errorf("Expected 2 permissions, got %d", len(perms.Permissions))
+	}
+	if perms.Permissions[0].Repository.Name != testRepoName {
+		t.Errorf("Expected first repo name %s, got %s", testRepoName, perms.Permissions[0].Repository.Name)
+	}
+	if perms.Permissions[0].Role != roleRead {
+		t.Errorf("Expected first role %s, got %s", roleRead, perms.Permissions[0].Role)
+	}
+}
+
+func TestSetTeamRepositoryPermission(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpPutTeam {
+			t.Errorf("Expected PUT request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName + "/permissions/" + testRepoName
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.SetTeamRepositoryPermission(testOrgName, testTeamName, testRepoName, "write")
+	if err != nil {
+		t.Fatalf("SetTeamRepositoryPermission returned error: %v", err)
+	}
+}
+
+func TestRemoveTeamRepositoryPermission(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpDeleteTeam {
+			t.Errorf("Expected DELETE request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName + "/permissions/" + testRepoName
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.RemoveTeamRepositoryPermission(testOrgName, testTeamName, testRepoName)
+	if err != nil {
+		t.Fatalf("RemoveTeamRepositoryPermission returned error: %v", err)
+	}
+}
+
+func TestGetTeamsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetTeams(testOrgName)
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}
+
+func TestGetTeamError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetTeam(testOrgName, "nonexistent-team")
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}


### PR DESCRIPTION
Adds support for the `team` API.

**Team API Support:**

* Added a new `teamCmd` command to the CLI, enabling management of teams, team members, and repository permissions within organizations.

**Documentation Updates:**

* Updated the `README.md` to indicate that the Team API is now supported, including detailed usage instructions and examples for all major team operations (listing, creating, updating, deleting teams, managing members, and setting permissions). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R32) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R477-R586)

**Testing Improvements:**

* Refactored the repository test code in `lib/repository_test.go` to use a constant for the updated description, improving maintainability and consistency in tests. [[1]](diffhunk://#diff-6cffe951c68257f3308bd43a57a9e6eff10f3fa40e26144456891d494ca8c3d4R14) [[2]](diffhunk://#diff-6cffe951c68257f3308bd43a57a9e6eff10f3fa40e26144456891d494ca8c3d4L90-R91) [[3]](diffhunk://#diff-6cffe951c68257f3308bd43a57a9e6eff10f3fa40e26144456891d494ca8c3d4L109-R110) [[4]](diffhunk://#diff-6cffe951c68257f3308bd43a57a9e6eff10f3fa40e26144456891d494ca8c3d4L131-R137)