### PR TITLE
Add 'Trigger' API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following APIs are covered by the repo. Each API links to the corresponding 
 | [SecScan](https://docs.quay.io/api/swagger/#SecScan)                | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/security |
 | [Tag](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--tag-get)                    | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/tag, /api/v1/repository/{namespace}/{repository}/tag/{tag}, /api/v1/repository/{namespace}/{repository}/tag/{tag}/history |
 | [Team](https://docs.quay.io/api/swagger/#Team)                   | Yes     | Yes     | /api/v1/organization/{orgname}/team/{teamname}, /api/v1/organization/{orgname}/team/{teamname}/members, /api/v1/organization/{orgname}/team/{teamname}/permissions |
-| [Trigger](https://docs.quay.io/api/swagger/#Trigger)                | No      | No      |                                                                                                                                                                                                                     |
+| [Trigger](https://docs.quay.io/api/swagger/#Trigger)                | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/trigger/, /api/v1/repository/{namespace}/{repository}/trigger/{trigger_uuid}, /api/v1/repository/{namespace}/{repository}/trigger/{trigger_uuid}/start, /api/v1/repository/{namespace}/{repository}/trigger/{trigger_uuid}/activate |
 | [User](https://docs.quay.io/api/swagger/#operation--api-v1-user-get)                   | Yes     | Yes     | /api/v1/user, /api/v1/user/starred, /api/v1/repository/{namespace}/{repository}/star | 
 
 ## Authentication
@@ -127,6 +127,88 @@ The build API allows you to manage automated image builds from Dockerfiles.
 - `pushing`: Pushing built image
 - `complete`: Build completed successfully
 - `error`: Build failed
+
+### Trigger API
+
+The trigger API allows you to manage build triggers for automated builds when code is pushed to connected source repositories.
+
+📖 **API Reference:** [Trigger endpoints in Swagger](https://docs.quay.io/api/swagger/#Trigger)
+
+#### List triggers for a repository
+```bash
+./go-quay get trigger list \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --token YOUR_TOKEN
+```
+
+#### Get trigger details
+```bash
+./go-quay get trigger info \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --uuid TRIGGER_UUID \
+  --token YOUR_TOKEN
+```
+
+#### Delete a trigger
+```bash
+./go-quay get trigger delete \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --uuid TRIGGER_UUID \
+  --token YOUR_TOKEN
+```
+
+#### Enable a trigger
+```bash
+./go-quay get trigger enable \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --uuid TRIGGER_UUID \
+  --token YOUR_TOKEN
+```
+
+#### Disable a trigger
+```bash
+./go-quay get trigger disable \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --uuid TRIGGER_UUID \
+  --token YOUR_TOKEN
+```
+
+#### Manually start a build from trigger
+```bash
+./go-quay get trigger start \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --uuid TRIGGER_UUID \
+  --token YOUR_TOKEN
+
+# Optionally specify a commit SHA
+./go-quay get trigger start \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --uuid TRIGGER_UUID \
+  --commit-sha abc123def456 \
+  --token YOUR_TOKEN
+```
+
+#### Activate a trigger
+```bash
+./go-quay get trigger activate \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --uuid TRIGGER_UUID \
+  --token YOUR_TOKEN
+```
+
+**Supported Trigger Services:**
+- `github`: GitHub repository
+- `gitlab`: GitLab repository
+- `bitbucket`: Bitbucket repository
+- `custom-git`: Custom git repository
 
 ### Repository Notification API
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,6 +30,7 @@ func init() {
 	getCmd.AddCommand(teamCmd)
 	getCmd.AddCommand(buildCmd)
 	getCmd.AddCommand(notificationCmd)
+	getCmd.AddCommand(triggerCmd)
 }
 
 // Execute executes the root command.

--- a/cmd/trigger.go
+++ b/cmd/trigger.go
@@ -1,0 +1,300 @@
+/*
+Package cmd provides the command-line interface for go-quay.
+
+This file contains the commands for the Trigger API:
+  - go-quay get trigger list         - List all build triggers for a repository
+  - go-quay get trigger info         - Get details of a specific build trigger
+  - go-quay get trigger delete       - Delete a build trigger
+  - go-quay get trigger enable       - Enable a build trigger
+  - go-quay get trigger disable      - Disable a build trigger
+  - go-quay get trigger start        - Manually start a build from a trigger
+  - go-quay get trigger activate     - Activate a build trigger with configuration
+*/
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/sebrandon1/go-quay/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	triggerNamespace  string
+	triggerRepository string
+	triggerUUID       string
+	triggerCommitSHA  string
+	triggerPullRobot  string
+)
+
+// triggerCmd represents the trigger command
+var triggerCmd = &cobra.Command{
+	Use:   "trigger",
+	Short: "Manage repository build triggers",
+	Long: `Manage build triggers for repositories.
+
+Build triggers allow automated image builds when code is pushed to 
+connected source repositories like GitHub, GitLab, or Bitbucket.`,
+}
+
+// triggerListCmd represents the trigger list command
+var triggerListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all build triggers for a repository",
+	Long:  `List all build triggers configured for a repository.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		triggers, err := client.GetTriggers(triggerNamespace, triggerRepository)
+		if err != nil {
+			fmt.Println("Error getting triggers:", err)
+			os.Exit(1)
+		}
+
+		output, err := json.MarshalIndent(triggers, "", "  ")
+		if err != nil {
+			fmt.Println("Error marshaling response:", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(output))
+	},
+}
+
+// triggerInfoCmd represents the trigger info command
+var triggerInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Get details of a specific build trigger",
+	Long:  `Get detailed information about a specific build trigger by its UUID.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		if triggerUUID == "" {
+			fmt.Println("Error: --uuid is required")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		trigger, err := client.GetTrigger(triggerNamespace, triggerRepository, triggerUUID)
+		if err != nil {
+			fmt.Println("Error getting trigger:", err)
+			os.Exit(1)
+		}
+
+		output, err := json.MarshalIndent(trigger, "", "  ")
+		if err != nil {
+			fmt.Println("Error marshaling response:", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(output))
+	},
+}
+
+// triggerDeleteCmd represents the trigger delete command
+var triggerDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a build trigger",
+	Long:  `Delete a build trigger from a repository.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		if triggerUUID == "" {
+			fmt.Println("Error: --uuid is required")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		err = client.DeleteTrigger(triggerNamespace, triggerRepository, triggerUUID)
+		if err != nil {
+			fmt.Println("Error deleting trigger:", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Trigger %s deleted successfully\n", triggerUUID)
+	},
+}
+
+// triggerEnableCmd represents the trigger enable command
+var triggerEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable a build trigger",
+	Long:  `Enable a build trigger for a repository.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		if triggerUUID == "" {
+			fmt.Println("Error: --uuid is required")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		trigger, err := client.UpdateTrigger(triggerNamespace, triggerRepository, triggerUUID, true)
+		if err != nil {
+			fmt.Println("Error enabling trigger:", err)
+			os.Exit(1)
+		}
+
+		output, err := json.MarshalIndent(trigger, "", "  ")
+		if err != nil {
+			fmt.Println("Error marshaling response:", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(output))
+	},
+}
+
+// triggerDisableCmd represents the trigger disable command
+var triggerDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable a build trigger",
+	Long:  `Disable a build trigger for a repository.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		if triggerUUID == "" {
+			fmt.Println("Error: --uuid is required")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		trigger, err := client.UpdateTrigger(triggerNamespace, triggerRepository, triggerUUID, false)
+		if err != nil {
+			fmt.Println("Error disabling trigger:", err)
+			os.Exit(1)
+		}
+
+		output, err := json.MarshalIndent(trigger, "", "  ")
+		if err != nil {
+			fmt.Println("Error marshaling response:", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(output))
+	},
+}
+
+// triggerStartCmd represents the trigger start command
+var triggerStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Manually start a build from a trigger",
+	Long:  `Manually start a build using a configured trigger.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		if triggerUUID == "" {
+			fmt.Println("Error: --uuid is required")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		var triggerReq *lib.ManualTriggerRequest
+		if triggerCommitSHA != "" {
+			triggerReq = &lib.ManualTriggerRequest{
+				CommitSHA: triggerCommitSHA,
+			}
+		}
+
+		build, err := client.StartTriggerBuild(triggerNamespace, triggerRepository, triggerUUID, triggerReq)
+		if err != nil {
+			fmt.Println("Error starting trigger build:", err)
+			os.Exit(1)
+		}
+
+		output, err := json.MarshalIndent(build, "", "  ")
+		if err != nil {
+			fmt.Println("Error marshaling response:", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(output))
+	},
+}
+
+// triggerActivateCmd represents the trigger activate command
+var triggerActivateCmd = &cobra.Command{
+	Use:   "activate",
+	Short: "Activate a build trigger with configuration",
+	Long:  `Activate a build trigger with the specified configuration.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		if triggerUUID == "" {
+			fmt.Println("Error: --uuid is required")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		activateReq := &lib.ActivateTriggerRequest{}
+		if triggerPullRobot != "" {
+			activateReq.PullRobot = triggerPullRobot
+		}
+
+		trigger, err := client.ActivateTrigger(triggerNamespace, triggerRepository, triggerUUID, activateReq)
+		if err != nil {
+			fmt.Println("Error activating trigger:", err)
+			os.Exit(1)
+		}
+
+		output, err := json.MarshalIndent(trigger, "", "  ")
+		if err != nil {
+			fmt.Println("Error marshaling response:", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(output))
+	},
+}
+
+func setupTriggerFlags() {
+	// Common flags for all subcommands
+	for _, cmd := range []*cobra.Command{triggerListCmd, triggerInfoCmd, triggerDeleteCmd, triggerEnableCmd, triggerDisableCmd, triggerStartCmd, triggerActivateCmd} {
+		cmd.Flags().StringVarP(&triggerNamespace, "namespace", "n", "", "Namespace/organization")
+		cmd.Flags().StringVarP(&triggerRepository, "repository", "r", "", "Repository name")
+		cmd.Flags().StringVarP(&token, "token", "t", "", "Quay.io API token")
+	}
+
+	// UUID flags for subcommands that need it
+	for _, cmd := range []*cobra.Command{triggerInfoCmd, triggerDeleteCmd, triggerEnableCmd, triggerDisableCmd, triggerStartCmd, triggerActivateCmd} {
+		cmd.Flags().StringVar(&triggerUUID, "uuid", "", "UUID of the build trigger")
+	}
+
+	// Start command specific flags
+	triggerStartCmd.Flags().StringVar(&triggerCommitSHA, "commit-sha", "", "Specific commit SHA to build (optional)")
+
+	// Activate command specific flags
+	triggerActivateCmd.Flags().StringVar(&triggerPullRobot, "pull-robot", "", "Robot account to use for pulling base images (optional)")
+}
+
+func init() {
+	// Add subcommands to trigger command
+	triggerCmd.AddCommand(triggerListCmd)
+	triggerCmd.AddCommand(triggerInfoCmd)
+	triggerCmd.AddCommand(triggerDeleteCmd)
+	triggerCmd.AddCommand(triggerEnableCmd)
+	triggerCmd.AddCommand(triggerDisableCmd)
+	triggerCmd.AddCommand(triggerStartCmd)
+	triggerCmd.AddCommand(triggerActivateCmd)
+
+	// Setup flags
+	setupTriggerFlags()
+}

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -684,11 +684,33 @@ type Build struct {
 
 // BuildTrigger represents a build trigger
 type BuildTrigger struct {
-	ID            string `json:"id,omitempty"`
-	Service       string `json:"service,omitempty"`
-	IsActive      bool   `json:"is_active,omitempty"`
-	BuildSource   string `json:"build_source,omitempty"`
-	RepositoryURL string `json:"repository_url,omitempty"`
+	ID            string                 `json:"id,omitempty"`
+	Service       string                 `json:"service,omitempty"`
+	IsActive      bool                   `json:"is_active,omitempty"`
+	BuildSource   string                 `json:"build_source,omitempty"`
+	RepositoryURL string                 `json:"repository_url,omitempty"`
+	Config        map[string]interface{} `json:"config,omitempty"`
+	CanInvoke     bool                   `json:"can_invoke,omitempty"`
+	Enabled       bool                   `json:"enabled,omitempty"`
+	DisableReason string                 `json:"disable_reason,omitempty"`
+	PullRobot     *BuildPullRobot        `json:"pull_robot,omitempty"`
+}
+
+// BuildTriggers represents a list of build triggers
+type BuildTriggers struct {
+	Triggers []BuildTrigger `json:"triggers,omitempty"`
+}
+
+// ActivateTriggerRequest represents the request to activate a build trigger
+type ActivateTriggerRequest struct {
+	Config    map[string]interface{} `json:"config,omitempty"`
+	PullRobot string                 `json:"pull_robot,omitempty"`
+}
+
+// ManualTriggerRequest represents the request to manually start a build trigger
+type ManualTriggerRequest struct {
+	CommitSHA string            `json:"commit_sha,omitempty"`
+	Refs      map[string]string `json:"refs,omitempty"`
 }
 
 // BuildPullRobot represents a robot account for pulling

--- a/lib/trigger.go
+++ b/lib/trigger.go
@@ -1,0 +1,125 @@
+/*
+Package lib provides Quay.io API client functionality.
+
+This file covers BUILD TRIGGER operations:
+
+Trigger Management:
+  - GET    /api/v1/repository/{namespace}/{repository}/trigger/                       - GetTriggers()
+  - GET    /api/v1/repository/{namespace}/{repository}/trigger/{trigger_uuid}         - GetTrigger()
+  - DELETE /api/v1/repository/{namespace}/{repository}/trigger/{trigger_uuid}         - DeleteTrigger()
+  - PUT    /api/v1/repository/{namespace}/{repository}/trigger/{trigger_uuid}         - UpdateTrigger()
+  - POST   /api/v1/repository/{namespace}/{repository}/trigger/{trigger_uuid}/start   - StartTriggerBuild()
+  - POST   /api/v1/repository/{namespace}/{repository}/trigger/{trigger_uuid}/activate - ActivateTrigger()
+
+Build triggers allow automated image builds when code is pushed to connected
+source repositories like GitHub, GitLab, or Bitbucket.
+
+Supported trigger services:
+  - github: GitHub repository
+  - gitlab: GitLab repository
+  - bitbucket: Bitbucket repository
+  - custom-git: Custom git repository
+*/
+package lib
+
+import (
+	"fmt"
+)
+
+// GetTriggers retrieves all build triggers for a repository
+func (c *Client) GetTriggers(namespace, repository string) (*BuildTriggers, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/trigger/", QuayURL, namespace, repository), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get triggers request: %w", err)
+	}
+
+	var triggers BuildTriggers
+	if err := c.get(req, &triggers); err != nil {
+		return nil, fmt.Errorf("failed to get triggers: %w", err)
+	}
+
+	return &triggers, nil
+}
+
+// GetTrigger retrieves a specific build trigger by UUID
+func (c *Client) GetTrigger(namespace, repository, triggerUUID string) (*BuildTrigger, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/trigger/%s", QuayURL, namespace, repository, triggerUUID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get trigger request: %w", err)
+	}
+
+	var trigger BuildTrigger
+	if err := c.get(req, &trigger); err != nil {
+		return nil, fmt.Errorf("failed to get trigger: %w", err)
+	}
+
+	return &trigger, nil
+}
+
+// DeleteTrigger deletes a build trigger
+func (c *Client) DeleteTrigger(namespace, repository, triggerUUID string) error {
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/trigger/%s", QuayURL, namespace, repository, triggerUUID), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete trigger request: %w", err)
+	}
+
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to delete trigger: %w", err)
+	}
+
+	return nil
+}
+
+// UpdateTrigger updates a build trigger (enable/disable)
+func (c *Client) UpdateTrigger(namespace, repository, triggerUUID string, enabled bool) (*BuildTrigger, error) {
+	body := map[string]interface{}{
+		"enabled": enabled,
+	}
+
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/trigger/%s", QuayURL, namespace, repository, triggerUUID), body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create update trigger request: %w", err)
+	}
+
+	var trigger BuildTrigger
+	if err := c.put(req, &trigger); err != nil {
+		return nil, fmt.Errorf("failed to update trigger: %w", err)
+	}
+
+	return &trigger, nil
+}
+
+// StartTriggerBuild manually starts a build from a trigger
+func (c *Client) StartTriggerBuild(namespace, repository, triggerUUID string, triggerReq *ManualTriggerRequest) (*Build, error) {
+	var body interface{}
+	if triggerReq != nil {
+		body = triggerReq
+	}
+
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/trigger/%s/start", QuayURL, namespace, repository, triggerUUID), body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create start trigger build request: %w", err)
+	}
+
+	var build Build
+	if err := c.post(req, &build); err != nil {
+		return nil, fmt.Errorf("failed to start trigger build: %w", err)
+	}
+
+	return &build, nil
+}
+
+// ActivateTrigger activates a build trigger with configuration
+func (c *Client) ActivateTrigger(namespace, repository, triggerUUID string, activateReq *ActivateTriggerRequest) (*BuildTrigger, error) {
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/trigger/%s/activate", QuayURL, namespace, repository, triggerUUID), activateReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create activate trigger request: %w", err)
+	}
+
+	var trigger BuildTrigger
+	if err := c.post(req, &trigger); err != nil {
+		return nil, fmt.Errorf("failed to activate trigger: %w", err)
+	}
+
+	return &trigger, nil
+}

--- a/lib/trigger_test.go
+++ b/lib/trigger_test.go
@@ -1,0 +1,323 @@
+package lib
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	httpGetTrigger    = "GET"
+	httpPutTrigger    = "PUT"
+	httpPostTrigger   = "POST"
+	httpDeleteTrigger = "DELETE"
+
+	testTriggerNamespace  = "testorg"
+	testTriggerRepository = "testrepo"
+	testTriggerUUID       = "trigger-uuid-123"
+	testTriggerService    = "github"
+)
+
+func TestGetTriggers(t *testing.T) {
+	mockResponse := BuildTriggers{
+		Triggers: []BuildTrigger{
+			{ID: testTriggerUUID, Service: testTriggerService, IsActive: true, BuildSource: "org/repo"},
+			{ID: "trigger-uuid-456", Service: "gitlab", IsActive: false, BuildSource: "group/project"},
+		},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetTrigger {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testTriggerNamespace + "/" + testTriggerRepository + "/trigger/"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	triggers, err := client.GetTriggers(testTriggerNamespace, testTriggerRepository)
+	if err != nil {
+		t.Fatalf("GetTriggers returned error: %v", err)
+	}
+
+	if len(triggers.Triggers) != 2 {
+		t.Errorf("Expected 2 triggers, got %d", len(triggers.Triggers))
+	}
+	if triggers.Triggers[0].ID != testTriggerUUID {
+		t.Errorf("Expected first trigger ID %s, got %s", testTriggerUUID, triggers.Triggers[0].ID)
+	}
+	if triggers.Triggers[0].Service != testTriggerService {
+		t.Errorf("Expected service %s, got %s", testTriggerService, triggers.Triggers[0].Service)
+	}
+}
+
+func TestGetTrigger(t *testing.T) {
+	mockResponse := BuildTrigger{
+		ID:            testTriggerUUID,
+		Service:       testTriggerService,
+		IsActive:      true,
+		BuildSource:   "myorg/myrepo",
+		RepositoryURL: "https://github.com/myorg/myrepo",
+		CanInvoke:     true,
+		Enabled:       true,
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetTrigger {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testTriggerNamespace + "/" + testTriggerRepository + "/trigger/" + testTriggerUUID
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	trigger, err := client.GetTrigger(testTriggerNamespace, testTriggerRepository, testTriggerUUID)
+	if err != nil {
+		t.Fatalf("GetTrigger returned error: %v", err)
+	}
+
+	if trigger.ID != testTriggerUUID {
+		t.Errorf("Expected trigger ID %s, got %s", testTriggerUUID, trigger.ID)
+	}
+	if trigger.Service != testTriggerService {
+		t.Errorf("Expected service %s, got %s", testTriggerService, trigger.Service)
+	}
+	if !trigger.IsActive {
+		t.Error("Expected trigger to be active")
+	}
+}
+
+func TestDeleteTrigger(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpDeleteTrigger {
+			t.Errorf("Expected DELETE request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testTriggerNamespace + "/" + testTriggerRepository + "/trigger/" + testTriggerUUID
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.DeleteTrigger(testTriggerNamespace, testTriggerRepository, testTriggerUUID)
+	if err != nil {
+		t.Fatalf("DeleteTrigger returned error: %v", err)
+	}
+}
+
+func TestUpdateTrigger(t *testing.T) {
+	mockResponse := BuildTrigger{
+		ID:       testTriggerUUID,
+		Service:  testTriggerService,
+		IsActive: true,
+		Enabled:  false,
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpPutTrigger {
+			t.Errorf("Expected PUT request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testTriggerNamespace + "/" + testTriggerRepository + "/trigger/" + testTriggerUUID
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	trigger, err := client.UpdateTrigger(testTriggerNamespace, testTriggerRepository, testTriggerUUID, false)
+	if err != nil {
+		t.Fatalf("UpdateTrigger returned error: %v", err)
+	}
+
+	if trigger.ID != testTriggerUUID {
+		t.Errorf("Expected trigger ID %s, got %s", testTriggerUUID, trigger.ID)
+	}
+}
+
+func TestStartTriggerBuild(t *testing.T) {
+	mockResponse := Build{
+		ID:    "build-uuid-789",
+		Phase: "waiting",
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpPostTrigger {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testTriggerNamespace + "/" + testTriggerRepository + "/trigger/" + testTriggerUUID + "/start"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	triggerReq := &ManualTriggerRequest{
+		CommitSHA: "abc123def456",
+	}
+
+	build, err := client.StartTriggerBuild(testTriggerNamespace, testTriggerRepository, testTriggerUUID, triggerReq)
+	if err != nil {
+		t.Fatalf("StartTriggerBuild returned error: %v", err)
+	}
+
+	if build.ID != "build-uuid-789" {
+		t.Errorf("Expected build ID 'build-uuid-789', got %s", build.ID)
+	}
+}
+
+func TestActivateTrigger(t *testing.T) {
+	mockResponse := BuildTrigger{
+		ID:       testTriggerUUID,
+		Service:  testTriggerService,
+		IsActive: true,
+		Enabled:  true,
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpPostTrigger {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testTriggerNamespace + "/" + testTriggerRepository + "/trigger/" + testTriggerUUID + "/activate"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	activateReq := &ActivateTriggerRequest{
+		Config: map[string]interface{}{
+			"build_source":    "myorg/myrepo",
+			"dockerfile_path": "/Dockerfile",
+		},
+	}
+
+	trigger, err := client.ActivateTrigger(testTriggerNamespace, testTriggerRepository, testTriggerUUID, activateReq)
+	if err != nil {
+		t.Fatalf("ActivateTrigger returned error: %v", err)
+	}
+
+	if trigger.ID != testTriggerUUID {
+		t.Errorf("Expected trigger ID %s, got %s", testTriggerUUID, trigger.ID)
+	}
+	if !trigger.IsActive {
+		t.Error("Expected trigger to be active")
+	}
+}
+
+func TestGetTriggersError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetTriggers(testTriggerNamespace, testTriggerRepository)
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}
+
+func TestGetTriggerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetTrigger(testTriggerNamespace, testTriggerRepository, "nonexistent-uuid")
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}


### PR DESCRIPTION
Adds `Trigger` API support.

**Trigger API Support**

* Introduced a new `trigger` command group in the CLI (`cmd/trigger.go`) with subcommands to list, get info, delete, enable, disable, manually start, and activate build triggers for a repository. Each subcommand is fully integrated with flag handling and JSON output.
* Registered the `triggerCmd` with the root command, making trigger management available in the CLI tool.

**API Client Enhancements**

* Implemented new client methods in `lib/trigger.go` for all Trigger API endpoints: listing triggers, retrieving trigger details, deleting, enabling/disabling, manually starting, and activating triggers. These methods handle request construction, response parsing, and error handling.
* Extended data structures in `lib/structs.go` to represent triggers, trigger lists, and trigger-related requests, ensuring accurate mapping of API responses and requests.

**Documentation Updates**

* Updated `README.md` to indicate full Trigger API support, including a detailed section with command usage examples for all trigger operations and a summary of supported trigger services. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R33) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R131-R212)