### PR TITLE
Add 'Build' and 'RepositoryNotification' API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following APIs are covered by the repo. Each API links to the corresponding 
 | API                    | Cmd     | Lib     | Covered                                                                                                                                                                                                             |
 | ---------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Billing](https://docs.quay.io/api/swagger/#operation--api-v1-user-plan-get)                | Yes     | Yes     | /api/v1/user/plan, /api/v1/organization/{orgname}/plan, /api/v1/organization/{orgname}/invoices, /api/v1/plans/                                                                                                   |
-| [Build](https://docs.quay.io/api/swagger/#Build)                  | No      | No      |                                                                                                                                                                                                                     |
+| [Build](https://docs.quay.io/api/swagger/#Build)                  | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/build/, /api/v1/repository/{namespace}/{repository}/build/{build_uuid}, /api/v1/repository/{namespace}/{repository}/build/{build_uuid}/logs |
 | [Discovery](https://docs.quay.io/api/swagger/#Discovery)              | No      | No      |                                                                                                                                                                                                                     |
 | [Error](https://docs.quay.io/api/swagger/#Error)                  | No      | No      |                                                                                                                                                                                                                     |
 | [Messages](https://docs.quay.io/api/swagger/#Messages)               | No      | No      |                                                                                                                                                                                                                     |
@@ -23,7 +23,7 @@ The following APIs are covered by the repo. Each API links to the corresponding 
 | [Permission](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--permissions-get)             | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/permissions, /api/v1/repository/{namespace}/{repository}/permissions/{username} |
 | [Prototype](https://docs.quay.io/api/swagger/#Prototype)              | No      | No      |                                                                                                                                                                                                                     |
 | [Repository](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--get)             | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}, /api/v1/repository/{namespace}/{repository}/tag, /api/v1/repository, /api/v1/repository/{namespace}/{repository} (CRUD) |
-| [RepositoryNotification](https://docs.quay.io/api/swagger/#RepositoryNotification) | No      | No      |                                                                                                                                                                                                                     |
+| [RepositoryNotification](https://docs.quay.io/api/swagger/#RepositoryNotification) | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/notification/, /api/v1/repository/{namespace}/{repository}/notification/{uuid}, /api/v1/repository/{namespace}/{repository}/notification/{uuid}/test |
 | [RepoToken](https://docs.quay.io/api/swagger/#RepoToken)              | No      | No      |                                                                                                                                                                                                                     |
 | [Robot](https://docs.quay.io/api/swagger/#Robot)                  | Yes     | Yes     | /api/v1/user/robots, /api/v1/user/robots/{robot_shortname}, /api/v1/user/robots/{robot_shortname}/regenerate, /api/v1/user/robots/{robot_shortname}/permissions |
 | [Search](https://docs.quay.io/api/swagger/#Search)                 | Yes     | Yes     | /api/v1/find/repositories, /api/v1/find/all |
@@ -67,6 +67,155 @@ The billing API provides access to subscription plans, billing information, and 
 ./go-quay get billing org-subscription --organization ORG_NAME --token YOUR_TOKEN
 ./go-quay get billing org-invoices --organization ORG_NAME --token YOUR_TOKEN
 ```
+
+### Build API
+
+The build API allows you to manage automated image builds from Dockerfiles.
+
+📖 **API Reference:** [Build endpoints in Swagger](https://docs.quay.io/api/swagger/#Build)
+
+#### List builds for a repository
+```bash
+./go-quay get build list \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --token YOUR_TOKEN
+```
+
+#### Get build details
+```bash
+./go-quay get build info \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --uuid BUILD_UUID \
+  --token YOUR_TOKEN
+```
+
+#### Get build logs
+```bash
+./go-quay get build logs \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --uuid BUILD_UUID \
+  --token YOUR_TOKEN
+```
+
+#### Request a new build
+```bash
+./go-quay get build request \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --archive-url "https://example.com/archive.tar.gz" \
+  --tag latest \
+  --token YOUR_TOKEN
+```
+
+#### Cancel a build
+```bash
+./go-quay get build cancel \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --uuid BUILD_UUID \
+  --confirm \
+  --token YOUR_TOKEN
+```
+
+**Build Phases:**
+- `waiting`: Build is queued
+- `starting`: Build is starting
+- `building`: Build is in progress
+- `pushing`: Pushing built image
+- `complete`: Build completed successfully
+- `error`: Build failed
+
+### Repository Notification API
+
+The notification API allows you to manage webhooks for repository events.
+
+📖 **API Reference:** [RepositoryNotification endpoints in Swagger](https://docs.quay.io/api/swagger/#RepositoryNotification)
+
+#### List notifications for a repository
+```bash
+./go-quay get notification list \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --token YOUR_TOKEN
+```
+
+#### Get notification details
+```bash
+./go-quay get notification info \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --uuid NOTIFICATION_UUID \
+  --token YOUR_TOKEN
+```
+
+#### Create a webhook notification
+```bash
+./go-quay get notification create \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --event repo_push \
+  --method webhook \
+  --url "https://example.com/webhook" \
+  --title "Push Webhook" \
+  --token YOUR_TOKEN
+```
+
+#### Create a Slack notification
+```bash
+./go-quay get notification create \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --event build_success \
+  --method slack \
+  --url "https://hooks.slack.com/services/..." \
+  --title "Build Success" \
+  --token YOUR_TOKEN
+```
+
+#### Test a notification
+```bash
+./go-quay get notification test \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --uuid NOTIFICATION_UUID \
+  --token YOUR_TOKEN
+```
+
+#### Reset notification failure count
+```bash
+./go-quay get notification reset \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --uuid NOTIFICATION_UUID \
+  --token YOUR_TOKEN
+```
+
+#### Delete a notification
+```bash
+./go-quay get notification delete \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --uuid NOTIFICATION_UUID \
+  --confirm \
+  --token YOUR_TOKEN
+```
+
+**Supported Events:**
+- `repo_push`: Image push to repository
+- `build_queued`: Build has been queued
+- `build_start`: Build has started
+- `build_success`: Build completed successfully
+- `build_failure`: Build failed
+- `build_canceled`: Build was canceled
+- `vulnerability_found`: New vulnerability discovered
+
+**Supported Methods:**
+- `webhook`: HTTP POST to a URL
+- `email`: Email notification
+- `slack`: Slack webhook
 
 ### Logs API
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -1,0 +1,219 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sebrandon1/go-quay/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	buildNamespace     string
+	buildRepository    string
+	buildUUID          string
+	buildLimit         int
+	buildArchiveURL    string
+	buildDockerfile    string
+	buildSubdirectory  string
+	buildTags          []string
+	confirmBuildCancel bool
+)
+
+// buildCmd represents the build command group
+var buildCmd = &cobra.Command{
+	Use:   "build",
+	Short: "Repository build management commands",
+	Long: `Commands for managing repository builds.
+
+Builds allow automated image creation from Dockerfiles stored in git repositories
+or uploaded archives.
+
+Available commands:
+  list    - List builds for a repository
+  info    - Get build details
+  logs    - Get build logs
+  request - Request a new build
+  cancel  - Cancel an ongoing build`,
+}
+
+// Build List
+var buildListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List builds for a repository",
+	Long:  `List all builds for the specified repository.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		builds, err := client.GetBuilds(buildNamespace, buildRepository, buildLimit)
+		if err != nil {
+			fmt.Printf("Error getting builds: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Builds for %s/%s:\n", buildNamespace, buildRepository)
+		printJSON(builds)
+	},
+}
+
+// Build Info
+var buildInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Get build details",
+	Long:  `Get detailed information about a specific build.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		build, err := client.GetBuild(buildNamespace, buildRepository, buildUUID)
+		if err != nil {
+			fmt.Printf("Error getting build: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Build: %s\n", buildUUID)
+		printJSON(build)
+	},
+}
+
+// Build Logs
+var buildLogsCmd = &cobra.Command{
+	Use:   "logs",
+	Short: "Get build logs",
+	Long:  `Get the logs for a specific build.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		logs, err := client.GetBuildLogs(buildNamespace, buildRepository, buildUUID)
+		if err != nil {
+			fmt.Printf("Error getting build logs: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Logs for build %s:\n", buildUUID)
+		printJSON(logs)
+	},
+}
+
+// Build Request
+var buildRequestCmd = &cobra.Command{
+	Use:   "request",
+	Short: "Request a new build",
+	Long: `Request a new build from an archive URL.
+
+The archive should be a tar.gz file containing a Dockerfile and any necessary build context.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		buildReq := &lib.RequestBuildRequest{
+			ArchiveURL:     buildArchiveURL,
+			DockerfilePath: buildDockerfile,
+			Subdirectory:   buildSubdirectory,
+			Tags:           buildTags,
+		}
+
+		build, err := client.RequestBuild(buildNamespace, buildRepository, buildReq)
+		if err != nil {
+			fmt.Printf("Error requesting build: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Build requested successfully!\n")
+		printJSON(build)
+	},
+}
+
+// Build Cancel
+var buildCancelCmd = &cobra.Command{
+	Use:   "cancel",
+	Short: "Cancel an ongoing build",
+	Long:  `Cancel an ongoing build. This action cannot be undone.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirmBuildCancel {
+			fmt.Printf("Are you sure you want to cancel build '%s'? This action cannot be undone.\n", buildUUID)
+			fmt.Println("Use --confirm to proceed with cancellation.")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.CancelBuild(buildNamespace, buildRepository, buildUUID)
+		if err != nil {
+			fmt.Printf("Error canceling build: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Build '%s' canceled successfully.\n", buildUUID)
+	},
+}
+
+func init() {
+	// Add subcommands to build command
+	buildCmd.AddCommand(buildListCmd)
+	buildCmd.AddCommand(buildInfoCmd)
+	buildCmd.AddCommand(buildLogsCmd)
+	buildCmd.AddCommand(buildRequestCmd)
+	buildCmd.AddCommand(buildCancelCmd)
+
+	// Global build flags
+	buildCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
+	buildCmd.PersistentFlags().StringVarP(&buildNamespace, "namespace", "n", "", "Repository namespace")
+	buildCmd.PersistentFlags().StringVarP(&buildRepository, "repository", "r", "", "Repository name")
+	markBuildFlagRequired(buildCmd.MarkPersistentFlagRequired("token"))
+	markBuildFlagRequired(buildCmd.MarkPersistentFlagRequired("namespace"))
+	markBuildFlagRequired(buildCmd.MarkPersistentFlagRequired("repository"))
+
+	initBuildListFlags()
+	initBuildInfoFlags()
+	initBuildRequestFlags()
+	initBuildCancelFlags()
+}
+
+func initBuildListFlags() {
+	buildListCmd.Flags().IntVarP(&buildLimit, "limit", "l", 10, "Maximum number of builds to return")
+}
+
+func initBuildInfoFlags() {
+	buildInfoCmd.Flags().StringVarP(&buildUUID, "uuid", "u", "", "Build UUID")
+	markBuildFlagRequired(buildInfoCmd.MarkFlagRequired("uuid"))
+}
+
+func initBuildRequestFlags() {
+	buildRequestCmd.Flags().StringVarP(&buildArchiveURL, "archive-url", "a", "", "URL to archive containing Dockerfile")
+	buildRequestCmd.Flags().StringVarP(&buildDockerfile, "dockerfile", "d", "", "Path to Dockerfile within archive")
+	buildRequestCmd.Flags().StringVarP(&buildSubdirectory, "subdirectory", "s", "", "Subdirectory containing build context")
+	buildRequestCmd.Flags().StringSliceVar(&buildTags, "tag", []string{"latest"}, "Tags for the built image")
+	markBuildFlagRequired(buildRequestCmd.MarkFlagRequired("archive-url"))
+}
+
+func initBuildCancelFlags() {
+	buildCancelCmd.Flags().StringVarP(&buildUUID, "uuid", "u", "", "Build UUID")
+	buildCancelCmd.Flags().BoolVar(&confirmBuildCancel, "confirm", false, "Confirm build cancellation")
+	markBuildFlagRequired(buildCancelCmd.MarkFlagRequired("uuid"))
+}
+
+func markBuildFlagRequired(err error) {
+	if err != nil {
+		fmt.Printf("Error marking flag as required: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -1,0 +1,276 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sebrandon1/go-quay/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	notificationNamespace  string
+	notificationRepository string
+	notificationUUID       string
+	notificationEvent      string
+	notificationMethod     string
+	notificationTitle      string
+	notificationURL        string
+	confirmNotificationDel bool
+)
+
+// notificationCmd represents the notification command group
+var notificationCmd = &cobra.Command{
+	Use:   "notification",
+	Short: "Repository notification/webhook management commands",
+	Long: `Commands for managing repository notifications (webhooks).
+
+Repository notifications allow external services to be notified
+of events such as image pushes, builds, and vulnerability scans.
+
+Supported events:
+  - repo_push: Image push to repository
+  - build_queued: Build has been queued
+  - build_start: Build has started
+  - build_success: Build completed successfully
+  - build_failure: Build failed
+  - build_canceled: Build was canceled
+  - vulnerability_found: New vulnerability discovered
+
+Supported methods:
+  - webhook: HTTP webhook
+  - email: Email notification
+  - slack: Slack notification
+
+Available commands:
+  list   - List notifications for a repository
+  info   - Get notification details
+  create - Create a new notification
+  delete - Delete a notification
+  test   - Test a notification
+  reset  - Reset notification failure count`,
+}
+
+// Notification List
+var notificationListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List notifications for a repository",
+	Long:  `List all notifications (webhooks) for the specified repository.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		notifications, err := client.GetNotifications(notificationNamespace, notificationRepository)
+		if err != nil {
+			fmt.Printf("Error getting notifications: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Notifications for %s/%s:\n", notificationNamespace, notificationRepository)
+		printJSON(notifications)
+	},
+}
+
+// Notification Info
+var notificationInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Get notification details",
+	Long:  `Get detailed information about a specific notification.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		notification, err := client.GetNotification(notificationNamespace, notificationRepository, notificationUUID)
+		if err != nil {
+			fmt.Printf("Error getting notification: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Notification: %s\n", notificationUUID)
+		printJSON(notification)
+	},
+}
+
+// Notification Create
+var notificationCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new notification",
+	Long: `Create a new notification (webhook) for the repository.
+
+For webhook method, provide the --url flag with the webhook endpoint.
+For email method, provide the --url flag with the email address.
+For slack method, provide the --url flag with the Slack webhook URL.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		config := map[string]interface{}{}
+		switch notificationMethod {
+		case "webhook":
+			config["url"] = notificationURL
+		case "email":
+			config["email"] = notificationURL
+		case "slack":
+			config["url"] = notificationURL
+		}
+
+		notificationReq := &lib.CreateNotificationRequest{
+			Event:  notificationEvent,
+			Method: notificationMethod,
+			Config: config,
+			Title:  notificationTitle,
+		}
+
+		notification, err := client.CreateNotification(notificationNamespace, notificationRepository, notificationReq)
+		if err != nil {
+			fmt.Printf("Error creating notification: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Notification created successfully!\n")
+		printJSON(notification)
+	},
+}
+
+// Notification Delete
+var notificationDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a notification",
+	Long:  `Delete a notification from the repository. This action cannot be undone.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirmNotificationDel {
+			fmt.Printf("Are you sure you want to delete notification '%s'? This action cannot be undone.\n", notificationUUID)
+			fmt.Println("Use --confirm to proceed with deletion.")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.DeleteNotification(notificationNamespace, notificationRepository, notificationUUID)
+		if err != nil {
+			fmt.Printf("Error deleting notification: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Notification '%s' deleted successfully.\n", notificationUUID)
+	},
+}
+
+// Notification Test
+var notificationTestCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Test a notification",
+	Long:  `Send a test event to the notification endpoint.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.TestNotification(notificationNamespace, notificationRepository, notificationUUID)
+		if err != nil {
+			fmt.Printf("Error testing notification: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Test event sent to notification '%s'.\n", notificationUUID)
+	},
+}
+
+// Notification Reset
+var notificationResetCmd = &cobra.Command{
+	Use:   "reset",
+	Short: "Reset notification failure count",
+	Long:  `Reset the failure count for a notification that has failed.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.ResetNotification(notificationNamespace, notificationRepository, notificationUUID)
+		if err != nil {
+			fmt.Printf("Error resetting notification: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Notification '%s' failure count reset.\n", notificationUUID)
+	},
+}
+
+func init() {
+	// Add subcommands to notification command
+	notificationCmd.AddCommand(notificationListCmd)
+	notificationCmd.AddCommand(notificationInfoCmd)
+	notificationCmd.AddCommand(notificationCreateCmd)
+	notificationCmd.AddCommand(notificationDeleteCmd)
+	notificationCmd.AddCommand(notificationTestCmd)
+	notificationCmd.AddCommand(notificationResetCmd)
+
+	// Global notification flags
+	notificationCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
+	notificationCmd.PersistentFlags().StringVarP(&notificationNamespace, "namespace", "n", "", "Repository namespace")
+	notificationCmd.PersistentFlags().StringVarP(&notificationRepository, "repository", "r", "", "Repository name")
+	markNotificationFlagRequired(notificationCmd.MarkPersistentFlagRequired("token"))
+	markNotificationFlagRequired(notificationCmd.MarkPersistentFlagRequired("namespace"))
+	markNotificationFlagRequired(notificationCmd.MarkPersistentFlagRequired("repository"))
+
+	initNotificationInfoFlags()
+	initNotificationCreateFlags()
+	initNotificationDeleteFlags()
+	initNotificationTestFlags()
+	initNotificationResetFlags()
+}
+
+func initNotificationInfoFlags() {
+	notificationInfoCmd.Flags().StringVarP(&notificationUUID, "uuid", "u", "", "Notification UUID")
+	markNotificationFlagRequired(notificationInfoCmd.MarkFlagRequired("uuid"))
+}
+
+func initNotificationCreateFlags() {
+	notificationCreateCmd.Flags().StringVarP(&notificationEvent, "event", "e", "", "Event type (repo_push, build_success, etc.)")
+	notificationCreateCmd.Flags().StringVarP(&notificationMethod, "method", "m", "", "Method (webhook, email, slack)")
+	notificationCreateCmd.Flags().StringVar(&notificationURL, "url", "", "Webhook URL or email address")
+	notificationCreateCmd.Flags().StringVar(&notificationTitle, "title", "", "Notification title")
+	markNotificationFlagRequired(notificationCreateCmd.MarkFlagRequired("event"))
+	markNotificationFlagRequired(notificationCreateCmd.MarkFlagRequired("method"))
+	markNotificationFlagRequired(notificationCreateCmd.MarkFlagRequired("url"))
+}
+
+func initNotificationDeleteFlags() {
+	notificationDeleteCmd.Flags().StringVarP(&notificationUUID, "uuid", "u", "", "Notification UUID")
+	notificationDeleteCmd.Flags().BoolVar(&confirmNotificationDel, "confirm", false, "Confirm notification deletion")
+	markNotificationFlagRequired(notificationDeleteCmd.MarkFlagRequired("uuid"))
+}
+
+func initNotificationTestFlags() {
+	notificationTestCmd.Flags().StringVarP(&notificationUUID, "uuid", "u", "", "Notification UUID")
+	markNotificationFlagRequired(notificationTestCmd.MarkFlagRequired("uuid"))
+}
+
+func initNotificationResetFlags() {
+	notificationResetCmd.Flags().StringVarP(&notificationUUID, "uuid", "u", "", "Notification UUID")
+	markNotificationFlagRequired(notificationResetCmd.MarkFlagRequired("uuid"))
+}
+
+func markNotificationFlagRequired(err error) {
+	if err != nil {
+		fmt.Printf("Error marking flag as required: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,8 @@ func init() {
 	getCmd.AddCommand(robotCmd)
 	getCmd.AddCommand(searchCmd)
 	getCmd.AddCommand(teamCmd)
+	getCmd.AddCommand(buildCmd)
+	getCmd.AddCommand(notificationCmd)
 }
 
 // Execute executes the root command.

--- a/lib/build.go
+++ b/lib/build.go
@@ -1,0 +1,99 @@
+/*
+Package lib provides Quay.io API client functionality.
+
+This file covers BUILD operations:
+
+Build Management:
+  - GET    /api/v1/repository/{namespace}/{repository}/build/                    - GetBuilds()
+  - GET    /api/v1/repository/{namespace}/{repository}/build/{build_uuid}        - GetBuild()
+  - POST   /api/v1/repository/{namespace}/{repository}/build/                    - RequestBuild()
+  - DELETE /api/v1/repository/{namespace}/{repository}/build/{build_uuid}        - CancelBuild()
+  - GET    /api/v1/repository/{namespace}/{repository}/build/{build_uuid}/logs   - GetBuildLogs()
+
+Builds allow automated image creation from Dockerfiles stored in git repositories
+or uploaded archives.
+*/
+package lib
+
+import (
+	"fmt"
+)
+
+// GetBuilds retrieves a list of builds for a repository
+func (c *Client) GetBuilds(namespace, repository string, limit int) (*Builds, error) {
+	url := fmt.Sprintf("%s/repository/%s/%s/build/", QuayURL, namespace, repository)
+	if limit > 0 {
+		url = fmt.Sprintf("%s?limit=%d", url, limit)
+	}
+
+	req, err := newRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get builds request: %w", err)
+	}
+
+	var builds Builds
+	if err := c.get(req, &builds); err != nil {
+		return nil, fmt.Errorf("failed to get builds: %w", err)
+	}
+
+	return &builds, nil
+}
+
+// GetBuild retrieves a specific build by UUID
+func (c *Client) GetBuild(namespace, repository, buildUUID string) (*Build, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/build/%s", QuayURL, namespace, repository, buildUUID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get build request: %w", err)
+	}
+
+	var build Build
+	if err := c.get(req, &build); err != nil {
+		return nil, fmt.Errorf("failed to get build: %w", err)
+	}
+
+	return &build, nil
+}
+
+// GetBuildLogs retrieves the logs for a specific build
+func (c *Client) GetBuildLogs(namespace, repository, buildUUID string) (*BuildLogs, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/build/%s/logs", QuayURL, namespace, repository, buildUUID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get build logs request: %w", err)
+	}
+
+	var logs BuildLogs
+	if err := c.get(req, &logs); err != nil {
+		return nil, fmt.Errorf("failed to get build logs: %w", err)
+	}
+
+	return &logs, nil
+}
+
+// RequestBuild triggers a new build for a repository
+func (c *Client) RequestBuild(namespace, repository string, buildRequest *RequestBuildRequest) (*Build, error) {
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/build/", QuayURL, namespace, repository), buildRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request build request: %w", err)
+	}
+
+	var build Build
+	if err := c.post(req, &build); err != nil {
+		return nil, fmt.Errorf("failed to request build: %w", err)
+	}
+
+	return &build, nil
+}
+
+// CancelBuild cancels an ongoing build
+func (c *Client) CancelBuild(namespace, repository, buildUUID string) error {
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/build/%s", QuayURL, namespace, repository, buildUUID), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create cancel build request: %w", err)
+	}
+
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to cancel build: %w", err)
+	}
+
+	return nil
+}

--- a/lib/build_test.go
+++ b/lib/build_test.go
@@ -1,0 +1,269 @@
+package lib
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	httpGetBuild    = "GET"
+	httpPostBuild   = "POST"
+	httpDeleteBuild = "DELETE"
+
+	testBuildNamespace  = "testorg"
+	testBuildRepository = "testrepo"
+	testBuildUUID       = "build-uuid-123"
+	testBuildPhase      = "complete"
+)
+
+func TestGetBuilds(t *testing.T) {
+	mockResponse := Builds{
+		Builds: []Build{
+			{ID: testBuildUUID, Phase: testBuildPhase, DisplayName: "Build 1"},
+			{ID: "build-uuid-456", Phase: "building", DisplayName: "Build 2"},
+		},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetBuild {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testBuildNamespace + "/" + testBuildRepository + "/build/"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	builds, err := client.GetBuilds(testBuildNamespace, testBuildRepository, 0)
+	if err != nil {
+		t.Fatalf("GetBuilds returned error: %v", err)
+	}
+
+	if len(builds.Builds) != 2 {
+		t.Errorf("Expected 2 builds, got %d", len(builds.Builds))
+	}
+	if builds.Builds[0].ID != testBuildUUID {
+		t.Errorf("Expected first build ID %s, got %s", testBuildUUID, builds.Builds[0].ID)
+	}
+}
+
+func TestGetBuild(t *testing.T) {
+	mockResponse := Build{
+		ID:          testBuildUUID,
+		Phase:       testBuildPhase,
+		DisplayName: "Test Build",
+		Started:     "2024-01-15T10:30:00Z",
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetBuild {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testBuildNamespace + "/" + testBuildRepository + "/build/" + testBuildUUID
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	build, err := client.GetBuild(testBuildNamespace, testBuildRepository, testBuildUUID)
+	if err != nil {
+		t.Fatalf("GetBuild returned error: %v", err)
+	}
+
+	if build.ID != testBuildUUID {
+		t.Errorf("Expected build ID %s, got %s", testBuildUUID, build.ID)
+	}
+	if build.Phase != testBuildPhase {
+		t.Errorf("Expected phase %s, got %s", testBuildPhase, build.Phase)
+	}
+}
+
+func TestGetBuildLogs(t *testing.T) {
+	mockResponse := BuildLogs{
+		Start: 0,
+		Total: 2,
+		Logs: []BuildLogEntry{
+			{Type: "phase", Message: "Starting build"},
+			{Type: "command", Message: "docker build ."},
+		},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetBuild {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testBuildNamespace + "/" + testBuildRepository + "/build/" + testBuildUUID + "/logs"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	logs, err := client.GetBuildLogs(testBuildNamespace, testBuildRepository, testBuildUUID)
+	if err != nil {
+		t.Fatalf("GetBuildLogs returned error: %v", err)
+	}
+
+	if logs.Total != 2 {
+		t.Errorf("Expected 2 log entries, got %d", logs.Total)
+	}
+	if len(logs.Logs) != 2 {
+		t.Errorf("Expected 2 log entries in array, got %d", len(logs.Logs))
+	}
+}
+
+func TestRequestBuild(t *testing.T) {
+	mockResponse := Build{
+		ID:    testBuildUUID,
+		Phase: "waiting",
+		Tags:  []string{"latest"},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpPostBuild {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testBuildNamespace + "/" + testBuildRepository + "/build/"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	buildReq := &RequestBuildRequest{
+		ArchiveURL: "https://example.com/archive.tar.gz",
+		Tags:       []string{"latest"},
+	}
+
+	build, err := client.RequestBuild(testBuildNamespace, testBuildRepository, buildReq)
+	if err != nil {
+		t.Fatalf("RequestBuild returned error: %v", err)
+	}
+
+	if build.ID != testBuildUUID {
+		t.Errorf("Expected build ID %s, got %s", testBuildUUID, build.ID)
+	}
+}
+
+func TestCancelBuild(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpDeleteBuild {
+			t.Errorf("Expected DELETE request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testBuildNamespace + "/" + testBuildRepository + "/build/" + testBuildUUID
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.CancelBuild(testBuildNamespace, testBuildRepository, testBuildUUID)
+	if err != nil {
+		t.Fatalf("CancelBuild returned error: %v", err)
+	}
+}
+
+func TestGetBuildsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetBuilds(testBuildNamespace, testBuildRepository, 0)
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}
+
+func TestGetBuildError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetBuild(testBuildNamespace, testBuildRepository, "nonexistent-uuid")
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}

--- a/lib/notification.go
+++ b/lib/notification.go
@@ -1,0 +1,124 @@
+/*
+Package lib provides Quay.io API client functionality.
+
+This file covers REPOSITORY NOTIFICATION operations:
+
+Notification Management:
+  - GET    /api/v1/repository/{namespace}/{repository}/notification/              - GetNotifications()
+  - GET    /api/v1/repository/{namespace}/{repository}/notification/{uuid}        - GetNotification()
+  - POST   /api/v1/repository/{namespace}/{repository}/notification/              - CreateNotification()
+  - DELETE /api/v1/repository/{namespace}/{repository}/notification/{uuid}        - DeleteNotification()
+  - POST   /api/v1/repository/{namespace}/{repository}/notification/{uuid}/test   - TestNotification()
+  - POST   /api/v1/repository/{namespace}/{repository}/notification/{uuid}/reset  - ResetNotification()
+
+Repository notifications (webhooks) allow external services to be notified
+of events such as image pushes, builds, and vulnerability scans.
+
+Supported events:
+  - repo_push: Image push to repository
+  - build_queued: Build has been queued
+  - build_start: Build has started
+  - build_success: Build completed successfully
+  - build_failure: Build failed
+  - build_canceled: Build was canceled
+  - vulnerability_found: New vulnerability discovered
+
+Supported methods:
+  - webhook: HTTP webhook
+  - email: Email notification
+  - slack: Slack notification
+  - hipchat: HipChat notification
+  - flowdock: Flowdock notification
+*/
+package lib
+
+import (
+	"fmt"
+)
+
+// GetNotifications retrieves all notifications for a repository
+func (c *Client) GetNotifications(namespace, repository string) (*RepositoryNotifications, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/notification/", QuayURL, namespace, repository), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get notifications request: %w", err)
+	}
+
+	var notifications RepositoryNotifications
+	if err := c.get(req, &notifications); err != nil {
+		return nil, fmt.Errorf("failed to get notifications: %w", err)
+	}
+
+	return &notifications, nil
+}
+
+// GetNotification retrieves a specific notification by UUID
+func (c *Client) GetNotification(namespace, repository, uuid string) (*RepositoryNotification, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/notification/%s", QuayURL, namespace, repository, uuid), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get notification request: %w", err)
+	}
+
+	var notification RepositoryNotification
+	if err := c.get(req, &notification); err != nil {
+		return nil, fmt.Errorf("failed to get notification: %w", err)
+	}
+
+	return &notification, nil
+}
+
+// CreateNotification creates a new notification for a repository
+func (c *Client) CreateNotification(namespace, repository string, notificationReq *CreateNotificationRequest) (*RepositoryNotification, error) {
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/notification/", QuayURL, namespace, repository), notificationReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create notification request: %w", err)
+	}
+
+	var notification RepositoryNotification
+	if err := c.post(req, &notification); err != nil {
+		return nil, fmt.Errorf("failed to create notification: %w", err)
+	}
+
+	return &notification, nil
+}
+
+// DeleteNotification deletes a notification from a repository
+func (c *Client) DeleteNotification(namespace, repository, uuid string) error {
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/notification/%s", QuayURL, namespace, repository, uuid), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete notification request: %w", err)
+	}
+
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to delete notification: %w", err)
+	}
+
+	return nil
+}
+
+// TestNotification tests a notification by sending a test event
+func (c *Client) TestNotification(namespace, repository, uuid string) error {
+	req, err := newRequest("POST", fmt.Sprintf("%s/repository/%s/%s/notification/%s/test", QuayURL, namespace, repository, uuid), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create test notification request: %w", err)
+	}
+
+	if err := c.post(req, nil); err != nil {
+		return fmt.Errorf("failed to test notification: %w", err)
+	}
+
+	return nil
+}
+
+// ResetNotification resets failure count for a notification
+func (c *Client) ResetNotification(namespace, repository, uuid string) error {
+	req, err := newRequest("POST", fmt.Sprintf("%s/repository/%s/%s/notification/%s/reset", QuayURL, namespace, repository, uuid), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create reset notification request: %w", err)
+	}
+
+	if err := c.post(req, nil); err != nil {
+		return fmt.Errorf("failed to reset notification: %w", err)
+	}
+
+	return nil
+}

--- a/lib/notification_test.go
+++ b/lib/notification_test.go
@@ -1,0 +1,284 @@
+package lib
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	httpGetNotification    = "GET"
+	httpPostNotification   = "POST"
+	httpDeleteNotification = "DELETE"
+
+	testNotificationNamespace  = "testorg"
+	testNotificationRepository = "testrepo"
+	testNotificationUUID       = "notification-uuid-123"
+	testNotificationEvent      = "repo_push"
+	testNotificationMethod     = "webhook"
+)
+
+func TestGetNotifications(t *testing.T) {
+	mockResponse := RepositoryNotifications{
+		Notifications: []RepositoryNotification{
+			{UUID: testNotificationUUID, Event: testNotificationEvent, Method: testNotificationMethod, Title: "Push Webhook"},
+			{UUID: "notification-uuid-456", Event: "build_success", Method: "slack", Title: "Build Slack"},
+		},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetNotification {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testNotificationNamespace + "/" + testNotificationRepository + "/notification/"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	notifications, err := client.GetNotifications(testNotificationNamespace, testNotificationRepository)
+	if err != nil {
+		t.Fatalf("GetNotifications returned error: %v", err)
+	}
+
+	if len(notifications.Notifications) != 2 {
+		t.Errorf("Expected 2 notifications, got %d", len(notifications.Notifications))
+	}
+	if notifications.Notifications[0].UUID != testNotificationUUID {
+		t.Errorf("Expected first notification UUID %s, got %s", testNotificationUUID, notifications.Notifications[0].UUID)
+	}
+}
+
+func TestGetNotification(t *testing.T) {
+	mockResponse := RepositoryNotification{
+		UUID:   testNotificationUUID,
+		Event:  testNotificationEvent,
+		Method: testNotificationMethod,
+		Title:  "Push Webhook",
+		Config: map[string]interface{}{"url": "https://example.com/webhook"},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetNotification {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testNotificationNamespace + "/" + testNotificationRepository + "/notification/" + testNotificationUUID
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	notification, err := client.GetNotification(testNotificationNamespace, testNotificationRepository, testNotificationUUID)
+	if err != nil {
+		t.Fatalf("GetNotification returned error: %v", err)
+	}
+
+	if notification.UUID != testNotificationUUID {
+		t.Errorf("Expected notification UUID %s, got %s", testNotificationUUID, notification.UUID)
+	}
+	if notification.Event != testNotificationEvent {
+		t.Errorf("Expected event %s, got %s", testNotificationEvent, notification.Event)
+	}
+}
+
+func TestCreateNotification(t *testing.T) {
+	mockResponse := RepositoryNotification{
+		UUID:   testNotificationUUID,
+		Event:  testNotificationEvent,
+		Method: testNotificationMethod,
+		Title:  "New Webhook",
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpPostNotification {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testNotificationNamespace + "/" + testNotificationRepository + "/notification/"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	notificationReq := &CreateNotificationRequest{
+		Event:  testNotificationEvent,
+		Method: testNotificationMethod,
+		Config: map[string]interface{}{"url": "https://example.com/webhook"},
+		Title:  "New Webhook",
+	}
+
+	notification, err := client.CreateNotification(testNotificationNamespace, testNotificationRepository, notificationReq)
+	if err != nil {
+		t.Fatalf("CreateNotification returned error: %v", err)
+	}
+
+	if notification.UUID != testNotificationUUID {
+		t.Errorf("Expected notification UUID %s, got %s", testNotificationUUID, notification.UUID)
+	}
+}
+
+func TestDeleteNotification(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpDeleteNotification {
+			t.Errorf("Expected DELETE request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testNotificationNamespace + "/" + testNotificationRepository + "/notification/" + testNotificationUUID
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.DeleteNotification(testNotificationNamespace, testNotificationRepository, testNotificationUUID)
+	if err != nil {
+		t.Fatalf("DeleteNotification returned error: %v", err)
+	}
+}
+
+func TestTestNotification(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpPostNotification {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testNotificationNamespace + "/" + testNotificationRepository + "/notification/" + testNotificationUUID + "/test"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.TestNotification(testNotificationNamespace, testNotificationRepository, testNotificationUUID)
+	if err != nil {
+		t.Fatalf("TestNotification returned error: %v", err)
+	}
+}
+
+func TestResetNotification(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpPostNotification {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testNotificationNamespace + "/" + testNotificationRepository + "/notification/" + testNotificationUUID + "/reset"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.ResetNotification(testNotificationNamespace, testNotificationRepository, testNotificationUUID)
+	if err != nil {
+		t.Fatalf("ResetNotification returned error: %v", err)
+	}
+}
+
+func TestGetNotificationsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetNotifications(testNotificationNamespace, testNotificationRepository)
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}
+
+func TestGetNotificationError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetNotification(testNotificationNamespace, testNotificationRepository, "nonexistent-uuid")
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -658,6 +658,116 @@ type SecurityVulnerability struct {
 	FixedBy       string                 `json:"FixedBy,omitempty"`
 }
 
+// Build Structures
+
+// Build represents a repository build
+type Build struct {
+	ID              string                 `json:"id,omitempty"`
+	Phase           string                 `json:"phase,omitempty"`
+	Started         string                 `json:"started,omitempty"`
+	DisplayName     string                 `json:"display_name,omitempty"`
+	Status          map[string]interface{} `json:"status,omitempty"`
+	Subdirectory    string                 `json:"subdirectory,omitempty"`
+	Dockerfile      string                 `json:"dockerfile_path,omitempty"`
+	Context         string                 `json:"context,omitempty"`
+	IsWriter        bool                   `json:"is_writer,omitempty"`
+	Trigger         *BuildTrigger          `json:"trigger,omitempty"`
+	TriggerMetadata map[string]interface{} `json:"trigger_metadata,omitempty"`
+	ResourceKey     string                 `json:"resource_key,omitempty"`
+	Pull            *BuildPullRobot        `json:"pull_robot,omitempty"`
+	Repository      *BuildRepository       `json:"repository,omitempty"`
+	Error           string                 `json:"error,omitempty"`
+	ManualUser      string                 `json:"manual_user,omitempty"`
+	Archive         string                 `json:"archive_url,omitempty"`
+	Tags            []string               `json:"tags,omitempty"`
+}
+
+// BuildTrigger represents a build trigger
+type BuildTrigger struct {
+	ID            string `json:"id,omitempty"`
+	Service       string `json:"service,omitempty"`
+	IsActive      bool   `json:"is_active,omitempty"`
+	BuildSource   string `json:"build_source,omitempty"`
+	RepositoryURL string `json:"repository_url,omitempty"`
+}
+
+// BuildPullRobot represents a robot account for pulling
+type BuildPullRobot struct {
+	Name    string `json:"name,omitempty"`
+	IsRobot bool   `json:"is_robot,omitempty"`
+	Kind    string `json:"kind,omitempty"`
+	Avatar  Avatar `json:"avatar,omitempty"`
+}
+
+// BuildRepository represents repository info in a build
+type BuildRepository struct {
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name,omitempty"`
+}
+
+// Builds represents a list of builds
+type Builds struct {
+	Builds []Build `json:"builds,omitempty"`
+}
+
+// BuildLogs represents build logs
+type BuildLogs struct {
+	Start int             `json:"start,omitempty"`
+	Total int             `json:"total,omitempty"`
+	Logs  []BuildLogEntry `json:"logs,omitempty"`
+}
+
+// BuildLogEntry represents a single log entry in build logs
+type BuildLogEntry struct {
+	Type    string                 `json:"type,omitempty"`
+	Message string                 `json:"message,omitempty"`
+	Data    map[string]interface{} `json:"data,omitempty"`
+}
+
+// RequestBuildRequest represents the request to trigger a build
+type RequestBuildRequest struct {
+	FileID         string   `json:"file_id,omitempty"`
+	ArchiveURL     string   `json:"archive_url,omitempty"`
+	Subdirectory   string   `json:"subdirectory,omitempty"`
+	DockerfilePath string   `json:"dockerfile_path,omitempty"`
+	Context        string   `json:"context,omitempty"`
+	PullRobot      string   `json:"pull_robot,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+}
+
+// Repository Notification Structures
+
+// RepositoryNotification represents a repository notification/webhook
+type RepositoryNotification struct {
+	UUID             string                 `json:"uuid,omitempty"`
+	Title            string                 `json:"title,omitempty"`
+	Event            string                 `json:"event,omitempty"`
+	Method           string                 `json:"method,omitempty"`
+	Config           map[string]interface{} `json:"config,omitempty"`
+	EventConfig      map[string]interface{} `json:"event_config,omitempty"`
+	NumberOfFailures int                    `json:"number_of_failures,omitempty"`
+}
+
+// RepositoryNotifications represents a list of notifications
+type RepositoryNotifications struct {
+	Notifications []RepositoryNotification `json:"notifications,omitempty"`
+}
+
+// CreateNotificationRequest represents the request to create a notification
+type CreateNotificationRequest struct {
+	Event       string                 `json:"event"`
+	Method      string                 `json:"method"`
+	Config      map[string]interface{} `json:"config"`
+	EventConfig map[string]interface{} `json:"eventConfig,omitempty"`
+	Title       string                 `json:"title,omitempty"`
+}
+
+// TestNotificationResponse represents the response from testing a notification
+type TestNotificationResponse struct {
+	Success bool   `json:"success,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
 // Error Response Structure
 
 // QuayError represents a Quay API error response


### PR DESCRIPTION
Add `Build and RepositoryNotification APIs`.

The most important changes are:

**New CLI Commands:**

* Added a new `build` command group (`cmd/build.go`) with subcommands to list, get info, fetch logs, request, and cancel builds for repositories. This enables full management of automated image builds via the CLI.
* Added a new `notification` command group (`cmd/notification.go`) with subcommands to list, get info, create, delete, test, and reset notifications (webhooks) for repositories. This allows users to manage repository event notifications directly from the CLI.
* Registered the new `build` and `notification` commands with the root command so they are available to users.

**Documentation Updates:**

* Updated the API coverage table in `README.md` to indicate that the Build and RepositoryNotification APIs are now supported by both the CLI and library, and listed the specific endpoints covered. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R26)
* Added detailed documentation and usage examples for the new build and notification commands, including supported events, methods, and example CLI invocations.