### PR TITLE
Replace panic() with proper error handling and add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,113 @@
+# Contributing to go-quay
+
+Thank you for your interest in contributing to go-quay! This document provides guidelines and information for contributors.
+
+## Getting Started
+
+### Prerequisites
+
+- Go 1.21 or later
+- Valid Quay.io API token (for integration testing)
+- golangci-lint (for linting)
+
+### Setup
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/sebrandon1/go-quay.git
+   cd go-quay
+   ```
+
+2. Install dependencies:
+   ```bash
+   go mod download
+   ```
+
+3. Build the project:
+   ```bash
+   make build
+   ```
+
+## Development Workflow
+
+### Running Tests
+
+```bash
+make test
+```
+
+### Running Linter
+
+```bash
+make lint
+```
+
+### Building
+
+```bash
+make build
+```
+
+## Code Style
+
+- Follow standard Go conventions
+- Run `go fmt` before committing
+- Ensure `golangci-lint` passes with no issues
+- Add tests for new functionality
+
+## Pull Request Process
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/my-feature`)
+3. Make your changes
+4. Run tests and linting:
+   ```bash
+   make test
+   make lint
+   ```
+5. Commit your changes with a descriptive commit message
+6. Push to your fork
+7. Open a Pull Request against the `main` branch
+
+### PR Requirements
+
+- All tests must pass
+- Linting must pass with no issues
+- Include tests for new functionality
+- Update documentation if adding new features or CLI commands
+
+## Adding New Quay API Endpoints
+
+When adding support for a new Quay API endpoint:
+
+1. Add data structures to `lib/structs.go`
+2. Add the client method to `lib/client.go`
+3. Add tests to `lib/client_test.go`
+4. Add CLI command to appropriate file in `cmd/`
+5. Add CLI tests if applicable
+6. Update the README.md with usage documentation
+7. Update the API coverage table in README.md
+
+## Project Structure
+
+```
+go-quay/
+├── cmd/           # CLI command implementations
+│   ├── root.go    # Root command and subcommand registration
+│   ├── billing.go # Billing API commands
+│   ├── build.go   # Build API commands
+│   ├── manifest.go# Manifest API commands
+│   ├── organization.go # Organization API commands
+│   ├── repository.go   # Repository API commands
+│   └── ...        # Other API command files
+├── lib/           # Quay API client library
+│   ├── client.go  # HTTP client and API methods
+│   └── structs.go # Data structures
+├── scripts/       # Helper scripts
+├── main.go        # Application entry point
+└── Makefile       # Build and development commands
+```
+
+## Questions?
+
+If you have questions, please open an issue on GitHub.

--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -27,17 +28,20 @@ var orgBillingCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := lib.NewClient(billingToken)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error creating client:", err)
+			return
 		}
 
 		billing, err := client.GetOrganizationBilling(billingOrgName)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error getting organization billing:", err)
+			return
 		}
 
 		jsonOutput, err := json.Marshal(billing)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error marshaling JSON:", err)
+			return
 		}
 
 		fmt.Println(string(jsonOutput))
@@ -51,17 +55,20 @@ var userBillingCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := lib.NewClient(billingToken)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error creating client:", err)
+			return
 		}
 
 		billing, err := client.GetUserBilling()
 		if err != nil {
-			panic(err)
+			fmt.Println("Error getting user billing:", err)
+			return
 		}
 
 		jsonOutput, err := json.Marshal(billing)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error marshaling JSON:", err)
+			return
 		}
 
 		fmt.Println(string(jsonOutput))
@@ -75,17 +82,20 @@ var orgSubscriptionCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := lib.NewClient(billingToken)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error creating client:", err)
+			return
 		}
 
 		subscription, err := client.GetOrganizationSubscription(billingOrgName)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error getting organization subscription:", err)
+			return
 		}
 
 		jsonOutput, err := json.Marshal(subscription)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error marshaling JSON:", err)
+			return
 		}
 
 		fmt.Println(string(jsonOutput))
@@ -99,17 +109,20 @@ var userSubscriptionCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := lib.NewClient(billingToken)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error creating client:", err)
+			return
 		}
 
 		subscription, err := client.GetUserSubscription()
 		if err != nil {
-			panic(err)
+			fmt.Println("Error getting user subscription:", err)
+			return
 		}
 
 		jsonOutput, err := json.Marshal(subscription)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error marshaling JSON:", err)
+			return
 		}
 
 		fmt.Println(string(jsonOutput))
@@ -123,17 +136,20 @@ var orgInvoicesCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := lib.NewClient(billingToken)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error creating client:", err)
+			return
 		}
 
 		invoices, err := client.GetOrganizationInvoices(billingOrgName)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error getting organization invoices:", err)
+			return
 		}
 
 		jsonOutput, err := json.Marshal(invoices)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error marshaling JSON:", err)
+			return
 		}
 
 		fmt.Println(string(jsonOutput))
@@ -157,17 +173,20 @@ var plansCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := lib.NewClient(billingToken)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error creating client:", err)
+			return
 		}
 
 		plans, err := client.GetAvailablePlans()
 		if err != nil {
-			panic(err)
+			fmt.Println("Error getting available plans:", err)
+			return
 		}
 
 		jsonOutput, err := json.Marshal(plans)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error marshaling JSON:", err)
+			return
 		}
 
 		fmt.Println(string(jsonOutput))
@@ -179,49 +198,59 @@ func init() {
 	orgBillingCmd.PersistentFlags().StringVarP(&billingOrgName, "organization", "o", "", "Organization name")
 	orgBillingCmd.PersistentFlags().StringVarP(&billingToken, "token", "t", "", "Bearer token")
 	if err := orgBillingCmd.MarkPersistentFlagRequired("organization"); err != nil {
-		panic(err)
+		fmt.Printf("Error marking organization flag required: %v\n", err)
+		os.Exit(1)
 	}
 	if err := orgBillingCmd.MarkPersistentFlagRequired("token"); err != nil {
-		panic(err)
+		fmt.Printf("Error marking token flag required: %v\n", err)
+		os.Exit(1)
 	}
 
 	orgSubscriptionCmd.PersistentFlags().StringVarP(&billingOrgName, "organization", "o", "", "Organization name")
 	orgSubscriptionCmd.PersistentFlags().StringVarP(&billingToken, "token", "t", "", "Bearer token")
 	if err := orgSubscriptionCmd.MarkPersistentFlagRequired("organization"); err != nil {
-		panic(err)
+		fmt.Printf("Error marking organization flag required: %v\n", err)
+		os.Exit(1)
 	}
 	if err := orgSubscriptionCmd.MarkPersistentFlagRequired("token"); err != nil {
-		panic(err)
+		fmt.Printf("Error marking token flag required: %v\n", err)
+		os.Exit(1)
 	}
 
 	orgInvoicesCmd.PersistentFlags().StringVarP(&billingOrgName, "organization", "o", "", "Organization name")
 	orgInvoicesCmd.PersistentFlags().StringVarP(&billingToken, "token", "t", "", "Bearer token")
 	if err := orgInvoicesCmd.MarkPersistentFlagRequired("organization"); err != nil {
-		panic(err)
+		fmt.Printf("Error marking organization flag required: %v\n", err)
+		os.Exit(1)
 	}
 	if err := orgInvoicesCmd.MarkPersistentFlagRequired("token"); err != nil {
-		panic(err)
+		fmt.Printf("Error marking token flag required: %v\n", err)
+		os.Exit(1)
 	}
 
 	// Add persistent flags for user commands
 	userBillingCmd.PersistentFlags().StringVarP(&billingToken, "token", "t", "", "Bearer token")
 	if err := userBillingCmd.MarkPersistentFlagRequired("token"); err != nil {
-		panic(err)
+		fmt.Printf("Error marking token flag required: %v\n", err)
+		os.Exit(1)
 	}
 
 	userSubscriptionCmd.PersistentFlags().StringVarP(&billingToken, "token", "t", "", "Bearer token")
 	if err := userSubscriptionCmd.MarkPersistentFlagRequired("token"); err != nil {
-		panic(err)
+		fmt.Printf("Error marking token flag required: %v\n", err)
+		os.Exit(1)
 	}
 
 	userInvoicesCmd.PersistentFlags().StringVarP(&billingToken, "token", "t", "", "Bearer token")
 	if err := userInvoicesCmd.MarkPersistentFlagRequired("token"); err != nil {
-		panic(err)
+		fmt.Printf("Error marking token flag required: %v\n", err)
+		os.Exit(1)
 	}
 
 	plansCmd.PersistentFlags().StringVarP(&billingToken, "token", "t", "", "Bearer token")
 	if err := plansCmd.MarkPersistentFlagRequired("token"); err != nil {
-		panic(err)
+		fmt.Printf("Error marking token flag required: %v\n", err)
+		os.Exit(1)
 	}
 
 	// Add subcommands to the billing command

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -30,17 +30,20 @@ var aggregatedLogsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := lib.NewClient(token)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error creating client:", err)
+			return
 		}
 
 		logs, err := client.GetAggregatedLogs(namespace, repository, startdate, enddate)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error getting aggregated logs:", err)
+			return
 		}
 
 		jsonOutput, err := json.Marshal(logs)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error marshaling JSON:", err)
+			return
 		}
 
 		fmt.Println(string(jsonOutput))

--- a/lib/client.go
+++ b/lib/client.go
@@ -173,20 +173,15 @@ func newRequest(method, url string, body io.Reader) (*http.Request, error) {
 	return http.NewRequest(method, url, body)
 }
 
-// mustMarshal marshals a value to JSON and panics on error
-func mustMarshal(v interface{}) []byte {
-	data, err := json.Marshal(v)
-	if err != nil {
-		panic(fmt.Sprintf("failed to marshal JSON: %v", err))
-	}
-	return data
-}
-
 // newRequestWithBody creates a new HTTP request with JSON body
 func newRequestWithBody(method, url string, body interface{}) (*http.Request, error) {
 	var bodyReader io.Reader
 	if body != nil {
-		bodyReader = bytes.NewReader(mustMarshal(body))
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal JSON: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
 	}
 	return http.NewRequest(method, url, bodyReader)
 }


### PR DESCRIPTION
## Summary
- Replace all `panic()` calls with proper error handling (fmt.Println + return)
- Add CONTRIBUTING.md with contribution guidelines
- Keep go-quay in sync with go-dci repository patterns

## Changes
- **cmd/billing.go**: Replace 25+ panic() calls with graceful error messages
- **cmd/logs.go**: Replace 3 panic() calls with graceful error messages
- **lib/client.go**: Replace mustMarshal panic() with proper error return in newRequestWithBody()
- **CONTRIBUTING.md**: New file with contribution guidelines

## Test plan
- [x] Run `go test ./...` - all tests pass
- [x] Run `make lint` - 0 issues
- [x] Build with `make build` - verifies compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)