### PR TITLE
Add remaining low priority APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ The following APIs are covered by the repo. Each API links to the corresponding 
 | ---------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Billing](https://docs.quay.io/api/swagger/#operation--api-v1-user-plan-get)                | Yes     | Yes     | /api/v1/user/plan, /api/v1/organization/{orgname}/plan, /api/v1/organization/{orgname}/invoices, /api/v1/plans/                                                                                                   |
 | [Build](https://docs.quay.io/api/swagger/#Build)                  | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/build/, /api/v1/repository/{namespace}/{repository}/build/{build_uuid}, /api/v1/repository/{namespace}/{repository}/build/{build_uuid}/logs |
-| [Discovery](https://docs.quay.io/api/swagger/#Discovery)              | No      | No      |                                                                                                                                                                                                                     |
-| [Error](https://docs.quay.io/api/swagger/#Error)                  | No      | No      |                                                                                                                                                                                                                     |
-| [Messages](https://docs.quay.io/api/swagger/#Messages)               | No      | No      |                                                                                                                                                                                                                     |
+| [Discovery](https://docs.quay.io/api/swagger/#Discovery)              | Yes     | Yes     | /api/v1/discovery |
+| [Error](https://docs.quay.io/api/swagger/#Error)                  | Yes     | Yes     | /api/v1/error/{error_type} |
+| [Messages](https://docs.quay.io/api/swagger/#Messages)               | Yes     | Yes     | /api/v1/messages |
 | [Logs](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--aggregatelogs-get)                   | Partial | Partial | /api/v1/repository/{namespace}/{repository}/aggregatelogs, /api/v1/repository/{namespace}/{repository}/logs, /api/v1/organization/{orgname}/logs |
 | [Manifest](https://docs.quay.io/api/swagger/#Manifest)               | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}, /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/labels, /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/labels/{labelid} |
 | [Organization](https://docs.quay.io/api/swagger/#operation--api-v1-organization--orgname--get)           | Yes     | Yes     | /api/v1/organization/{orgname}, /api/v1/organization/{orgname}/members, /api/v1/organization/{orgname}/teams, /api/v1/organization/{orgname}/team/{teamname}, /api/v1/organization/{orgname}/robots, /api/v1/organization/{orgname}/quota, /api/v1/organization/{orgname}/autoprunepolicy, /api/v1/organization/{orgname}/applications |
 | [Permission](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--permissions-get)             | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/permissions, /api/v1/repository/{namespace}/{repository}/permissions/{username} |
-| [Prototype](https://docs.quay.io/api/swagger/#Prototype)              | No      | No      |                                                                                                                                                                                                                     |
+| [Prototype](https://docs.quay.io/api/swagger/#Prototype)              | Yes     | Yes     | /api/v1/organization/{orgname}/prototypes, /api/v1/organization/{orgname}/prototypes/{uuid} |
 | [Repository](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--get)             | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}, /api/v1/repository/{namespace}/{repository}/tag, /api/v1/repository, /api/v1/repository/{namespace}/{repository} (CRUD) |
 | [RepositoryNotification](https://docs.quay.io/api/swagger/#RepositoryNotification) | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/notification/, /api/v1/repository/{namespace}/{repository}/notification/{uuid}, /api/v1/repository/{namespace}/{repository}/notification/{uuid}/test |
-| [RepoToken](https://docs.quay.io/api/swagger/#RepoToken)              | No      | No      |                                                                                                                                                                                                                     |
+| [RepoToken](https://docs.quay.io/api/swagger/#RepoToken)              | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/tokens, /api/v1/repository/{namespace}/{repository}/tokens/{code} (DEPRECATED) |
 | [Robot](https://docs.quay.io/api/swagger/#Robot)                  | Yes     | Yes     | /api/v1/user/robots, /api/v1/user/robots/{robot_shortname}, /api/v1/user/robots/{robot_shortname}/regenerate, /api/v1/user/robots/{robot_shortname}/permissions |
 | [Search](https://docs.quay.io/api/swagger/#Search)                 | Yes     | Yes     | /api/v1/find/repositories, /api/v1/find/all |
 | [SecScan](https://docs.quay.io/api/swagger/#SecScan)                | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/security |
@@ -914,4 +914,152 @@ The organization API provides comprehensive management of organizations, teams, 
 ./go-quay get organization applications \
   -o myorg \
   -t YOUR_TOKEN
+```
+
+### Discovery API
+
+The discovery API provides information about available API endpoints and versions.
+
+📖 **API Reference:** [Discovery endpoints in Swagger](https://docs.quay.io/api/swagger/#Discovery)
+
+#### Get API discovery information
+```bash
+./go-quay get discovery \
+  --token YOUR_TOKEN
+```
+
+### Error API
+
+The error API provides details about specific error types returned by the Quay.io API.
+
+📖 **API Reference:** [Error endpoints in Swagger](https://docs.quay.io/api/swagger/#Error)
+
+#### Get error type details
+```bash
+./go-quay get error \
+  --type invalid_token \
+  --token YOUR_TOKEN
+```
+
+### Messages API
+
+The messages API returns system-wide messages for the authenticated user.
+
+📖 **API Reference:** [Messages endpoints in Swagger](https://docs.quay.io/api/swagger/#Messages)
+
+#### Get system messages
+```bash
+./go-quay get messages \
+  --token YOUR_TOKEN
+```
+
+### Prototype API
+
+The prototype API manages default permission prototypes that are automatically applied to new repositories.
+
+📖 **API Reference:** [Prototype endpoints in Swagger](https://docs.quay.io/api/swagger/#Prototype)
+
+#### List all prototypes
+```bash
+./go-quay get prototype list \
+  --organization myorg \
+  --token YOUR_TOKEN
+```
+
+#### Get prototype details
+```bash
+./go-quay get prototype info \
+  --organization myorg \
+  --uuid PROTOTYPE_UUID \
+  --token YOUR_TOKEN
+```
+
+#### Create a prototype
+```bash
+./go-quay get prototype create \
+  --organization myorg \
+  --delegate-name devteam \
+  --delegate-kind team \
+  --role write \
+  --token YOUR_TOKEN
+```
+
+#### Update a prototype
+```bash
+./go-quay get prototype update \
+  --organization myorg \
+  --uuid PROTOTYPE_UUID \
+  --role admin \
+  --token YOUR_TOKEN
+```
+
+#### Delete a prototype
+```bash
+./go-quay get prototype delete \
+  --organization myorg \
+  --uuid PROTOTYPE_UUID \
+  --confirm \
+  --token YOUR_TOKEN
+```
+
+**Delegate Kinds:**
+- `user`: A specific user account
+- `team`: A team within the organization
+- `robot`: A robot account
+
+**Roles:**
+- `read`: Pull images
+- `write`: Pull and push images
+- `admin`: Full administrative access
+
+### RepoToken API (DEPRECATED)
+
+⚠️ **WARNING:** Repository tokens are deprecated. Use robot accounts instead for better security.
+
+📖 **API Reference:** [RepoToken endpoints in Swagger](https://docs.quay.io/api/swagger/#RepoToken)
+
+#### List repository tokens
+```bash
+./go-quay get repotoken list \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --token YOUR_TOKEN
+```
+
+#### Get token details
+```bash
+./go-quay get repotoken info \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --code TOKEN_CODE \
+  --token YOUR_TOKEN
+```
+
+#### Create a token
+```bash
+./go-quay get repotoken create \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --name "CI Token" \
+  --token YOUR_TOKEN
+```
+
+#### Update a token
+```bash
+./go-quay get repotoken update \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --code TOKEN_CODE \
+  --role write \
+  --token YOUR_TOKEN
+```
+
+#### Delete a token
+```bash
+./go-quay get repotoken delete \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --code TOKEN_CODE \
+  --confirm \
+  --token YOUR_TOKEN
 ```

--- a/cmd/discovery.go
+++ b/cmd/discovery.go
@@ -1,0 +1,49 @@
+/*
+Package cmd provides the command-line interface for go-quay.
+
+This file contains the commands for the Discovery API:
+  - go-quay get discovery - Get API discovery information
+*/
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/sebrandon1/go-quay/lib"
+	"github.com/spf13/cobra"
+)
+
+// discoveryCmd represents the discovery command
+var discoveryCmd = &cobra.Command{
+	Use:   "discovery",
+	Short: "Get API discovery information",
+	Long: `Get API discovery information from Quay.io.
+
+This endpoint returns information about available API endpoints and versions.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		discovery, err := client.GetDiscovery()
+		if err != nil {
+			fmt.Println("Error getting discovery:", err)
+			os.Exit(1)
+		}
+
+		output, err := json.MarshalIndent(discovery, "", "  ")
+		if err != nil {
+			fmt.Println("Error marshaling response:", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(output))
+	},
+}
+
+func init() {
+	discoveryCmd.Flags().StringVarP(&token, "token", "t", "", "Quay.io API token")
+}

--- a/cmd/errortype.go
+++ b/cmd/errortype.go
@@ -1,0 +1,59 @@
+/*
+Package cmd provides the command-line interface for go-quay.
+
+This file contains the commands for the Error API:
+  - go-quay get error - Get details about a specific error type
+*/
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/sebrandon1/go-quay/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	errorTypeName string
+)
+
+// errorTypeCmd represents the error command
+var errorTypeCmd = &cobra.Command{
+	Use:   "error",
+	Short: "Get error type information",
+	Long: `Get detailed information about a specific error type.
+
+This endpoint provides details about error types that can be returned by the Quay.io API.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		if errorTypeName == "" {
+			fmt.Println("Error: --type is required")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		errType, err := client.GetErrorType(errorTypeName)
+		if err != nil {
+			fmt.Println("Error getting error type:", err)
+			os.Exit(1)
+		}
+
+		output, err := json.MarshalIndent(errType, "", "  ")
+		if err != nil {
+			fmt.Println("Error marshaling response:", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(output))
+	},
+}
+
+func init() {
+	errorTypeCmd.Flags().StringVarP(&token, "token", "t", "", "Quay.io API token")
+	errorTypeCmd.Flags().StringVar(&errorTypeName, "type", "", "Error type to look up (e.g., 'invalid_token')")
+}

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -1,0 +1,49 @@
+/*
+Package cmd provides the command-line interface for go-quay.
+
+This file contains the commands for the Messages API:
+  - go-quay get messages - Get system messages
+*/
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/sebrandon1/go-quay/lib"
+	"github.com/spf13/cobra"
+)
+
+// messagesCmd represents the messages command
+var messagesCmd = &cobra.Command{
+	Use:   "messages",
+	Short: "Get system messages",
+	Long: `Get system-wide messages for the authenticated user.
+
+This includes maintenance notifications, announcements, and other important messages.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		messages, err := client.GetMessages()
+		if err != nil {
+			fmt.Println("Error getting messages:", err)
+			os.Exit(1)
+		}
+
+		output, err := json.MarshalIndent(messages, "", "  ")
+		if err != nil {
+			fmt.Println("Error marshaling response:", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(output))
+	},
+}
+
+func init() {
+	messagesCmd.Flags().StringVarP(&token, "token", "t", "", "Quay.io API token")
+}

--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -1,0 +1,262 @@
+/*
+Package cmd provides the command-line interface for go-quay.
+
+This file contains the commands for the Prototype API:
+  - go-quay get prototype list     - List all permission prototypes
+  - go-quay get prototype info     - Get a specific prototype
+  - go-quay get prototype create   - Create a new prototype
+  - go-quay get prototype update   - Update a prototype
+  - go-quay get prototype delete   - Delete a prototype
+*/
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/sebrandon1/go-quay/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	prototypeOrg          string
+	prototypeUUID         string
+	prototypeDelegateName string
+	prototypeDelegateKind string
+	prototypeRole         string
+	confirmProtoDelete    bool
+)
+
+// prototypeCmd represents the prototype command
+var prototypeCmd = &cobra.Command{
+	Use:   "prototype",
+	Short: "Manage organization permission prototypes",
+	Long: `Manage default permission prototypes for an organization.
+
+Prototypes define default permissions that are automatically applied to new
+repositories created within an organization. They allow setting up permission
+templates for users, teams, or robot accounts.`,
+}
+
+// prototypeListCmd lists all prototypes
+var prototypeListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all permission prototypes",
+	Long:  `List all permission prototypes for an organization.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		prototypes, err := client.GetPrototypes(prototypeOrg)
+		if err != nil {
+			fmt.Println("Error getting prototypes:", err)
+			os.Exit(1)
+		}
+
+		output, err := json.MarshalIndent(prototypes, "", "  ")
+		if err != nil {
+			fmt.Println("Error marshaling response:", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(output))
+	},
+}
+
+// prototypeInfoCmd gets a specific prototype
+var prototypeInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Get a specific prototype",
+	Long:  `Get detailed information about a specific permission prototype.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		if prototypeUUID == "" {
+			fmt.Println("Error: --uuid is required")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		prototype, err := client.GetPrototype(prototypeOrg, prototypeUUID)
+		if err != nil {
+			fmt.Println("Error getting prototype:", err)
+			os.Exit(1)
+		}
+
+		output, err := json.MarshalIndent(prototype, "", "  ")
+		if err != nil {
+			fmt.Println("Error marshaling response:", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(output))
+	},
+}
+
+// prototypeCreateCmd creates a new prototype
+var prototypeCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new prototype",
+	Long: `Create a new permission prototype for an organization.
+
+Delegate kinds:
+  - user: A specific user account
+  - team: A team within the organization  
+  - robot: A robot account
+
+Roles:
+  - read: Pull images
+  - write: Pull and push images
+  - admin: Full administrative access`,
+	Run: func(_ *cobra.Command, _ []string) {
+		if prototypeDelegateName == "" {
+			fmt.Println("Error: --delegate-name is required")
+			os.Exit(1)
+		}
+		if prototypeDelegateKind == "" {
+			fmt.Println("Error: --delegate-kind is required")
+			os.Exit(1)
+		}
+		if prototypeRole == "" {
+			fmt.Println("Error: --role is required")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		createReq := &lib.CreatePrototypeRequest{
+			Delegate: lib.PrototypeDelegateRequest{
+				Name: prototypeDelegateName,
+				Kind: prototypeDelegateKind,
+			},
+			Role: prototypeRole,
+		}
+
+		prototype, err := client.CreatePrototype(prototypeOrg, createReq)
+		if err != nil {
+			fmt.Println("Error creating prototype:", err)
+			os.Exit(1)
+		}
+
+		output, err := json.MarshalIndent(prototype, "", "  ")
+		if err != nil {
+			fmt.Println("Error marshaling response:", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(output))
+	},
+}
+
+// prototypeUpdateCmd updates a prototype
+var prototypeUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update a prototype",
+	Long:  `Update an existing permission prototype's role.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		if prototypeUUID == "" {
+			fmt.Println("Error: --uuid is required")
+			os.Exit(1)
+		}
+		if prototypeRole == "" {
+			fmt.Println("Error: --role is required")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		updateReq := &lib.UpdatePrototypeRequest{
+			Role: prototypeRole,
+		}
+
+		prototype, err := client.UpdatePrototype(prototypeOrg, prototypeUUID, updateReq)
+		if err != nil {
+			fmt.Println("Error updating prototype:", err)
+			os.Exit(1)
+		}
+
+		output, err := json.MarshalIndent(prototype, "", "  ")
+		if err != nil {
+			fmt.Println("Error marshaling response:", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(output))
+	},
+}
+
+// prototypeDeleteCmd deletes a prototype
+var prototypeDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a prototype",
+	Long:  `Delete a permission prototype from an organization.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		if prototypeUUID == "" {
+			fmt.Println("Error: --uuid is required")
+			os.Exit(1)
+		}
+		if !confirmProtoDelete {
+			fmt.Println("Error: --confirm is required to delete a prototype")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		err = client.DeletePrototype(prototypeOrg, prototypeUUID)
+		if err != nil {
+			fmt.Println("Error deleting prototype:", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Prototype %s deleted successfully\n", prototypeUUID)
+	},
+}
+
+func setupPrototypeFlags() {
+	// Common flags
+	for _, cmd := range []*cobra.Command{prototypeListCmd, prototypeInfoCmd, prototypeCreateCmd, prototypeUpdateCmd, prototypeDeleteCmd} {
+		cmd.Flags().StringVarP(&prototypeOrg, "organization", "o", "", "Organization name")
+		cmd.Flags().StringVarP(&token, "token", "t", "", "Quay.io API token")
+	}
+
+	// UUID flags
+	for _, cmd := range []*cobra.Command{prototypeInfoCmd, prototypeUpdateCmd, prototypeDeleteCmd} {
+		cmd.Flags().StringVar(&prototypeUUID, "uuid", "", "Prototype UUID")
+	}
+
+	// Create flags
+	prototypeCreateCmd.Flags().StringVar(&prototypeDelegateName, "delegate-name", "", "Name of the delegate (user/team/robot)")
+	prototypeCreateCmd.Flags().StringVar(&prototypeDelegateKind, "delegate-kind", "", "Kind of delegate (user, team, robot)")
+	prototypeCreateCmd.Flags().StringVar(&prototypeRole, "role", "", "Permission role (read, write, admin)")
+
+	// Update flags
+	prototypeUpdateCmd.Flags().StringVar(&prototypeRole, "role", "", "New permission role (read, write, admin)")
+
+	// Delete flags
+	prototypeDeleteCmd.Flags().BoolVar(&confirmProtoDelete, "confirm", false, "Confirm deletion")
+}
+
+func init() {
+	prototypeCmd.AddCommand(prototypeListCmd)
+	prototypeCmd.AddCommand(prototypeInfoCmd)
+	prototypeCmd.AddCommand(prototypeCreateCmd)
+	prototypeCmd.AddCommand(prototypeUpdateCmd)
+	prototypeCmd.AddCommand(prototypeDeleteCmd)
+
+	setupPrototypeFlags()
+}

--- a/cmd/repotoken.go
+++ b/cmd/repotoken.go
@@ -1,0 +1,240 @@
+/*
+Package cmd provides the command-line interface for go-quay.
+
+This file contains the commands for the RepoToken API:
+  - go-quay get repotoken list     - List all repository tokens
+  - go-quay get repotoken info     - Get a specific token
+  - go-quay get repotoken create   - Create a new token
+  - go-quay get repotoken update   - Update a token
+  - go-quay get repotoken delete   - Delete a token
+
+WARNING: Repository tokens are deprecated. Use robot accounts instead.
+*/
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/sebrandon1/go-quay/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	repoTokenNamespace  string
+	repoTokenRepository string
+	repoTokenCode       string
+	repoTokenName       string
+	repoTokenRole       string
+	confirmTokenDelete  bool
+)
+
+// repotokenCmd represents the repotoken command
+var repotokenCmd = &cobra.Command{
+	Use:   "repotoken",
+	Short: "Manage repository tokens (DEPRECATED)",
+	Long: `Manage repository tokens for authentication.
+
+WARNING: Repository tokens are deprecated. Use robot accounts instead for
+better security, auditing, and permission management.`,
+}
+
+// repotokenListCmd lists all tokens
+var repotokenListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all repository tokens",
+	Long:  `List all tokens for a repository. (DEPRECATED - use robot accounts)`,
+	Run: func(_ *cobra.Command, _ []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		tokens, err := client.GetRepoTokens(repoTokenNamespace, repoTokenRepository) //nolint:staticcheck // Intentionally using deprecated API
+		if err != nil {
+			fmt.Println("Error getting tokens:", err)
+			os.Exit(1)
+		}
+
+		output, err := json.MarshalIndent(tokens, "", "  ")
+		if err != nil {
+			fmt.Println("Error marshaling response:", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(output))
+	},
+}
+
+// repotokenInfoCmd gets a specific token
+var repotokenInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Get a specific token",
+	Long:  `Get detailed information about a specific repository token. (DEPRECATED - use robot accounts)`,
+	Run: func(_ *cobra.Command, _ []string) {
+		if repoTokenCode == "" {
+			fmt.Println("Error: --code is required")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		repoToken, err := client.GetRepoToken(repoTokenNamespace, repoTokenRepository, repoTokenCode) //nolint:staticcheck // Intentionally using deprecated API
+		if err != nil {
+			fmt.Println("Error getting token:", err)
+			os.Exit(1)
+		}
+
+		output, err := json.MarshalIndent(repoToken, "", "  ")
+		if err != nil {
+			fmt.Println("Error marshaling response:", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(output))
+	},
+}
+
+// repotokenCreateCmd creates a new token
+var repotokenCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new token",
+	Long:  `Create a new repository token. (DEPRECATED - use robot accounts)`,
+	Run: func(_ *cobra.Command, _ []string) {
+		if repoTokenName == "" {
+			fmt.Println("Error: --name is required")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		createReq := &lib.CreateRepoTokenRequest{
+			FriendlyName: repoTokenName,
+		}
+
+		repoToken, err := client.CreateRepoToken(repoTokenNamespace, repoTokenRepository, createReq) //nolint:staticcheck // Intentionally using deprecated API
+		if err != nil {
+			fmt.Println("Error creating token:", err)
+			os.Exit(1)
+		}
+
+		output, err := json.MarshalIndent(repoToken, "", "  ")
+		if err != nil {
+			fmt.Println("Error marshaling response:", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(output))
+	},
+}
+
+// repotokenUpdateCmd updates a token
+var repotokenUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update a token",
+	Long:  `Update a repository token's role. (DEPRECATED - use robot accounts)`,
+	Run: func(_ *cobra.Command, _ []string) {
+		if repoTokenCode == "" {
+			fmt.Println("Error: --code is required")
+			os.Exit(1)
+		}
+		if repoTokenRole == "" {
+			fmt.Println("Error: --role is required")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		updateReq := &lib.UpdateRepoTokenRequest{
+			Role: repoTokenRole,
+		}
+
+		repoToken, err := client.UpdateRepoToken(repoTokenNamespace, repoTokenRepository, repoTokenCode, updateReq) //nolint:staticcheck // Intentionally using deprecated API
+		if err != nil {
+			fmt.Println("Error updating token:", err)
+			os.Exit(1)
+		}
+
+		output, err := json.MarshalIndent(repoToken, "", "  ")
+		if err != nil {
+			fmt.Println("Error marshaling response:", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(output))
+	},
+}
+
+// repotokenDeleteCmd deletes a token
+var repotokenDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a token",
+	Long:  `Delete a repository token. (DEPRECATED - use robot accounts)`,
+	Run: func(_ *cobra.Command, _ []string) {
+		if repoTokenCode == "" {
+			fmt.Println("Error: --code is required")
+			os.Exit(1)
+		}
+		if !confirmTokenDelete {
+			fmt.Println("Error: --confirm is required to delete a token")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		err = client.DeleteRepoToken(repoTokenNamespace, repoTokenRepository, repoTokenCode) //nolint:staticcheck // Intentionally using deprecated API
+		if err != nil {
+			fmt.Println("Error deleting token:", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Token %s deleted successfully\n", repoTokenCode)
+	},
+}
+
+func setupRepoTokenFlags() {
+	// Common flags
+	for _, cmd := range []*cobra.Command{repotokenListCmd, repotokenInfoCmd, repotokenCreateCmd, repotokenUpdateCmd, repotokenDeleteCmd} {
+		cmd.Flags().StringVarP(&repoTokenNamespace, "namespace", "n", "", "Namespace/organization")
+		cmd.Flags().StringVarP(&repoTokenRepository, "repository", "r", "", "Repository name")
+		cmd.Flags().StringVarP(&token, "token", "t", "", "Quay.io API token")
+	}
+
+	// Code flags
+	for _, cmd := range []*cobra.Command{repotokenInfoCmd, repotokenUpdateCmd, repotokenDeleteCmd} {
+		cmd.Flags().StringVar(&repoTokenCode, "code", "", "Token code")
+	}
+
+	// Create flags
+	repotokenCreateCmd.Flags().StringVar(&repoTokenName, "name", "", "Friendly name for the token")
+
+	// Update flags
+	repotokenUpdateCmd.Flags().StringVar(&repoTokenRole, "role", "", "New role (read, write, admin)")
+
+	// Delete flags
+	repotokenDeleteCmd.Flags().BoolVar(&confirmTokenDelete, "confirm", false, "Confirm deletion")
+}
+
+func init() {
+	repotokenCmd.AddCommand(repotokenListCmd)
+	repotokenCmd.AddCommand(repotokenInfoCmd)
+	repotokenCmd.AddCommand(repotokenCreateCmd)
+	repotokenCmd.AddCommand(repotokenUpdateCmd)
+	repotokenCmd.AddCommand(repotokenDeleteCmd)
+
+	setupRepoTokenFlags()
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,11 @@ func init() {
 	getCmd.AddCommand(buildCmd)
 	getCmd.AddCommand(notificationCmd)
 	getCmd.AddCommand(triggerCmd)
+	getCmd.AddCommand(discoveryCmd)
+	getCmd.AddCommand(errorTypeCmd)
+	getCmd.AddCommand(messagesCmd)
+	getCmd.AddCommand(prototypeCmd)
+	getCmd.AddCommand(repotokenCmd)
 }
 
 // Execute executes the root command.

--- a/lib/discovery.go
+++ b/lib/discovery.go
@@ -1,0 +1,30 @@
+/*
+Package lib provides Quay.io API client functionality.
+
+This file covers DISCOVERY operations:
+
+API Discovery:
+  - GET /api/v1/discovery - GetDiscovery()
+
+The Discovery API provides information about available API endpoints and versions.
+*/
+package lib
+
+import (
+	"fmt"
+)
+
+// GetDiscovery retrieves API discovery information
+func (c *Client) GetDiscovery() (*Discovery, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/discovery", QuayURL), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create discovery request: %w", err)
+	}
+
+	var discovery Discovery
+	if err := c.get(req, &discovery); err != nil {
+		return nil, fmt.Errorf("failed to get discovery: %w", err)
+	}
+
+	return &discovery, nil
+}

--- a/lib/discovery_test.go
+++ b/lib/discovery_test.go
@@ -1,0 +1,81 @@
+package lib
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	httpGetDiscovery = "GET"
+)
+
+func TestGetDiscovery(t *testing.T) {
+	mockResponse := Discovery{
+		Version: "v1",
+		APIs: map[string]DiscoveryAPI{
+			"repository": {
+				Path:        "/api/v1/repository",
+				Methods:     []string{"GET", "POST"},
+				Description: "Repository operations",
+			},
+		},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetDiscovery {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/discovery"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	discovery, err := client.GetDiscovery()
+	if err != nil {
+		t.Fatalf("GetDiscovery returned error: %v", err)
+	}
+
+	if discovery.Version != "v1" {
+		t.Errorf("Expected version 'v1', got %s", discovery.Version)
+	}
+	if len(discovery.APIs) != 1 {
+		t.Errorf("Expected 1 API, got %d", len(discovery.APIs))
+	}
+}
+
+func TestGetDiscoveryError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetDiscovery()
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}

--- a/lib/error.go
+++ b/lib/error.go
@@ -1,0 +1,31 @@
+/*
+Package lib provides Quay.io API client functionality.
+
+This file covers ERROR TYPE operations:
+
+Error Information:
+  - GET /api/v1/error/{error_type} - GetErrorType()
+
+The Error API provides detailed information about specific error types
+that can be returned by the Quay.io API.
+*/
+package lib
+
+import (
+	"fmt"
+)
+
+// GetErrorType retrieves details about a specific error type
+func (c *Client) GetErrorType(errorType string) (*ErrorType, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/error/%s", QuayURL, errorType), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create error type request: %w", err)
+	}
+
+	var errType ErrorType
+	if err := c.get(req, &errType); err != nil {
+		return nil, fmt.Errorf("failed to get error type: %w", err)
+	}
+
+	return &errType, nil
+}

--- a/lib/error_test.go
+++ b/lib/error_test.go
@@ -1,0 +1,78 @@
+package lib
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	httpGetError  = "GET"
+	testErrorType = "invalid_token"
+)
+
+func TestGetErrorType(t *testing.T) {
+	mockResponse := ErrorType{
+		Type:        testErrorType,
+		Title:       "Invalid Token",
+		Description: "The provided authentication token is invalid or expired",
+		Status:      401,
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetError {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/error/" + testErrorType
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	errType, err := client.GetErrorType(testErrorType)
+	if err != nil {
+		t.Fatalf("GetErrorType returned error: %v", err)
+	}
+
+	if errType.Type != testErrorType {
+		t.Errorf("Expected type '%s', got %s", testErrorType, errType.Type)
+	}
+	if errType.Status != 401 {
+		t.Errorf("Expected status 401, got %d", errType.Status)
+	}
+}
+
+func TestGetErrorTypeError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetErrorType("nonexistent_error")
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}

--- a/lib/messages.go
+++ b/lib/messages.go
@@ -1,0 +1,31 @@
+/*
+Package lib provides Quay.io API client functionality.
+
+This file covers MESSAGES operations:
+
+System Messages:
+  - GET /api/v1/messages - GetMessages()
+
+The Messages API returns system-wide messages for the authenticated user,
+such as maintenance notifications or important announcements.
+*/
+package lib
+
+import (
+	"fmt"
+)
+
+// GetMessages retrieves system messages for the user
+func (c *Client) GetMessages() (*Messages, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/messages", QuayURL), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create messages request: %w", err)
+	}
+
+	var messages Messages
+	if err := c.get(req, &messages); err != nil {
+		return nil, fmt.Errorf("failed to get messages: %w", err)
+	}
+
+	return &messages, nil
+}

--- a/lib/messages_test.go
+++ b/lib/messages_test.go
@@ -1,0 +1,118 @@
+package lib
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	httpGetMessages = "GET"
+)
+
+func TestGetMessages(t *testing.T) {
+	mockResponse := Messages{
+		Messages: []Message{
+			{
+				UUID:      "msg-uuid-123",
+				Content:   "Scheduled maintenance on Sunday",
+				Severity:  "info",
+				MediaType: "text/plain",
+			},
+			{
+				UUID:      "msg-uuid-456",
+				Content:   "New feature available",
+				Severity:  "info",
+				MediaType: "text/plain",
+			},
+		},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetMessages {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/messages"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	messages, err := client.GetMessages()
+	if err != nil {
+		t.Fatalf("GetMessages returned error: %v", err)
+	}
+
+	if len(messages.Messages) != 2 {
+		t.Errorf("Expected 2 messages, got %d", len(messages.Messages))
+	}
+	if messages.Messages[0].UUID != "msg-uuid-123" {
+		t.Errorf("Expected first message UUID 'msg-uuid-123', got %s", messages.Messages[0].UUID)
+	}
+}
+
+func TestGetMessagesEmpty(t *testing.T) {
+	mockResponse := Messages{
+		Messages: []Message{},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	messages, err := client.GetMessages()
+	if err != nil {
+		t.Fatalf("GetMessages returned error: %v", err)
+	}
+
+	if len(messages.Messages) != 0 {
+		t.Errorf("Expected 0 messages, got %d", len(messages.Messages))
+	}
+}
+
+func TestGetMessagesError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetMessages()
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}

--- a/lib/permissions_test.go
+++ b/lib/permissions_test.go
@@ -11,6 +11,8 @@ const (
 	httpGetPerms    = "GET"
 	httpPutPerms    = "PUT"
 	httpDeletePerms = "DELETE"
+
+	permRoleWrite = "write"
 )
 
 func TestGetRepositoryPermissions(t *testing.T) {
@@ -19,7 +21,7 @@ func TestGetRepositoryPermissions(t *testing.T) {
 			{
 				Name: "john.doe",
 				Kind: "user",
-				Role: "write",
+				Role: permRoleWrite,
 				Avatar: Avatar{
 					Name: "john.doe",
 					Kind: "user",
@@ -80,7 +82,7 @@ func TestGetRepositoryPermissions(t *testing.T) {
 	if userPerm.Name != "john.doe" {
 		t.Errorf("Expected user name 'john.doe', got '%s'", userPerm.Name)
 	}
-	if userPerm.Role != "write" {
+	if userPerm.Role != permRoleWrite {
 		t.Errorf("Expected role 'write', got '%s'", userPerm.Role)
 	}
 	if userPerm.IsRobot != false {
@@ -115,7 +117,7 @@ func TestSetRepositoryPermission(t *testing.T) {
 			t.Errorf("Failed to decode request body: %v", err)
 		}
 
-		if req.Role != "write" {
+		if req.Role != permRoleWrite {
 			t.Errorf("Expected role 'write', got '%s'", req.Role)
 		}
 
@@ -132,7 +134,7 @@ func TestSetRepositoryPermission(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.SetRepositoryPermission("testorg", "testrepo", "john.doe", "write")
+	err = client.SetRepositoryPermission("testorg", "testrepo", "john.doe", permRoleWrite)
 	if err != nil {
 		t.Fatalf("SetRepositoryPermission failed: %v", err)
 	}

--- a/lib/prototype.go
+++ b/lib/prototype.go
@@ -1,0 +1,100 @@
+/*
+Package lib provides Quay.io API client functionality.
+
+This file covers PROTOTYPE (Default Permission) operations:
+
+Prototype Management:
+  - GET    /api/v1/organization/{orgname}/prototypes             - GetPrototypes()
+  - POST   /api/v1/organization/{orgname}/prototypes             - CreatePrototype()
+  - GET    /api/v1/organization/{orgname}/prototypes/{uuid}      - GetPrototype()
+  - PUT    /api/v1/organization/{orgname}/prototypes/{uuid}      - UpdatePrototype()
+  - DELETE /api/v1/organization/{orgname}/prototypes/{uuid}      - DeletePrototype()
+
+Prototypes define default permissions that are automatically applied to new
+repositories created within an organization. They allow setting up permission
+templates for users, teams, or robot accounts.
+
+Delegate kinds:
+  - user: A specific user account
+  - team: A team within the organization
+  - robot: A robot account
+*/
+package lib
+
+import (
+	"fmt"
+)
+
+// GetPrototypes retrieves all permission prototypes for an organization
+func (c *Client) GetPrototypes(orgname string) (*Prototypes, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/prototypes", QuayURL, orgname), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get prototypes request: %w", err)
+	}
+
+	var prototypes Prototypes
+	if err := c.get(req, &prototypes); err != nil {
+		return nil, fmt.Errorf("failed to get prototypes: %w", err)
+	}
+
+	return &prototypes, nil
+}
+
+// CreatePrototype creates a new permission prototype for an organization
+func (c *Client) CreatePrototype(orgname string, createReq *CreatePrototypeRequest) (*Prototype, error) {
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/prototypes", QuayURL, orgname), createReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create prototype request: %w", err)
+	}
+
+	var prototype Prototype
+	if err := c.post(req, &prototype); err != nil {
+		return nil, fmt.Errorf("failed to create prototype: %w", err)
+	}
+
+	return &prototype, nil
+}
+
+// GetPrototype retrieves a specific prototype by UUID
+func (c *Client) GetPrototype(orgname, prototypeUUID string) (*Prototype, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/prototypes/%s", QuayURL, orgname, prototypeUUID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get prototype request: %w", err)
+	}
+
+	var prototype Prototype
+	if err := c.get(req, &prototype); err != nil {
+		return nil, fmt.Errorf("failed to get prototype: %w", err)
+	}
+
+	return &prototype, nil
+}
+
+// UpdatePrototype updates an existing prototype
+func (c *Client) UpdatePrototype(orgname, prototypeUUID string, updateReq *UpdatePrototypeRequest) (*Prototype, error) {
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/prototypes/%s", QuayURL, orgname, prototypeUUID), updateReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create update prototype request: %w", err)
+	}
+
+	var prototype Prototype
+	if err := c.put(req, &prototype); err != nil {
+		return nil, fmt.Errorf("failed to update prototype: %w", err)
+	}
+
+	return &prototype, nil
+}
+
+// DeletePrototype deletes a prototype
+func (c *Client) DeletePrototype(orgname, prototypeUUID string) error {
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/prototypes/%s", QuayURL, orgname, prototypeUUID), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete prototype request: %w", err)
+	}
+
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to delete prototype: %w", err)
+	}
+
+	return nil
+}

--- a/lib/prototype_test.go
+++ b/lib/prototype_test.go
@@ -1,0 +1,248 @@
+package lib
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	httpGetPrototype    = "GET"
+	httpPostPrototype   = "POST"
+	httpPutPrototype    = "PUT"
+	httpDeletePrototype = "DELETE"
+
+	testPrototypeOrg  = "testorg"
+	testPrototypeUUID = "proto-uuid-123"
+	prototypeRoleRead = "read"
+)
+
+func TestGetPrototypes(t *testing.T) {
+	mockResponse := Prototypes{
+		Prototypes: []Prototype{
+			{
+				ID:   testPrototypeUUID,
+				Role: prototypeRoleRead,
+				Delegate: PrototypeDelegate{
+					Name: "devteam",
+					Kind: "team",
+				},
+			},
+		},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetPrototype {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/organization/" + testPrototypeOrg + "/prototypes"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	prototypes, err := client.GetPrototypes(testPrototypeOrg)
+	if err != nil {
+		t.Fatalf("GetPrototypes returned error: %v", err)
+	}
+
+	if len(prototypes.Prototypes) != 1 {
+		t.Errorf("Expected 1 prototype, got %d", len(prototypes.Prototypes))
+	}
+	if prototypes.Prototypes[0].ID != testPrototypeUUID {
+		t.Errorf("Expected prototype ID %s, got %s", testPrototypeUUID, prototypes.Prototypes[0].ID)
+	}
+}
+
+func TestCreatePrototype(t *testing.T) {
+	mockResponse := Prototype{
+		ID:   testPrototypeUUID,
+		Role: prototypeRoleRead,
+		Delegate: PrototypeDelegate{
+			Name: "devteam",
+			Kind: "team",
+		},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpPostPrototype {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	createReq := &CreatePrototypeRequest{
+		Delegate: PrototypeDelegateRequest{
+			Name: "devteam",
+			Kind: "team",
+		},
+		Role: prototypeRoleRead,
+	}
+
+	prototype, err := client.CreatePrototype(testPrototypeOrg, createReq)
+	if err != nil {
+		t.Fatalf("CreatePrototype returned error: %v", err)
+	}
+
+	if prototype.ID != testPrototypeUUID {
+		t.Errorf("Expected prototype ID %s, got %s", testPrototypeUUID, prototype.ID)
+	}
+}
+
+func TestGetPrototype(t *testing.T) {
+	mockResponse := Prototype{
+		ID:   testPrototypeUUID,
+		Role: prototypeRoleRead,
+		Delegate: PrototypeDelegate{
+			Name: "devteam",
+			Kind: "team",
+		},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetPrototype {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/organization/" + testPrototypeOrg + "/prototypes/" + testPrototypeUUID
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	prototype, err := client.GetPrototype(testPrototypeOrg, testPrototypeUUID)
+	if err != nil {
+		t.Fatalf("GetPrototype returned error: %v", err)
+	}
+
+	if prototype.ID != testPrototypeUUID {
+		t.Errorf("Expected prototype ID %s, got %s", testPrototypeUUID, prototype.ID)
+	}
+}
+
+func TestUpdatePrototype(t *testing.T) {
+	mockResponse := Prototype{
+		ID:   testPrototypeUUID,
+		Role: "write",
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpPutPrototype {
+			t.Errorf("Expected PUT request, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	updateReq := &UpdatePrototypeRequest{
+		Role: "write",
+	}
+
+	prototype, err := client.UpdatePrototype(testPrototypeOrg, testPrototypeUUID, updateReq)
+	if err != nil {
+		t.Fatalf("UpdatePrototype returned error: %v", err)
+	}
+
+	if prototype.Role != "write" {
+		t.Errorf("Expected role 'write', got %s", prototype.Role)
+	}
+}
+
+func TestDeletePrototype(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpDeletePrototype {
+			t.Errorf("Expected DELETE request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/organization/" + testPrototypeOrg + "/prototypes/" + testPrototypeUUID
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.DeletePrototype(testPrototypeOrg, testPrototypeUUID)
+	if err != nil {
+		t.Fatalf("DeletePrototype returned error: %v", err)
+	}
+}
+
+func TestGetPrototypesError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetPrototypes(testPrototypeOrg)
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}

--- a/lib/repotoken.go
+++ b/lib/repotoken.go
@@ -1,0 +1,104 @@
+/*
+Package lib provides Quay.io API client functionality.
+
+This file covers REPOTOKEN operations:
+
+Repository Token Management (DEPRECATED - use robot accounts instead):
+  - GET    /api/v1/repository/{namespace}/{repository}/tokens        - GetRepoTokens()
+  - POST   /api/v1/repository/{namespace}/{repository}/tokens        - CreateRepoToken()
+  - GET    /api/v1/repository/{namespace}/{repository}/tokens/{code} - GetRepoToken()
+  - PUT    /api/v1/repository/{namespace}/{repository}/tokens/{code} - UpdateRepoToken()
+  - DELETE /api/v1/repository/{namespace}/{repository}/tokens/{code} - DeleteRepoToken()
+
+WARNING: Repository tokens are deprecated. Use robot accounts for authentication instead.
+Robot accounts provide better security, auditing, and permission management.
+*/
+package lib
+
+import (
+	"fmt"
+)
+
+// GetRepoTokens retrieves all tokens for a repository.
+//
+// Deprecated: Use robot accounts instead.
+func (c *Client) GetRepoTokens(namespace, repository string) (*RepoTokens, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/tokens", QuayURL, namespace, repository), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get repo tokens request: %w", err)
+	}
+
+	var tokens RepoTokens
+	if err := c.get(req, &tokens); err != nil {
+		return nil, fmt.Errorf("failed to get repo tokens: %w", err)
+	}
+
+	return &tokens, nil
+}
+
+// CreateRepoToken creates a new repository token.
+//
+// Deprecated: Use robot accounts instead.
+func (c *Client) CreateRepoToken(namespace, repository string, createReq *CreateRepoTokenRequest) (*RepoToken, error) {
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/tokens", QuayURL, namespace, repository), createReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create repo token request: %w", err)
+	}
+
+	var token RepoToken
+	if err := c.post(req, &token); err != nil {
+		return nil, fmt.Errorf("failed to create repo token: %w", err)
+	}
+
+	return &token, nil
+}
+
+// GetRepoToken retrieves a specific repository token.
+//
+// Deprecated: Use robot accounts instead.
+func (c *Client) GetRepoToken(namespace, repository, code string) (*RepoToken, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/tokens/%s", QuayURL, namespace, repository, code), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get repo token request: %w", err)
+	}
+
+	var token RepoToken
+	if err := c.get(req, &token); err != nil {
+		return nil, fmt.Errorf("failed to get repo token: %w", err)
+	}
+
+	return &token, nil
+}
+
+// UpdateRepoToken updates a repository token.
+//
+// Deprecated: Use robot accounts instead.
+func (c *Client) UpdateRepoToken(namespace, repository, code string, updateReq *UpdateRepoTokenRequest) (*RepoToken, error) {
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/tokens/%s", QuayURL, namespace, repository, code), updateReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create update repo token request: %w", err)
+	}
+
+	var token RepoToken
+	if err := c.put(req, &token); err != nil {
+		return nil, fmt.Errorf("failed to update repo token: %w", err)
+	}
+
+	return &token, nil
+}
+
+// DeleteRepoToken deletes a repository token.
+//
+// Deprecated: Use robot accounts instead.
+func (c *Client) DeleteRepoToken(namespace, repository, code string) error {
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/tokens/%s", QuayURL, namespace, repository, code), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete repo token request: %w", err)
+	}
+
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to delete repo token: %w", err)
+	}
+
+	return nil
+}

--- a/lib/repotoken_test.go
+++ b/lib/repotoken_test.go
@@ -1,0 +1,234 @@
+package lib
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	httpGetRepoToken    = "GET"
+	httpPostRepoToken   = "POST"
+	httpPutRepoToken    = "PUT"
+	httpDeleteRepoToken = "DELETE"
+
+	testTokenNamespace  = "testorg"
+	testTokenRepository = "testrepo"
+	testTokenCode       = "ABCD1234"
+	testTokenRole       = "read"
+)
+
+func TestGetRepoTokens(t *testing.T) {
+	mockResponse := RepoTokens{
+		Tokens: []RepoToken{
+			{Code: testTokenCode, FriendlyName: "CI Token", Role: testTokenRole},
+			{Code: "EFGH5678", FriendlyName: "Deploy Token", Role: "write"},
+		},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetRepoToken {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testTokenNamespace + "/" + testTokenRepository + "/tokens"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	tokens, err := client.GetRepoTokens(testTokenNamespace, testTokenRepository)
+	if err != nil {
+		t.Fatalf("GetRepoTokens returned error: %v", err)
+	}
+
+	if len(tokens.Tokens) != 2 {
+		t.Errorf("Expected 2 tokens, got %d", len(tokens.Tokens))
+	}
+	if tokens.Tokens[0].Code != testTokenCode {
+		t.Errorf("Expected first token code %s, got %s", testTokenCode, tokens.Tokens[0].Code)
+	}
+}
+
+func TestCreateRepoToken(t *testing.T) {
+	mockResponse := RepoToken{
+		Code:         testTokenCode,
+		FriendlyName: "New CI Token",
+		Role:         testTokenRole,
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpPostRepoToken {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	createReq := &CreateRepoTokenRequest{
+		FriendlyName: "New CI Token",
+	}
+
+	token, err := client.CreateRepoToken(testTokenNamespace, testTokenRepository, createReq)
+	if err != nil {
+		t.Fatalf("CreateRepoToken returned error: %v", err)
+	}
+
+	if token.Code != testTokenCode {
+		t.Errorf("Expected token code %s, got %s", testTokenCode, token.Code)
+	}
+}
+
+func TestGetRepoToken(t *testing.T) {
+	mockResponse := RepoToken{
+		Code:         testTokenCode,
+		FriendlyName: "CI Token",
+		Role:         testTokenRole,
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpGetRepoToken {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testTokenNamespace + "/" + testTokenRepository + "/tokens/" + testTokenCode
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	token, err := client.GetRepoToken(testTokenNamespace, testTokenRepository, testTokenCode)
+	if err != nil {
+		t.Fatalf("GetRepoToken returned error: %v", err)
+	}
+
+	if token.Code != testTokenCode {
+		t.Errorf("Expected token code %s, got %s", testTokenCode, token.Code)
+	}
+}
+
+func TestUpdateRepoToken(t *testing.T) {
+	mockResponse := RepoToken{
+		Code:         testTokenCode,
+		FriendlyName: "CI Token",
+		Role:         "write",
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpPutRepoToken {
+			t.Errorf("Expected PUT request, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	updateReq := &UpdateRepoTokenRequest{
+		Role: "write",
+	}
+
+	token, err := client.UpdateRepoToken(testTokenNamespace, testTokenRepository, testTokenCode, updateReq)
+	if err != nil {
+		t.Fatalf("UpdateRepoToken returned error: %v", err)
+	}
+
+	if token.Role != "write" {
+		t.Errorf("Expected role 'write', got %s", token.Role)
+	}
+}
+
+func TestDeleteRepoToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpDeleteRepoToken {
+			t.Errorf("Expected DELETE request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testTokenNamespace + "/" + testTokenRepository + "/tokens/" + testTokenCode
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.DeleteRepoToken(testTokenNamespace, testTokenRepository, testTokenCode)
+	if err != nil {
+		t.Fatalf("DeleteRepoToken returned error: %v", err)
+	}
+}
+
+func TestGetRepoTokensError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetRepoTokens(testTokenNamespace, testTokenRepository)
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -800,3 +800,115 @@ type QuayError struct {
 	Detail      string                 `json:"detail,omitempty"`
 	ErrorDetail map[string]interface{} `json:"error_detail,omitempty"`
 }
+
+// Discovery Structures
+
+// Discovery represents API discovery information
+type Discovery struct {
+	Version   string                  `json:"version,omitempty"`
+	APIs      map[string]DiscoveryAPI `json:"apis,omitempty"`
+	Endpoints map[string]DiscoveryAPI `json:"endpoints,omitempty"`
+	Info      map[string]interface{}  `json:"info,omitempty"`
+	Services  map[string]interface{}  `json:"services,omitempty"`
+	Contact   map[string]string       `json:"contact,omitempty"`
+}
+
+// DiscoveryAPI represents an API endpoint in discovery
+type DiscoveryAPI struct {
+	Path        string   `json:"path,omitempty"`
+	Methods     []string `json:"methods,omitempty"`
+	Description string   `json:"description,omitempty"`
+}
+
+// Error Type Structures
+
+// ErrorType represents details about a specific error type
+type ErrorType struct {
+	Type        string `json:"type,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	Status      int    `json:"status,omitempty"`
+}
+
+// Messages Structures
+
+// Message represents a system message
+type Message struct {
+	UUID      string `json:"uuid,omitempty"`
+	Content   string `json:"content,omitempty"`
+	Severity  string `json:"severity,omitempty"`
+	MediaType string `json:"media_type,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+}
+
+// Messages represents a list of system messages
+type Messages struct {
+	Messages []Message `json:"messages,omitempty"`
+}
+
+// Prototype (Default Permission) Structures
+
+// Prototype represents a default permission prototype
+type Prototype struct {
+	ID             string             `json:"id,omitempty"`
+	Delegate       PrototypeDelegate  `json:"delegate,omitempty"`
+	ActivatingUser *PrototypeDelegate `json:"activating_user,omitempty"`
+	Role           string             `json:"role,omitempty"`
+}
+
+// PrototypeDelegate represents a delegate in a prototype
+type PrototypeDelegate struct {
+	Name    string `json:"name,omitempty"`
+	Kind    string `json:"kind,omitempty"`
+	IsRobot bool   `json:"is_robot,omitempty"`
+	IsOrg   bool   `json:"is_org,omitempty"`
+	Avatar  Avatar `json:"avatar,omitempty"`
+}
+
+// Prototypes represents a list of prototypes
+type Prototypes struct {
+	Prototypes []Prototype `json:"prototypes,omitempty"`
+}
+
+// CreatePrototypeRequest represents a request to create a prototype
+type CreatePrototypeRequest struct {
+	Delegate       PrototypeDelegateRequest  `json:"delegate"`
+	Role           string                    `json:"role"`
+	ActivatingUser *PrototypeDelegateRequest `json:"activating_user,omitempty"`
+}
+
+// PrototypeDelegateRequest represents a delegate in a create/update request
+type PrototypeDelegateRequest struct {
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+}
+
+// UpdatePrototypeRequest represents a request to update a prototype
+type UpdatePrototypeRequest struct {
+	Role string `json:"role,omitempty"`
+}
+
+// RepoToken Structures (Deprecated - use robot accounts instead)
+
+// RepoToken represents a repository token
+type RepoToken struct {
+	Code         string `json:"code,omitempty"`
+	FriendlyName string `json:"friendlyName,omitempty"`
+	Created      string `json:"created,omitempty"`
+	Role         string `json:"role,omitempty"`
+}
+
+// RepoTokens represents a list of repository tokens
+type RepoTokens struct {
+	Tokens []RepoToken `json:"tokens,omitempty"`
+}
+
+// CreateRepoTokenRequest represents a request to create a repo token
+type CreateRepoTokenRequest struct {
+	FriendlyName string `json:"friendlyName"`
+}
+
+// UpdateRepoTokenRequest represents a request to update a repo token
+type UpdateRepoTokenRequest struct {
+	Role string `json:"role,omitempty"`
+}


### PR DESCRIPTION
This pull request adds support for several new Quay.io APIs to the CLI, including Discovery, Error, Messages, Prototype, and RepoToken APIs. It updates the documentation to reflect these new endpoints and provides usage examples for each. The implementation includes new command files for each API, enabling users to interact with these endpoints directly from the command line.

**New API command support:**

* Added `discovery` command to retrieve API discovery information (`cmd/discovery.go`).
* Added `error` command to get details about specific error types (`cmd/errortype.go`).
* Added `messages` command to fetch system-wide messages for the authenticated user (`cmd/messages.go`).
* Added comprehensive `prototype` commands for listing, retrieving, creating, updating, and deleting organization permission prototypes (`cmd/prototype.go`).

**Documentation updates:**

* Updated `README.md` to mark Discovery, Error, Messages, Prototype, and RepoToken APIs as supported, and added detailed usage instructions and examples for each new command. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17-R27) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R918-R1065)