### PR TITLE
Add CLAUDE.md for Claude Code guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A comprehensive Go wrapper around Quay.io APIs. Provides both a CLI and a library for interacting with Quay container registries.
+
+## Common Commands
+
+### Build
+```bash
+make build
+```
+
+### Run
+```bash
+./go-quay [command]
+```
+
+### Test
+```bash
+go test ./...
+make test
+```
+
+### Lint
+```bash
+make lint
+```
+
+## Architecture
+
+- **`cmd/`** - CLI command implementations using Cobra
+- **`lib/`** - Quay API client library with full API coverage
+- **`scripts/`** - Helper scripts
+- **`main.go`** - Application entry point
+
+## API Coverage
+
+| API | Commands |
+|-----|----------|
+| Billing | user/plan, organization plans, invoices |
+| Build | repository builds, logs |
+| Discovery | API discovery endpoint |
+| Manifest | manifest info, labels |
+| Organization | org details, members, teams, robots, quota |
+| Permission | repository permissions |
+| Repository | CRUD operations, tags |
+| Robot | user robots, permissions |
+| Search | repository search |
+| SecScan | security scanning results |
+
+## Configuration
+
+Set your Quay.io API token:
+```bash
+export QUAY_API_TOKEN="your-token"
+```
+
+## Requirements
+
+- Go 1.21+
+- Quay.io API token with appropriate permissions
+
+## Code Style
+
+- Follow standard Go conventions
+- Use `go fmt` before committing
+- Run `golangci-lint` for linting (config in `.golangci.yml`)


### PR DESCRIPTION
## Summary
- Adds CLAUDE.md file to provide guidance for Claude Code AI assistant
- Documents build commands, architecture, API coverage, and configuration

## Test plan
- [x] File created and follows project conventions
- [ ] Review content for accuracy

## Related PRs
This is part of a batch update adding CLAUDE.md to all public repositories:

| Repository | PR |
|------------|-----|
| compliance-scripts | https://github.com/sebrandon1/compliance-scripts/pull/45 ✅ |
| OpenStack_Shortcuts | https://github.com/sebrandon1/OpenStack_Shortcuts/pull/1 |
| testapp | https://github.com/sebrandon1/testapp/pull/1 |
| yaml-to-readme | https://github.com/sebrandon1/yaml-to-readme/pull/70 |
| ztp-scripts | https://github.com/sebrandon1/ztp-scripts/pull/1 |
| mirrorbot | https://github.com/sebrandon1/mirrorbot/pull/17 |
| go-dci | https://github.com/sebrandon1/go-dci/pull/82 |
| ocp-doc-checker | https://github.com/sebrandon1/ocp-doc-checker/pull/38 |
| jiracrawler | https://github.com/sebrandon1/jiracrawler/pull/36 |
| go-quay | https://github.com/sebrandon1/go-quay/pull/67 |
| CryptoPrices | https://github.com/sebrandon1/CryptoPrices/pull/1 |
| cert-manager-scripts | https://github.com/sebrandon1/cert-manager-scripts/pull/10 |
| grab | https://github.com/sebrandon1/grab/pull/25 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)