### PR TITLE
feat: expose all remaining lib functions via CLI commands

### DIFF
--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -161,8 +161,19 @@ var userInvoicesCmd = &cobra.Command{
 	Use:   "user-invoices",
 	Short: "Get invoices for the current user",
 	Run: func(cmd *cobra.Command, args []string) {
-		// User invoices endpoint doesn't exist in Quay API - return empty array to match expected format
-		fmt.Println("[]")
+		client, err := lib.NewClient(billingToken)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		invoices, err := client.GetUserInvoices()
+		if err != nil {
+			fmt.Printf("Error getting user invoices: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(invoices)
 	},
 }
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -166,6 +166,28 @@ var buildCancelCmd = &cobra.Command{
 	},
 }
 
+var buildStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Get build status",
+	Long:  `Get the current status of a specific build.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		status, err := client.GetBuildStatus(buildNamespace, buildRepository, buildUUID)
+		if err != nil {
+			fmt.Printf("Error getting build status: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Status for build %s:\n", buildUUID)
+		printJSON(status)
+	},
+}
+
 func init() {
 	// Add subcommands to build command
 	buildCmd.AddCommand(buildListCmd)
@@ -173,19 +195,26 @@ func init() {
 	buildCmd.AddCommand(buildLogsCmd)
 	buildCmd.AddCommand(buildRequestCmd)
 	buildCmd.AddCommand(buildCancelCmd)
+	buildCmd.AddCommand(buildStatusCmd)
 
 	// Global build flags
 	buildCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
 	buildCmd.PersistentFlags().StringVarP(&buildNamespace, "namespace", "n", "", "Repository namespace")
 	buildCmd.PersistentFlags().StringVarP(&buildRepository, "repository", "r", "", "Repository name")
-	markBuildFlagRequired(buildCmd.MarkPersistentFlagRequired("token"))
-	markBuildFlagRequired(buildCmd.MarkPersistentFlagRequired("namespace"))
-	markBuildFlagRequired(buildCmd.MarkPersistentFlagRequired("repository"))
+	markFlagRequired(buildCmd.MarkPersistentFlagRequired("token"))
+	markFlagRequired(buildCmd.MarkPersistentFlagRequired("namespace"))
+	markFlagRequired(buildCmd.MarkPersistentFlagRequired("repository"))
 
 	initBuildListFlags()
 	initBuildInfoFlags()
 	initBuildRequestFlags()
 	initBuildCancelFlags()
+	initBuildStatusFlags()
+}
+
+func initBuildStatusFlags() {
+	buildStatusCmd.Flags().StringVarP(&buildUUID, "uuid", "u", "", "Build UUID")
+	markFlagRequired(buildStatusCmd.MarkFlagRequired("uuid"))
 }
 
 func initBuildListFlags() {
@@ -194,7 +223,7 @@ func initBuildListFlags() {
 
 func initBuildInfoFlags() {
 	buildInfoCmd.Flags().StringVarP(&buildUUID, "uuid", "u", "", "Build UUID")
-	markBuildFlagRequired(buildInfoCmd.MarkFlagRequired("uuid"))
+	markFlagRequired(buildInfoCmd.MarkFlagRequired("uuid"))
 }
 
 func initBuildRequestFlags() {
@@ -202,18 +231,11 @@ func initBuildRequestFlags() {
 	buildRequestCmd.Flags().StringVarP(&buildDockerfile, "dockerfile", "d", "", "Path to Dockerfile within archive")
 	buildRequestCmd.Flags().StringVarP(&buildSubdirectory, "subdirectory", "s", "", "Subdirectory containing build context")
 	buildRequestCmd.Flags().StringSliceVar(&buildTags, "tag", []string{"latest"}, "Tags for the built image")
-	markBuildFlagRequired(buildRequestCmd.MarkFlagRequired("archive-url"))
+	markFlagRequired(buildRequestCmd.MarkFlagRequired("archive-url"))
 }
 
 func initBuildCancelFlags() {
 	buildCancelCmd.Flags().StringVarP(&buildUUID, "uuid", "u", "", "Build UUID")
 	buildCancelCmd.Flags().BoolVar(&confirmBuildCancel, "confirm", false, "Confirm build cancellation")
-	markBuildFlagRequired(buildCancelCmd.MarkFlagRequired("uuid"))
-}
-
-func markBuildFlagRequired(err error) {
-	if err != nil {
-		fmt.Printf("Error marking flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	markFlagRequired(buildCancelCmd.MarkFlagRequired("uuid"))
 }

--- a/cmd/discovery.go
+++ b/cmd/discovery.go
@@ -1,13 +1,6 @@
-/*
-Package cmd provides the command-line interface for go-quay.
-
-This file contains the commands for the Discovery API:
-  - go-quay get discovery - Get API discovery information
-*/
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -15,35 +8,99 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// discoveryCmd represents the discovery command
+var (
+	discoveryClientID string
+	entityPrefix      string
+	includeOrgs       bool
+	includeTeams      bool
+)
+
 var discoveryCmd = &cobra.Command{
 	Use:   "discovery",
-	Short: "Get API discovery information",
-	Long: `Get API discovery information from Quay.io.
+	Short: "API discovery and entity lookup commands",
+}
 
-This endpoint returns information about available API endpoints and versions.`,
+var discoveryAPICmd = &cobra.Command{
+	Use:   "api",
+	Short: "Get API discovery information",
+	Long:  `Get API discovery information from Quay.io including available endpoints and versions.`,
 	Run: func(_ *cobra.Command, _ []string) {
 		client, err := lib.NewClient(token)
 		if err != nil {
-			fmt.Println("Error creating client:", err)
+			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
 		}
 
 		discovery, err := client.GetDiscovery()
 		if err != nil {
-			fmt.Println("Error getting discovery:", err)
+			fmt.Printf("Error getting discovery: %v\n", err)
 			os.Exit(1)
 		}
 
-		output, err := json.MarshalIndent(discovery, "", "  ")
+		printJSON(discovery)
+	},
+}
+
+var discoveryAppInfoCmd = &cobra.Command{
+	Use:   "app-info",
+	Short: "Get application information by client ID",
+	Long:  `Get detailed information about an OAuth application by its client ID.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		client, err := lib.NewClient(token)
 		if err != nil {
-			fmt.Println("Error marshaling response:", err)
+			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
 		}
-		fmt.Println(string(output))
+
+		app, err := client.GetAppInfo(discoveryClientID)
+		if err != nil {
+			fmt.Printf("Error getting app info: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(app)
+	},
+}
+
+var discoveryEntitiesCmd = &cobra.Command{
+	Use:   "entities",
+	Short: "Search for entities by prefix",
+	Long:  `Search for users, organizations, and teams by name prefix.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		entities, err := client.GetEntities(entityPrefix, includeOrgs, includeTeams)
+		if err != nil {
+			fmt.Printf("Error getting entities: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(entities)
 	},
 }
 
 func init() {
-	discoveryCmd.Flags().StringVarP(&token, "token", "t", "", "Quay.io API token")
+	discoveryCmd.AddCommand(discoveryAPICmd)
+	discoveryCmd.AddCommand(discoveryAppInfoCmd)
+	discoveryCmd.AddCommand(discoveryEntitiesCmd)
+
+	discoveryCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Quay.io API token")
+
+	discoveryAppInfoCmd.Flags().StringVar(&discoveryClientID, "client-id", "", "OAuth application client ID")
+	if err := discoveryAppInfoCmd.MarkFlagRequired("client-id"); err != nil {
+		fmt.Printf("Error marking client-id flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	discoveryEntitiesCmd.Flags().StringVar(&entityPrefix, "prefix", "", "Entity name prefix to search")
+	discoveryEntitiesCmd.Flags().BoolVar(&includeOrgs, "include-orgs", false, "Include organizations in results")
+	discoveryEntitiesCmd.Flags().BoolVar(&includeTeams, "include-teams", false, "Include teams in results")
+	if err := discoveryEntitiesCmd.MarkFlagRequired("prefix"); err != nil {
+		fmt.Printf("Error marking prefix flag as required: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -1,0 +1,13 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+)
+
+func markFlagRequired(err error) {
+	if err != nil {
+		fmt.Printf("Error marking flag as required: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -3,26 +3,24 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
 )
 
 var (
-	namespace  string
-	repository string
-	startdate  string
-	enddate    string
-	token      string
+	namespace     string
+	repository    string
+	startdate     string
+	enddate       string
+	token         string
+	nextPage      string
+	starttime     string
+	endtime       string
+	callbackURL   string
+	callbackEmail string
 )
-
-func init() {
-	aggregatedLogsCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
-	aggregatedLogsCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
-	aggregatedLogsCmd.PersistentFlags().StringVarP(&startdate, "startdate", "s", "", "Start date for the logs")
-	aggregatedLogsCmd.PersistentFlags().StringVarP(&enddate, "enddate", "e", "", "End date for the logs")
-	aggregatedLogsCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
-}
 
 var aggregatedLogsCmd = &cobra.Command{
 	Use:   "aggregatedlogs",
@@ -48,4 +46,256 @@ var aggregatedLogsCmd = &cobra.Command{
 
 		fmt.Println(string(jsonOutput))
 	},
+}
+
+func init() {
+	aggregatedLogsCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
+	aggregatedLogsCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
+	aggregatedLogsCmd.PersistentFlags().StringVarP(&startdate, "startdate", "s", "", "Start date for the logs")
+	aggregatedLogsCmd.PersistentFlags().StringVarP(&enddate, "enddate", "e", "", "End date for the logs")
+	aggregatedLogsCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
+}
+
+// logsCmd is the parent command group for log management
+var logsCmd = &cobra.Command{
+	Use:   "logs",
+	Short: "Log management commands",
+}
+
+var repoLogsCmd = &cobra.Command{
+	Use:   "repo-logs",
+	Short: "Get repository logs",
+	Long:  `Get action logs for a specific repository.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		logs, err := client.GetLogs(namespace, repository, nextPage)
+		if err != nil {
+			fmt.Printf("Error getting repository logs: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(logs)
+	},
+}
+
+var orgLogsCmd = &cobra.Command{
+	Use:   "org-logs",
+	Short: "Get organization logs",
+	Long:  `Get action logs for an organization.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		logs, err := client.GetOrganizationLogs(orgName, nextPage)
+		if err != nil {
+			fmt.Printf("Error getting organization logs: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(logs)
+	},
+}
+
+var orgAggregatedLogsCmd = &cobra.Command{
+	Use:   "org-aggregated-logs",
+	Short: "Get aggregated organization logs",
+	Long:  `Get aggregated action logs for an organization.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		logs, err := client.GetOrganizationAggregatedLogs(orgName, startdate, enddate)
+		if err != nil {
+			fmt.Printf("Error getting organization aggregated logs: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(logs)
+	},
+}
+
+var userLogsCmd = &cobra.Command{
+	Use:   "user-logs",
+	Short: "Get user logs",
+	Long:  `Get action logs for the current user.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		logs, err := client.GetUserLogs(nextPage)
+		if err != nil {
+			fmt.Printf("Error getting user logs: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(logs)
+	},
+}
+
+var userAggregatedLogsCmd = &cobra.Command{
+	Use:   "user-aggregated-logs",
+	Short: "Get aggregated user logs",
+	Long:  `Get aggregated action logs for the current user.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		logs, err := client.GetUserAggregatedLogs(startdate, enddate)
+		if err != nil {
+			fmt.Printf("Error getting user aggregated logs: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(logs)
+	},
+}
+
+var exportOrgLogsCmd = &cobra.Command{
+	Use:   "export-org-logs",
+	Short: "Export organization logs",
+	Long:  `Export action logs for an organization via callback URL or email.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.ExportOrganizationLogs(orgName, &lib.ExportLogsRequest{
+			StartTime:   starttime,
+			EndTime:     endtime,
+			CallbackURL: callbackURL,
+			Email:       callbackEmail,
+		})
+		if err != nil {
+			fmt.Printf("Error exporting organization logs: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("Organization logs export initiated successfully.")
+	},
+}
+
+var exportUserLogsCmd = &cobra.Command{
+	Use:   "export-user-logs",
+	Short: "Export user logs",
+	Long:  `Export action logs for the current user via callback URL or email.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.ExportUserLogs(&lib.ExportLogsRequest{
+			StartTime:   starttime,
+			EndTime:     endtime,
+			CallbackURL: callbackURL,
+			Email:       callbackEmail,
+		})
+		if err != nil {
+			fmt.Printf("Error exporting user logs: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("User logs export initiated successfully.")
+	},
+}
+
+var exportRepoLogsCmd = &cobra.Command{
+	Use:   "export-repo-logs",
+	Short: "Export repository logs",
+	Long:  `Export action logs for a repository via callback URL or email.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.ExportRepositoryLogs(namespace, repository, &lib.ExportLogsRequest{
+			StartTime:   starttime,
+			EndTime:     endtime,
+			CallbackURL: callbackURL,
+			Email:       callbackEmail,
+		})
+		if err != nil {
+			fmt.Printf("Error exporting repository logs: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("Repository logs export initiated successfully.")
+	},
+}
+
+func init() {
+	logsCmd.AddCommand(repoLogsCmd)
+	logsCmd.AddCommand(orgLogsCmd)
+	logsCmd.AddCommand(orgAggregatedLogsCmd)
+	logsCmd.AddCommand(userLogsCmd)
+	logsCmd.AddCommand(userAggregatedLogsCmd)
+	logsCmd.AddCommand(exportOrgLogsCmd)
+	logsCmd.AddCommand(exportUserLogsCmd)
+	logsCmd.AddCommand(exportRepoLogsCmd)
+
+	logsCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
+
+	// repo-logs flags
+	repoLogsCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Repository namespace")
+	repoLogsCmd.Flags().StringVarP(&repository, "repository", "r", "", "Repository name")
+	repoLogsCmd.Flags().StringVar(&nextPage, "next-page", "", "Next page token for pagination")
+
+	// org-logs flags
+	orgLogsCmd.Flags().StringVarP(&orgName, "organization", "o", "", "Organization name")
+	orgLogsCmd.Flags().StringVar(&nextPage, "next-page", "", "Next page token for pagination")
+
+	// org-aggregated-logs flags
+	orgAggregatedLogsCmd.Flags().StringVarP(&orgName, "organization", "o", "", "Organization name")
+	orgAggregatedLogsCmd.Flags().StringVarP(&startdate, "startdate", "s", "", "Start date")
+	orgAggregatedLogsCmd.Flags().StringVarP(&enddate, "enddate", "e", "", "End date")
+
+	// user-logs flags
+	userLogsCmd.Flags().StringVar(&nextPage, "next-page", "", "Next page token for pagination")
+
+	// user-aggregated-logs flags
+	userAggregatedLogsCmd.Flags().StringVarP(&startdate, "startdate", "s", "", "Start date")
+	userAggregatedLogsCmd.Flags().StringVarP(&enddate, "enddate", "e", "", "End date")
+
+	// export-org-logs flags
+	exportOrgLogsCmd.Flags().StringVarP(&orgName, "organization", "o", "", "Organization name")
+	exportOrgLogsCmd.Flags().StringVar(&starttime, "start-time", "", "Start time for export")
+	exportOrgLogsCmd.Flags().StringVar(&endtime, "end-time", "", "End time for export")
+	exportOrgLogsCmd.Flags().StringVar(&callbackURL, "callback-url", "", "Callback URL for export results")
+	exportOrgLogsCmd.Flags().StringVar(&callbackEmail, "callback-email", "", "Email for export results")
+
+	// export-user-logs flags
+	exportUserLogsCmd.Flags().StringVar(&starttime, "start-time", "", "Start time for export")
+	exportUserLogsCmd.Flags().StringVar(&endtime, "end-time", "", "End time for export")
+	exportUserLogsCmd.Flags().StringVar(&callbackURL, "callback-url", "", "Callback URL for export results")
+	exportUserLogsCmd.Flags().StringVar(&callbackEmail, "callback-email", "", "Email for export results")
+
+	// export-repo-logs flags
+	exportRepoLogsCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Repository namespace")
+	exportRepoLogsCmd.Flags().StringVarP(&repository, "repository", "r", "", "Repository name")
+	exportRepoLogsCmd.Flags().StringVar(&starttime, "start-time", "", "Start time for export")
+	exportRepoLogsCmd.Flags().StringVar(&endtime, "end-time", "", "End time for export")
+	exportRepoLogsCmd.Flags().StringVar(&callbackURL, "callback-url", "", "Callback URL for export results")
+	exportRepoLogsCmd.Flags().StringVar(&callbackEmail, "callback-email", "", "Email for export results")
 }

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -1,13 +1,6 @@
-/*
-Package cmd provides the command-line interface for go-quay.
-
-This file contains the commands for the Messages API:
-  - go-quay get messages - Get system messages
-*/
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -15,35 +8,75 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// messagesCmd represents the messages command
+var (
+	messageContent   string
+	messageSeverity  string
+	messageMediaType string
+)
+
 var messagesCmd = &cobra.Command{
 	Use:   "messages",
-	Short: "Get system messages",
-	Long: `Get system-wide messages for the authenticated user.
+	Short: "System message management commands",
+}
 
-This includes maintenance notifications, announcements, and other important messages.`,
+var messagesListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Get system messages",
+	Long:  `Get system-wide messages including maintenance notifications and announcements.`,
 	Run: func(_ *cobra.Command, _ []string) {
 		client, err := lib.NewClient(token)
 		if err != nil {
-			fmt.Println("Error creating client:", err)
+			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
 		}
 
 		messages, err := client.GetMessages()
 		if err != nil {
-			fmt.Println("Error getting messages:", err)
+			fmt.Printf("Error getting messages: %v\n", err)
 			os.Exit(1)
 		}
 
-		output, err := json.MarshalIndent(messages, "", "  ")
+		printJSON(messages)
+	},
+}
+
+var messagesCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a system message",
+	Long:  `Create a new system-wide message.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		client, err := lib.NewClient(token)
 		if err != nil {
-			fmt.Println("Error marshaling response:", err)
+			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
 		}
-		fmt.Println(string(output))
+
+		message, err := client.CreateMessage(messageContent, messageSeverity, messageMediaType)
+		if err != nil {
+			fmt.Printf("Error creating message: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("Message created successfully!")
+		printJSON(message)
 	},
 }
 
 func init() {
-	messagesCmd.Flags().StringVarP(&token, "token", "t", "", "Quay.io API token")
+	messagesCmd.AddCommand(messagesListCmd)
+	messagesCmd.AddCommand(messagesCreateCmd)
+
+	messagesCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Quay.io API token")
+
+	messagesCreateCmd.Flags().StringVar(&messageContent, "content", "", "Message content")
+	messagesCreateCmd.Flags().StringVar(&messageSeverity, "severity", "", "Message severity (info, warning, error)")
+	messagesCreateCmd.Flags().StringVar(&messageMediaType, "media-type", "", "Media type for the message")
+	if err := messagesCreateCmd.MarkFlagRequired("content"); err != nil {
+		fmt.Printf("Error marking content flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	if err := messagesCreateCmd.MarkFlagRequired("severity"); err != nil {
+		fmt.Printf("Error marking severity flag as required: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -213,6 +213,45 @@ var notificationResetCmd = &cobra.Command{
 	},
 }
 
+var notificationUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update a notification",
+	Long:  `Update an existing notification (webhook) configuration.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		config := map[string]interface{}{}
+		switch notificationMethod {
+		case "webhook":
+			config["url"] = notificationURL
+		case "email":
+			config["email"] = notificationURL
+		case "slack":
+			config["url"] = notificationURL
+		}
+
+		notificationReq := &lib.CreateNotificationRequest{
+			Event:  notificationEvent,
+			Method: notificationMethod,
+			Config: config,
+			Title:  notificationTitle,
+		}
+
+		notification, err := client.UpdateNotification(notificationNamespace, notificationRepository, notificationUUID, notificationReq)
+		if err != nil {
+			fmt.Printf("Error updating notification: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Notification '%s' updated successfully!\n", notificationUUID)
+		printJSON(notification)
+	},
+}
+
 func init() {
 	// Add subcommands to notification command
 	notificationCmd.AddCommand(notificationListCmd)
@@ -221,25 +260,36 @@ func init() {
 	notificationCmd.AddCommand(notificationDeleteCmd)
 	notificationCmd.AddCommand(notificationTestCmd)
 	notificationCmd.AddCommand(notificationResetCmd)
+	notificationCmd.AddCommand(notificationUpdateCmd)
 
 	// Global notification flags
 	notificationCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
 	notificationCmd.PersistentFlags().StringVarP(&notificationNamespace, "namespace", "n", "", "Repository namespace")
 	notificationCmd.PersistentFlags().StringVarP(&notificationRepository, "repository", "r", "", "Repository name")
-	markNotificationFlagRequired(notificationCmd.MarkPersistentFlagRequired("token"))
-	markNotificationFlagRequired(notificationCmd.MarkPersistentFlagRequired("namespace"))
-	markNotificationFlagRequired(notificationCmd.MarkPersistentFlagRequired("repository"))
+	markFlagRequired(notificationCmd.MarkPersistentFlagRequired("token"))
+	markFlagRequired(notificationCmd.MarkPersistentFlagRequired("namespace"))
+	markFlagRequired(notificationCmd.MarkPersistentFlagRequired("repository"))
 
 	initNotificationInfoFlags()
 	initNotificationCreateFlags()
 	initNotificationDeleteFlags()
 	initNotificationTestFlags()
 	initNotificationResetFlags()
+	initNotificationUpdateFlags()
+}
+
+func initNotificationUpdateFlags() {
+	notificationUpdateCmd.Flags().StringVarP(&notificationUUID, "uuid", "u", "", "Notification UUID")
+	notificationUpdateCmd.Flags().StringVarP(&notificationEvent, "event", "e", "", "Event type (repo_push, build_success, etc.)")
+	notificationUpdateCmd.Flags().StringVarP(&notificationMethod, "method", "m", "", "Method (webhook, email, slack)")
+	notificationUpdateCmd.Flags().StringVar(&notificationURL, "url", "", "Webhook URL or email address")
+	notificationUpdateCmd.Flags().StringVar(&notificationTitle, "title", "", "Notification title")
+	markFlagRequired(notificationUpdateCmd.MarkFlagRequired("uuid"))
 }
 
 func initNotificationInfoFlags() {
 	notificationInfoCmd.Flags().StringVarP(&notificationUUID, "uuid", "u", "", "Notification UUID")
-	markNotificationFlagRequired(notificationInfoCmd.MarkFlagRequired("uuid"))
+	markFlagRequired(notificationInfoCmd.MarkFlagRequired("uuid"))
 }
 
 func initNotificationCreateFlags() {
@@ -247,30 +297,23 @@ func initNotificationCreateFlags() {
 	notificationCreateCmd.Flags().StringVarP(&notificationMethod, "method", "m", "", "Method (webhook, email, slack)")
 	notificationCreateCmd.Flags().StringVar(&notificationURL, "url", "", "Webhook URL or email address")
 	notificationCreateCmd.Flags().StringVar(&notificationTitle, "title", "", "Notification title")
-	markNotificationFlagRequired(notificationCreateCmd.MarkFlagRequired("event"))
-	markNotificationFlagRequired(notificationCreateCmd.MarkFlagRequired("method"))
-	markNotificationFlagRequired(notificationCreateCmd.MarkFlagRequired("url"))
+	markFlagRequired(notificationCreateCmd.MarkFlagRequired("event"))
+	markFlagRequired(notificationCreateCmd.MarkFlagRequired("method"))
+	markFlagRequired(notificationCreateCmd.MarkFlagRequired("url"))
 }
 
 func initNotificationDeleteFlags() {
 	notificationDeleteCmd.Flags().StringVarP(&notificationUUID, "uuid", "u", "", "Notification UUID")
 	notificationDeleteCmd.Flags().BoolVar(&confirmNotificationDel, "confirm", false, "Confirm notification deletion")
-	markNotificationFlagRequired(notificationDeleteCmd.MarkFlagRequired("uuid"))
+	markFlagRequired(notificationDeleteCmd.MarkFlagRequired("uuid"))
 }
 
 func initNotificationTestFlags() {
 	notificationTestCmd.Flags().StringVarP(&notificationUUID, "uuid", "u", "", "Notification UUID")
-	markNotificationFlagRequired(notificationTestCmd.MarkFlagRequired("uuid"))
+	markFlagRequired(notificationTestCmd.MarkFlagRequired("uuid"))
 }
 
 func initNotificationResetFlags() {
 	notificationResetCmd.Flags().StringVarP(&notificationUUID, "uuid", "u", "", "Notification UUID")
-	markNotificationFlagRequired(notificationResetCmd.MarkFlagRequired("uuid"))
-}
-
-func markNotificationFlagRequired(err error) {
-	if err != nil {
-		fmt.Printf("Error marking flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	markFlagRequired(notificationResetCmd.MarkFlagRequired("uuid"))
 }

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -10,8 +10,32 @@ import (
 )
 
 var (
-	orgName  string
-	teamName string
+	orgName          string
+	teamName         string
+	email            string
+	memberName       string
+	confirm          bool
+	description      string
+	role             string
+	delegateType     string
+	delegateName     string
+	prototypeID      string
+	upstreamRegistry string
+	insecure         bool
+	expiration       int
+	clientID         string
+	appName          string
+	applicationURI   string
+	redirectURI      string
+	sku              string
+	quantity         int
+	subscriptionID   string
+	subscriptionIDs  []string
+	limitBytes       int64
+	policyUUID       string
+	method           string
+	pruneValue       int
+	tagPattern       string
 )
 
 // organizationCmd represents the organization command
@@ -212,8 +236,836 @@ var orgApplicationsCmd = &cobra.Command{
 	},
 }
 
+// Create Organization
+var createOrgCmd = &cobra.Command{
+	Use:   "create-org",
+	Short: "Create an organization",
+	Long:  `Create a new organization with the specified name and email.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		org, err := client.CreateOrganization(orgName, email)
+		if err != nil {
+			fmt.Printf("Error creating organization: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(org)
+	},
+}
+
+// Update Organization
+var updateOrgCmd = &cobra.Command{
+	Use:   "update-org",
+	Short: "Update an organization",
+	Long:  `Update an organization's email.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		org, err := client.UpdateOrganization(orgName, email)
+		if err != nil {
+			fmt.Printf("Error updating organization: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(org)
+	},
+}
+
+// Delete Organization
+var deleteOrgCmd = &cobra.Command{
+	Use:   "delete-org",
+	Short: "Delete an organization",
+	Long:  `Delete an organization. Requires --confirm flag.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirm {
+			fmt.Println("Error: must pass --confirm to delete an organization")
+			os.Exit(1)
+		}
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		err = client.DeleteOrganization(orgName)
+		if err != nil {
+			fmt.Printf("Error deleting organization: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Organization deleted successfully")
+	},
+}
+
+// Add Organization Member
+var addMemberCmd = &cobra.Command{
+	Use:   "add-member",
+	Short: "Add a member to an organization",
+	Long:  `Add a member to an organization by member name.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		err = client.AddOrganizationMember(orgName, memberName)
+		if err != nil {
+			fmt.Printf("Error adding organization member: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Member added successfully")
+	},
+}
+
+// Remove Organization Member
+var removeMemberCmd = &cobra.Command{
+	Use:   "remove-member",
+	Short: "Remove a member from an organization",
+	Long:  `Remove a member from an organization. Requires --confirm flag.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirm {
+			fmt.Println("Error: must pass --confirm to remove a member")
+			os.Exit(1)
+		}
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		err = client.RemoveOrganizationMember(orgName, memberName)
+		if err != nil {
+			fmt.Printf("Error removing organization member: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Member removed successfully")
+	},
+}
+
+// Get Organization Member
+var getMemberCmd = &cobra.Command{
+	Use:   "member",
+	Short: "Get organization member information",
+	Long:  `Get detailed information about a specific organization member.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		member, err := client.GetOrganizationMember(orgName, memberName)
+		if err != nil {
+			fmt.Printf("Error getting organization member: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(member)
+	},
+}
+
+// Get Organization Collaborators
+var collaboratorsCmd = &cobra.Command{
+	Use:   "collaborators",
+	Short: "Get organization collaborators",
+	Long:  `Get list of collaborators for an organization.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		collaborators, err := client.GetOrganizationCollaborators(orgName)
+		if err != nil {
+			fmt.Printf("Error getting organization collaborators: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(collaborators)
+	},
+}
+
+// Get Organization Repositories
+var orgRepositoriesCmd = &cobra.Command{
+	Use:   "repositories",
+	Short: "Get organization repositories",
+	Long:  `Get list of repositories for an organization.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		repos, err := client.GetOrganizationRepositories(orgName)
+		if err != nil {
+			fmt.Printf("Error getting organization repositories: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(repos)
+	},
+}
+
+// Get Default Permissions
+var defaultPermissionsCmd = &cobra.Command{
+	Use:   "default-permissions",
+	Short: "Get default permissions",
+	Long:  `Get default permissions for an organization.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		perms, err := client.GetDefaultPermissions(orgName)
+		if err != nil {
+			fmt.Printf("Error getting default permissions: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(perms)
+	},
+}
+
+// Create Default Permission
+var createDefaultPermissionCmd = &cobra.Command{
+	Use:   "create-default-permission",
+	Short: "Create a default permission",
+	Long:  `Create a default permission for an organization.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		perm, err := client.CreateDefaultPermission(orgName, role, delegateType, delegateName)
+		if err != nil {
+			fmt.Printf("Error creating default permission: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(perm)
+	},
+}
+
+// Delete Default Permission
+var deleteDefaultPermissionCmd = &cobra.Command{
+	Use:   "delete-default-permission",
+	Short: "Delete a default permission",
+	Long:  `Delete a default permission for an organization. Requires --confirm flag.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirm {
+			fmt.Println("Error: must pass --confirm to delete a default permission")
+			os.Exit(1)
+		}
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		err = client.DeleteDefaultPermission(orgName, prototypeID)
+		if err != nil {
+			fmt.Printf("Error deleting default permission: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Default permission deleted successfully")
+	},
+}
+
+// Get Proxy Cache Config
+var proxyCacheCmd = &cobra.Command{
+	Use:   "proxy-cache",
+	Short: "Get proxy cache configuration",
+	Long:  `Get proxy cache configuration for an organization.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		config, err := client.GetProxyCacheConfig(orgName)
+		if err != nil {
+			fmt.Printf("Error getting proxy cache config: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(config)
+	},
+}
+
+// Create Proxy Cache Config
+var createProxyCacheCmd = &cobra.Command{
+	Use:   "create-proxy-cache",
+	Short: "Create proxy cache configuration",
+	Long:  `Create proxy cache configuration for an organization.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		config, err := client.CreateProxyCacheConfig(orgName, upstreamRegistry, insecure, expiration)
+		if err != nil {
+			fmt.Printf("Error creating proxy cache config: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(config)
+	},
+}
+
+// Delete Proxy Cache Config
+var deleteProxyCacheCmd = &cobra.Command{
+	Use:   "delete-proxy-cache",
+	Short: "Delete proxy cache configuration",
+	Long:  `Delete proxy cache configuration for an organization. Requires --confirm flag.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirm {
+			fmt.Println("Error: must pass --confirm to delete proxy cache config")
+			os.Exit(1)
+		}
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		err = client.DeleteProxyCacheConfig(orgName)
+		if err != nil {
+			fmt.Printf("Error deleting proxy cache config: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Proxy cache config deleted successfully")
+	},
+}
+
+// Get Robot Account
+var orgRobotCmd = &cobra.Command{
+	Use:   "robot",
+	Short: "Get robot account information",
+	Long:  `Get detailed information about a specific robot account.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		robot, err := client.GetRobotAccount(orgName, robotShortname)
+		if err != nil {
+			fmt.Printf("Error getting robot account: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(robot)
+	},
+}
+
+// Create Robot Account
+var createRobotCmd = &cobra.Command{
+	Use:   "create-robot",
+	Short: "Create a robot account",
+	Long:  `Create a new robot account in an organization.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		robot, err := client.CreateRobotAccount(orgName, robotShortname, description, nil)
+		if err != nil {
+			fmt.Printf("Error creating robot account: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(robot)
+	},
+}
+
+// Delete Robot Account
+var deleteRobotCmd = &cobra.Command{
+	Use:   "delete-robot",
+	Short: "Delete a robot account",
+	Long:  `Delete a robot account from an organization. Requires --confirm flag.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirm {
+			fmt.Println("Error: must pass --confirm to delete a robot account")
+			os.Exit(1)
+		}
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		err = client.DeleteRobotAccount(orgName, robotShortname)
+		if err != nil {
+			fmt.Printf("Error deleting robot account: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Robot account deleted successfully")
+	},
+}
+
+// Regenerate Robot Token
+var regenerateRobotCmd = &cobra.Command{
+	Use:   "regenerate-robot",
+	Short: "Regenerate a robot account token",
+	Long:  `Regenerate the token for a robot account.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		robot, err := client.RegenerateRobotToken(orgName, robotShortname)
+		if err != nil {
+			fmt.Printf("Error regenerating robot token: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(robot)
+	},
+}
+
+// Get Robot Permissions
+var orgRobotPermissionsCmd = &cobra.Command{
+	Use:   "robot-permissions",
+	Short: "Get robot account permissions",
+	Long:  `Get permissions for a specific robot account.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		perms, err := client.GetRobotPermissions(orgName, robotShortname)
+		if err != nil {
+			fmt.Printf("Error getting robot permissions: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(perms)
+	},
+}
+
+// Set Robot Repository Permission
+var setRobotPermissionCmd = &cobra.Command{
+	Use:   "set-robot-permission",
+	Short: "Set robot repository permission",
+	Long:  `Set a robot account's permission on a repository.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		err = client.SetRobotRepositoryPermission(orgName, robotShortname, repository, role)
+		if err != nil {
+			fmt.Printf("Error setting robot permission: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Robot permission set successfully")
+	},
+}
+
+// Remove Robot Repository Permission
+var removeRobotPermissionCmd = &cobra.Command{
+	Use:   "remove-robot-permission",
+	Short: "Remove robot repository permission",
+	Long:  `Remove a robot account's permission on a repository. Requires --confirm flag.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirm {
+			fmt.Println("Error: must pass --confirm to remove a robot permission")
+			os.Exit(1)
+		}
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		err = client.RemoveRobotRepositoryPermission(orgName, robotShortname, repository)
+		if err != nil {
+			fmt.Printf("Error removing robot permission: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Robot permission removed successfully")
+	},
+}
+
+// Get Application
+var applicationCmd = &cobra.Command{
+	Use:   "application",
+	Short: "Get application information",
+	Long:  `Get detailed information about a specific OAuth application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		app, err := client.GetApplication(orgName, clientID)
+		if err != nil {
+			fmt.Printf("Error getting application: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(app)
+	},
+}
+
+// Create Application
+var createApplicationCmd = &cobra.Command{
+	Use:   "create-application",
+	Short: "Create an OAuth application",
+	Long:  `Create a new OAuth application for an organization.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		app, err := client.CreateApplication(orgName, appName, description, applicationURI, redirectURI)
+		if err != nil {
+			fmt.Printf("Error creating application: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(app)
+	},
+}
+
+// Update Application
+var updateApplicationCmd = &cobra.Command{
+	Use:   "update-application",
+	Short: "Update an OAuth application",
+	Long:  `Update an existing OAuth application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		app, err := client.UpdateApplication(orgName, clientID, appName, description, applicationURI, redirectURI)
+		if err != nil {
+			fmt.Printf("Error updating application: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(app)
+	},
+}
+
+// Delete Application
+var deleteApplicationCmd = &cobra.Command{
+	Use:   "delete-application",
+	Short: "Delete an OAuth application",
+	Long:  `Delete an OAuth application. Requires --confirm flag.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirm {
+			fmt.Println("Error: must pass --confirm to delete an application")
+			os.Exit(1)
+		}
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		err = client.DeleteApplication(orgName, clientID)
+		if err != nil {
+			fmt.Printf("Error deleting application: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Application deleted successfully")
+	},
+}
+
+// Reset Application Client Secret
+var resetApplicationSecretCmd = &cobra.Command{
+	Use:   "reset-application-secret",
+	Short: "Reset application client secret",
+	Long:  `Reset the client secret for an OAuth application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		app, err := client.ResetApplicationClientSecret(orgName, clientID)
+		if err != nil {
+			fmt.Printf("Error resetting application secret: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(app)
+	},
+}
+
+// Get Organization Marketplace
+var marketplaceCmd = &cobra.Command{
+	Use:   "marketplace",
+	Short: "Get organization marketplace information",
+	Long:  `Get marketplace information for an organization.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		marketplace, err := client.GetOrganizationMarketplace(orgName)
+		if err != nil {
+			fmt.Printf("Error getting marketplace info: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(marketplace)
+	},
+}
+
+// Create Marketplace Subscription
+var createMarketplaceSubscriptionCmd = &cobra.Command{
+	Use:   "create-marketplace-subscription",
+	Short: "Create a marketplace subscription",
+	Long:  `Create a marketplace subscription for an organization.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		err = client.CreateOrganizationMarketplaceSubscription(orgName, &lib.MarketplaceSubscriptionRequest{SKU: sku, Quantity: quantity})
+		if err != nil {
+			fmt.Printf("Error creating marketplace subscription: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Marketplace subscription created successfully")
+	},
+}
+
+// Delete Marketplace Subscription
+var deleteMarketplaceSubscriptionCmd = &cobra.Command{
+	Use:   "delete-marketplace-subscription",
+	Short: "Delete a marketplace subscription",
+	Long:  `Delete a marketplace subscription. Requires --confirm flag.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirm {
+			fmt.Println("Error: must pass --confirm to delete a marketplace subscription")
+			os.Exit(1)
+		}
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		err = client.DeleteOrganizationMarketplaceSubscription(orgName, subscriptionID)
+		if err != nil {
+			fmt.Printf("Error deleting marketplace subscription: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Marketplace subscription deleted successfully")
+	},
+}
+
+// Batch Remove Marketplace Subscriptions
+var batchRemoveSubscriptionsCmd = &cobra.Command{
+	Use:   "batch-remove-subscriptions",
+	Short: "Batch remove marketplace subscriptions",
+	Long:  `Remove multiple marketplace subscriptions at once. Requires --confirm flag.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirm {
+			fmt.Println("Error: must pass --confirm to batch remove subscriptions")
+			os.Exit(1)
+		}
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		err = client.BatchRemoveOrganizationMarketplaceSubscriptions(orgName, subscriptionIDs)
+		if err != nil {
+			fmt.Printf("Error batch removing subscriptions: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Marketplace subscriptions removed successfully")
+	},
+}
+
+// Create Quota
+var createQuotaCmd = &cobra.Command{
+	Use:   "create-quota",
+	Short: "Create organization quota",
+	Long:  `Create a quota for an organization.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		quota, err := client.CreateQuota(orgName, limitBytes)
+		if err != nil {
+			fmt.Printf("Error creating quota: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(quota)
+	},
+}
+
+// Update Quota
+var updateQuotaCmd = &cobra.Command{
+	Use:   "update-quota",
+	Short: "Update organization quota",
+	Long:  `Update the quota for an organization.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		quota, err := client.UpdateQuota(orgName, limitBytes)
+		if err != nil {
+			fmt.Printf("Error updating quota: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(quota)
+	},
+}
+
+// Delete Quota
+var deleteQuotaCmd = &cobra.Command{
+	Use:   "delete-quota",
+	Short: "Delete organization quota",
+	Long:  `Delete the quota for an organization. Requires --confirm flag.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirm {
+			fmt.Println("Error: must pass --confirm to delete a quota")
+			os.Exit(1)
+		}
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		err = client.DeleteQuota(orgName)
+		if err != nil {
+			fmt.Printf("Error deleting quota: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Quota deleted successfully")
+	},
+}
+
+// Get Auto-Prune Policy
+var autoPrunePolicyCmd = &cobra.Command{
+	Use:   "auto-prune-policy",
+	Short: "Get a specific auto-prune policy",
+	Long:  `Get detailed information about a specific auto-prune policy.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		policy, err := client.GetAutoPrunePolicy(orgName, policyUUID)
+		if err != nil {
+			fmt.Printf("Error getting auto-prune policy: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(policy)
+	},
+}
+
+// Create Auto-Prune Policy
+var createAutoPruneCmd = &cobra.Command{
+	Use:   "create-auto-prune",
+	Short: "Create an auto-prune policy",
+	Long:  `Create an auto-prune policy for an organization.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		policy, err := client.CreateAutoPrunePolicy(orgName, method, pruneValue, tagPattern)
+		if err != nil {
+			fmt.Printf("Error creating auto-prune policy: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(policy)
+	},
+}
+
+// Update Auto-Prune Policy
+var updateAutoPruneCmd = &cobra.Command{
+	Use:   "update-auto-prune",
+	Short: "Update an auto-prune policy",
+	Long:  `Update an existing auto-prune policy.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		policy, err := client.UpdateAutoPrunePolicy(orgName, policyUUID, method, pruneValue, tagPattern)
+		if err != nil {
+			fmt.Printf("Error updating auto-prune policy: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(policy)
+	},
+}
+
+// Delete Auto-Prune Policy
+var deleteAutoPruneCmd = &cobra.Command{
+	Use:   "delete-auto-prune",
+	Short: "Delete an auto-prune policy",
+	Long:  `Delete an auto-prune policy. Requires --confirm flag.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirm {
+			fmt.Println("Error: must pass --confirm to delete an auto-prune policy")
+			os.Exit(1)
+		}
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		err = client.DeleteAutoPrunePolicy(orgName, policyUUID)
+		if err != nil {
+			fmt.Printf("Error deleting auto-prune policy: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Auto-prune policy deleted successfully")
+	},
+}
+
+// Invite Team Member
+var inviteMemberCmd = &cobra.Command{
+	Use:   "invite-member",
+	Short: "Invite a member to a team",
+	Long:  `Invite a member to a team by email.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		err = client.InviteTeamMember(orgName, teamName, email)
+		if err != nil {
+			fmt.Printf("Error inviting team member: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Team member invited successfully")
+	},
+}
+
+// Cancel Team Invite
+var cancelInviteCmd = &cobra.Command{
+	Use:   "cancel-invite",
+	Short: "Cancel a team member invitation",
+	Long:  `Cancel a pending team member invitation. Requires --confirm flag.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirm {
+			fmt.Println("Error: must pass --confirm to cancel an invite")
+			os.Exit(1)
+		}
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+		err = client.DeleteTeamInvite(orgName, teamName, email)
+		if err != nil {
+			fmt.Printf("Error canceling team invite: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Team invite canceled successfully")
+	},
+}
+
 func init() {
-	// Add organization command to get command
+	// Add all subcommands to organization command
 	organizationCmd.AddCommand(orgInfoCmd)
 	organizationCmd.AddCommand(orgMembersCmd)
 	organizationCmd.AddCommand(orgTeamsCmd)
@@ -223,12 +1075,63 @@ func init() {
 	organizationCmd.AddCommand(orgQuotaCmd)
 	organizationCmd.AddCommand(autoPruneCmd)
 	organizationCmd.AddCommand(orgApplicationsCmd)
+	organizationCmd.AddCommand(createOrgCmd)
+	organizationCmd.AddCommand(updateOrgCmd)
+	organizationCmd.AddCommand(deleteOrgCmd)
+	organizationCmd.AddCommand(addMemberCmd)
+	organizationCmd.AddCommand(removeMemberCmd)
+	organizationCmd.AddCommand(getMemberCmd)
+	organizationCmd.AddCommand(collaboratorsCmd)
+	organizationCmd.AddCommand(orgRepositoriesCmd)
+	organizationCmd.AddCommand(defaultPermissionsCmd)
+	organizationCmd.AddCommand(createDefaultPermissionCmd)
+	organizationCmd.AddCommand(deleteDefaultPermissionCmd)
+	organizationCmd.AddCommand(proxyCacheCmd)
+	organizationCmd.AddCommand(createProxyCacheCmd)
+	organizationCmd.AddCommand(deleteProxyCacheCmd)
+	organizationCmd.AddCommand(orgRobotCmd)
+	organizationCmd.AddCommand(createRobotCmd)
+	organizationCmd.AddCommand(deleteRobotCmd)
+	organizationCmd.AddCommand(regenerateRobotCmd)
+	organizationCmd.AddCommand(orgRobotPermissionsCmd)
+	organizationCmd.AddCommand(setRobotPermissionCmd)
+	organizationCmd.AddCommand(removeRobotPermissionCmd)
+	organizationCmd.AddCommand(applicationCmd)
+	organizationCmd.AddCommand(createApplicationCmd)
+	organizationCmd.AddCommand(updateApplicationCmd)
+	organizationCmd.AddCommand(deleteApplicationCmd)
+	organizationCmd.AddCommand(resetApplicationSecretCmd)
+	organizationCmd.AddCommand(marketplaceCmd)
+	organizationCmd.AddCommand(createMarketplaceSubscriptionCmd)
+	organizationCmd.AddCommand(deleteMarketplaceSubscriptionCmd)
+	organizationCmd.AddCommand(batchRemoveSubscriptionsCmd)
+	organizationCmd.AddCommand(createQuotaCmd)
+	organizationCmd.AddCommand(updateQuotaCmd)
+	organizationCmd.AddCommand(deleteQuotaCmd)
+	organizationCmd.AddCommand(autoPrunePolicyCmd)
+	organizationCmd.AddCommand(createAutoPruneCmd)
+	organizationCmd.AddCommand(updateAutoPruneCmd)
+	organizationCmd.AddCommand(deleteAutoPruneCmd)
+	organizationCmd.AddCommand(inviteMemberCmd)
+	organizationCmd.AddCommand(cancelInviteCmd)
 
-	// Add persistent flags for organization name
+	// Register persistent and command-specific flags
+	initOrgPersistentFlags()
+	initOrgMemberFlags()
+	initOrgPermissionFlags()
+	initOrgProxyCacheFlags()
+	initOrgRobotFlags()
+	initOrgApplicationFlags()
+	initOrgMarketplaceFlags()
+	initOrgQuotaFlags()
+	initOrgAutoPruneFlags()
+	initOrgInviteFlags()
+}
+
+func initOrgPersistentFlags() {
 	organizationCmd.PersistentFlags().StringVarP(&orgName, "organization", "o", "", "Organization name")
 	organizationCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Authentication token")
 
-	// Mark flags as required
 	if err := organizationCmd.MarkPersistentFlagRequired("organization"); err != nil {
 		fmt.Printf("Error marking organization flag as required: %v\n", err)
 		os.Exit(1)
@@ -237,19 +1140,340 @@ func init() {
 		fmt.Printf("Error marking token flag as required: %v\n", err)
 		os.Exit(1)
 	}
+}
 
-	// Add specific flags for team commands
+func initOrgMemberFlags() {
+	// team info flags
 	teamInfoCmd.Flags().StringVarP(&teamName, "team", "T", "", "Team name")
 	if err := teamInfoCmd.MarkFlagRequired("team"); err != nil {
 		fmt.Printf("Error marking team flag as required: %v\n", err)
 		os.Exit(1)
 	}
 
+	// team members flags
 	teamMembersCmd.Flags().StringVarP(&teamName, "team", "T", "", "Team name")
 	if err := teamMembersCmd.MarkFlagRequired("team"); err != nil {
 		fmt.Printf("Error marking team flag as required: %v\n", err)
 		os.Exit(1)
 	}
+
+	// create-org flags
+	createOrgCmd.Flags().StringVar(&email, "email", "", "Email address")
+	if err := createOrgCmd.MarkFlagRequired("email"); err != nil {
+		fmt.Printf("Error marking email flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// update-org flags
+	updateOrgCmd.Flags().StringVar(&email, "email", "", "Email address")
+	if err := updateOrgCmd.MarkFlagRequired("email"); err != nil {
+		fmt.Printf("Error marking email flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// delete-org flags
+	deleteOrgCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm deletion")
+
+	// add-member flags
+	addMemberCmd.Flags().StringVar(&memberName, "member", "", "Member name")
+	if err := addMemberCmd.MarkFlagRequired("member"); err != nil {
+		fmt.Printf("Error marking member flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// remove-member flags
+	removeMemberCmd.Flags().StringVar(&memberName, "member", "", "Member name")
+	if err := removeMemberCmd.MarkFlagRequired("member"); err != nil {
+		fmt.Printf("Error marking member flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	removeMemberCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm removal")
+
+	// member flags
+	getMemberCmd.Flags().StringVar(&memberName, "member", "", "Member name")
+	if err := getMemberCmd.MarkFlagRequired("member"); err != nil {
+		fmt.Printf("Error marking member flag as required: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func initOrgPermissionFlags() {
+	// create-default-permission flags
+	createDefaultPermissionCmd.Flags().StringVar(&role, "role", "", "Permission role")
+	if err := createDefaultPermissionCmd.MarkFlagRequired("role"); err != nil {
+		fmt.Printf("Error marking role flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	createDefaultPermissionCmd.Flags().StringVar(&delegateType, "delegate-type", "", "Delegate type")
+	if err := createDefaultPermissionCmd.MarkFlagRequired("delegate-type"); err != nil {
+		fmt.Printf("Error marking delegate-type flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	createDefaultPermissionCmd.Flags().StringVar(&delegateName, "delegate-name", "", "Delegate name")
+	if err := createDefaultPermissionCmd.MarkFlagRequired("delegate-name"); err != nil {
+		fmt.Printf("Error marking delegate-name flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// delete-default-permission flags
+	deleteDefaultPermissionCmd.Flags().StringVar(&prototypeID, "prototype-id", "", "Prototype ID")
+	if err := deleteDefaultPermissionCmd.MarkFlagRequired("prototype-id"); err != nil {
+		fmt.Printf("Error marking prototype-id flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	deleteDefaultPermissionCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm deletion")
+}
+
+func initOrgProxyCacheFlags() {
+	// create-proxy-cache flags
+	createProxyCacheCmd.Flags().StringVar(&upstreamRegistry, "upstream-registry", "", "Upstream registry URL")
+	if err := createProxyCacheCmd.MarkFlagRequired("upstream-registry"); err != nil {
+		fmt.Printf("Error marking upstream-registry flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	createProxyCacheCmd.Flags().BoolVar(&insecure, "insecure", false, "Allow insecure connections")
+	createProxyCacheCmd.Flags().IntVar(&expiration, "expiration", 0, "Cache expiration in seconds")
+
+	// delete-proxy-cache flags
+	deleteProxyCacheCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm deletion")
+}
+
+func initOrgRobotFlags() {
+	// robot flags
+	orgRobotCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
+	if err := orgRobotCmd.MarkFlagRequired("robot"); err != nil {
+		fmt.Printf("Error marking robot flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// create-robot flags
+	createRobotCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
+	if err := createRobotCmd.MarkFlagRequired("robot"); err != nil {
+		fmt.Printf("Error marking robot flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	createRobotCmd.Flags().StringVar(&description, "description", "", "Robot description")
+
+	// delete-robot flags
+	deleteRobotCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
+	if err := deleteRobotCmd.MarkFlagRequired("robot"); err != nil {
+		fmt.Printf("Error marking robot flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	deleteRobotCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm deletion")
+
+	// regenerate-robot flags
+	regenerateRobotCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
+	if err := regenerateRobotCmd.MarkFlagRequired("robot"); err != nil {
+		fmt.Printf("Error marking robot flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// robot-permissions flags
+	orgRobotPermissionsCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
+	if err := orgRobotPermissionsCmd.MarkFlagRequired("robot"); err != nil {
+		fmt.Printf("Error marking robot flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// set-robot-permission flags
+	setRobotPermissionCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
+	if err := setRobotPermissionCmd.MarkFlagRequired("robot"); err != nil {
+		fmt.Printf("Error marking robot flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	setRobotPermissionCmd.Flags().StringVar(&repository, "repository", "", "Repository name")
+	if err := setRobotPermissionCmd.MarkFlagRequired("repository"); err != nil {
+		fmt.Printf("Error marking repository flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	setRobotPermissionCmd.Flags().StringVar(&role, "role", "", "Permission role")
+	if err := setRobotPermissionCmd.MarkFlagRequired("role"); err != nil {
+		fmt.Printf("Error marking role flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// remove-robot-permission flags
+	removeRobotPermissionCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
+	if err := removeRobotPermissionCmd.MarkFlagRequired("robot"); err != nil {
+		fmt.Printf("Error marking robot flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	removeRobotPermissionCmd.Flags().StringVar(&repository, "repository", "", "Repository name")
+	if err := removeRobotPermissionCmd.MarkFlagRequired("repository"); err != nil {
+		fmt.Printf("Error marking repository flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	removeRobotPermissionCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm removal")
+}
+
+func initOrgApplicationFlags() {
+	// application flags
+	applicationCmd.Flags().StringVar(&clientID, "client-id", "", "Application client ID")
+	if err := applicationCmd.MarkFlagRequired("client-id"); err != nil {
+		fmt.Printf("Error marking client-id flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// create-application flags
+	createApplicationCmd.Flags().StringVar(&appName, "name", "", "Application name")
+	if err := createApplicationCmd.MarkFlagRequired("name"); err != nil {
+		fmt.Printf("Error marking name flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	createApplicationCmd.Flags().StringVar(&description, "description", "", "Application description")
+	createApplicationCmd.Flags().StringVar(&applicationURI, "application-uri", "", "Application URI")
+	createApplicationCmd.Flags().StringVar(&redirectURI, "redirect-uri", "", "Redirect URI")
+
+	// update-application flags
+	updateApplicationCmd.Flags().StringVar(&clientID, "client-id", "", "Application client ID")
+	if err := updateApplicationCmd.MarkFlagRequired("client-id"); err != nil {
+		fmt.Printf("Error marking client-id flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	updateApplicationCmd.Flags().StringVar(&appName, "name", "", "Application name")
+	if err := updateApplicationCmd.MarkFlagRequired("name"); err != nil {
+		fmt.Printf("Error marking name flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	updateApplicationCmd.Flags().StringVar(&description, "description", "", "Application description")
+	updateApplicationCmd.Flags().StringVar(&applicationURI, "application-uri", "", "Application URI")
+	updateApplicationCmd.Flags().StringVar(&redirectURI, "redirect-uri", "", "Redirect URI")
+
+	// delete-application flags
+	deleteApplicationCmd.Flags().StringVar(&clientID, "client-id", "", "Application client ID")
+	if err := deleteApplicationCmd.MarkFlagRequired("client-id"); err != nil {
+		fmt.Printf("Error marking client-id flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	deleteApplicationCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm deletion")
+
+	// reset-application-secret flags
+	resetApplicationSecretCmd.Flags().StringVar(&clientID, "client-id", "", "Application client ID")
+	if err := resetApplicationSecretCmd.MarkFlagRequired("client-id"); err != nil {
+		fmt.Printf("Error marking client-id flag as required: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func initOrgMarketplaceFlags() {
+	// create-marketplace-subscription flags
+	createMarketplaceSubscriptionCmd.Flags().StringVar(&sku, "sku", "", "Subscription SKU")
+	if err := createMarketplaceSubscriptionCmd.MarkFlagRequired("sku"); err != nil {
+		fmt.Printf("Error marking sku flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	createMarketplaceSubscriptionCmd.Flags().IntVar(&quantity, "quantity", 0, "Subscription quantity")
+
+	// delete-marketplace-subscription flags
+	deleteMarketplaceSubscriptionCmd.Flags().StringVar(&subscriptionID, "subscription-id", "", "Subscription ID")
+	if err := deleteMarketplaceSubscriptionCmd.MarkFlagRequired("subscription-id"); err != nil {
+		fmt.Printf("Error marking subscription-id flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	deleteMarketplaceSubscriptionCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm deletion")
+
+	// batch-remove-subscriptions flags
+	batchRemoveSubscriptionsCmd.Flags().StringSliceVar(&subscriptionIDs, "subscription-ids", nil, "Comma-separated subscription IDs")
+	if err := batchRemoveSubscriptionsCmd.MarkFlagRequired("subscription-ids"); err != nil {
+		fmt.Printf("Error marking subscription-ids flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	batchRemoveSubscriptionsCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm removal")
+}
+
+func initOrgQuotaFlags() {
+	// create-quota flags
+	createQuotaCmd.Flags().Int64Var(&limitBytes, "limit-bytes", 0, "Quota limit in bytes")
+	if err := createQuotaCmd.MarkFlagRequired("limit-bytes"); err != nil {
+		fmt.Printf("Error marking limit-bytes flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// update-quota flags
+	updateQuotaCmd.Flags().Int64Var(&limitBytes, "limit-bytes", 0, "Quota limit in bytes")
+	if err := updateQuotaCmd.MarkFlagRequired("limit-bytes"); err != nil {
+		fmt.Printf("Error marking limit-bytes flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// delete-quota flags
+	deleteQuotaCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm deletion")
+}
+
+func initOrgAutoPruneFlags() {
+	// auto-prune-policy flags
+	autoPrunePolicyCmd.Flags().StringVar(&policyUUID, "policy-uuid", "", "Policy UUID")
+	if err := autoPrunePolicyCmd.MarkFlagRequired("policy-uuid"); err != nil {
+		fmt.Printf("Error marking policy-uuid flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// create-auto-prune flags
+	createAutoPruneCmd.Flags().StringVar(&method, "method", "", "Prune method")
+	if err := createAutoPruneCmd.MarkFlagRequired("method"); err != nil {
+		fmt.Printf("Error marking method flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	createAutoPruneCmd.Flags().IntVar(&pruneValue, "value", 0, "Prune value")
+	if err := createAutoPruneCmd.MarkFlagRequired("value"); err != nil {
+		fmt.Printf("Error marking value flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	createAutoPruneCmd.Flags().StringVar(&tagPattern, "tag-pattern", "", "Tag pattern to match")
+
+	// update-auto-prune flags
+	updateAutoPruneCmd.Flags().StringVar(&policyUUID, "policy-uuid", "", "Policy UUID")
+	if err := updateAutoPruneCmd.MarkFlagRequired("policy-uuid"); err != nil {
+		fmt.Printf("Error marking policy-uuid flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	updateAutoPruneCmd.Flags().StringVar(&method, "method", "", "Prune method")
+	if err := updateAutoPruneCmd.MarkFlagRequired("method"); err != nil {
+		fmt.Printf("Error marking method flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	updateAutoPruneCmd.Flags().IntVar(&pruneValue, "value", 0, "Prune value")
+	if err := updateAutoPruneCmd.MarkFlagRequired("value"); err != nil {
+		fmt.Printf("Error marking value flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	updateAutoPruneCmd.Flags().StringVar(&tagPattern, "tag-pattern", "", "Tag pattern to match")
+
+	// delete-auto-prune flags
+	deleteAutoPruneCmd.Flags().StringVar(&policyUUID, "policy-uuid", "", "Policy UUID")
+	if err := deleteAutoPruneCmd.MarkFlagRequired("policy-uuid"); err != nil {
+		fmt.Printf("Error marking policy-uuid flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	deleteAutoPruneCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm deletion")
+}
+
+func initOrgInviteFlags() {
+	// invite-member flags
+	inviteMemberCmd.Flags().StringVarP(&teamName, "team", "T", "", "Team name")
+	if err := inviteMemberCmd.MarkFlagRequired("team"); err != nil {
+		fmt.Printf("Error marking team flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	inviteMemberCmd.Flags().StringVar(&email, "email", "", "Email address")
+	if err := inviteMemberCmd.MarkFlagRequired("email"); err != nil {
+		fmt.Printf("Error marking email flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// cancel-invite flags
+	cancelInviteCmd.Flags().StringVarP(&teamName, "team", "T", "", "Team name")
+	if err := cancelInviteCmd.MarkFlagRequired("team"); err != nil {
+		fmt.Printf("Error marking team flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	cancelInviteCmd.Flags().StringVar(&email, "email", "", "Email address")
+	if err := cancelInviteCmd.MarkFlagRequired("email"); err != nil {
+		fmt.Printf("Error marking email flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	cancelInviteCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm cancellation")
 }
 
 // Helper function to print JSON output

--- a/cmd/permissions.go
+++ b/cmd/permissions.go
@@ -9,8 +9,10 @@ import (
 )
 
 var (
-	permissionUser string
-	permissionRole string
+	permissionUser      string
+	permissionRole      string
+	permissionTeamName  string
+	confirmPermDeletion bool
 )
 
 // permissionsCmd represents the permissions command group
@@ -96,11 +98,218 @@ var permRemoveCmd = &cobra.Command{
 	},
 }
 
+var permUserPermissionsCmd = &cobra.Command{
+	Use:   "user-permissions",
+	Short: "List user permissions on repository",
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		permissions, err := client.ListUserPermissions(namespace, repository)
+		if err != nil {
+			fmt.Printf("Error getting user permissions: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(permissions)
+	},
+}
+
+var permUserPermissionCmd = &cobra.Command{
+	Use:   "user-permission",
+	Short: "Get specific user permission on repository",
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		permission, err := client.GetUserPermission(namespace, repository, permissionUser)
+		if err != nil {
+			fmt.Printf("Error getting user permission: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(permission)
+	},
+}
+
+var permSetUserPermCmd = &cobra.Command{
+	Use:   "set-user-permission",
+	Short: "Set user permission on repository",
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.SetUserPermission(namespace, repository, permissionUser, permissionRole)
+		if err != nil {
+			fmt.Printf("Error setting user permission: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully set %s permission for user %s on %s/%s\n",
+			permissionRole, permissionUser, namespace, repository)
+	},
+}
+
+var permDeleteUserPermCmd = &cobra.Command{
+	Use:   "delete-user-permission",
+	Short: "Delete user permission from repository",
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirmPermDeletion {
+			fmt.Printf("Are you sure you want to remove permission for user '%s' from %s/%s?\n",
+				permissionUser, namespace, repository)
+			fmt.Println("Use --confirm to proceed with removal.")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.DeleteUserPermission(namespace, repository, permissionUser)
+		if err != nil {
+			fmt.Printf("Error deleting user permission: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully removed permission for user %s from %s/%s\n",
+			permissionUser, namespace, repository)
+	},
+}
+
+var permUserTransitiveCmd = &cobra.Command{
+	Use:   "user-transitive-permission",
+	Short: "Get user transitive permission on repository",
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		permission, err := client.GetUserTransitivePermission(namespace, repository, permissionUser)
+		if err != nil {
+			fmt.Printf("Error getting user transitive permission: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(permission)
+	},
+}
+
+var permTeamPermissionsCmd = &cobra.Command{
+	Use:   "team-permissions",
+	Short: "List team permissions on repository",
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		permissions, err := client.ListTeamPermissions(namespace, repository)
+		if err != nil {
+			fmt.Printf("Error getting team permissions: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(permissions)
+	},
+}
+
+var permTeamPermissionCmd = &cobra.Command{
+	Use:   "team-permission",
+	Short: "Get specific team permission on repository",
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		permission, err := client.GetTeamPermission(namespace, repository, permissionTeamName)
+		if err != nil {
+			fmt.Printf("Error getting team permission: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(permission)
+	},
+}
+
+var permSetTeamPermCmd = &cobra.Command{
+	Use:   "set-team-permission",
+	Short: "Set team permission on repository",
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.SetTeamPermission(namespace, repository, permissionTeamName, permissionRole)
+		if err != nil {
+			fmt.Printf("Error setting team permission: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully set %s permission for team %s on %s/%s\n",
+			permissionRole, permissionTeamName, namespace, repository)
+	},
+}
+
+var permDeleteTeamPermCmd = &cobra.Command{
+	Use:   "delete-team-permission",
+	Short: "Delete team permission from repository",
+	Run: func(cmd *cobra.Command, args []string) {
+		if !confirmPermDeletion {
+			fmt.Printf("Are you sure you want to remove permission for team '%s' from %s/%s?\n",
+				permissionTeamName, namespace, repository)
+			fmt.Println("Use --confirm to proceed with removal.")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.DeleteTeamPermission(namespace, repository, permissionTeamName)
+		if err != nil {
+			fmt.Printf("Error deleting team permission: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully removed permission for team %s from %s/%s\n",
+			permissionTeamName, namespace, repository)
+	},
+}
+
 func init() {
 	// Add subcommands to permissions command
 	permissionsCmd.AddCommand(permListCmd)
 	permissionsCmd.AddCommand(permSetCmd)
 	permissionsCmd.AddCommand(permRemoveCmd)
+	permissionsCmd.AddCommand(permUserPermissionsCmd)
+	permissionsCmd.AddCommand(permUserPermissionCmd)
+	permissionsCmd.AddCommand(permSetUserPermCmd)
+	permissionsCmd.AddCommand(permDeleteUserPermCmd)
+	permissionsCmd.AddCommand(permUserTransitiveCmd)
+	permissionsCmd.AddCommand(permTeamPermissionsCmd)
+	permissionsCmd.AddCommand(permTeamPermissionCmd)
+	permissionsCmd.AddCommand(permSetTeamPermCmd)
+	permissionsCmd.AddCommand(permDeleteTeamPermCmd)
 
 	// Global permissions flags (repository context)
 	permissionsCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
@@ -139,4 +348,38 @@ func init() {
 		fmt.Printf("Error marking user flag as required: %v\n", err)
 		os.Exit(1)
 	}
+
+	initPermUserFlags()
+	initPermTeamFlags()
+}
+
+func initPermUserFlags() {
+	permUserPermissionCmd.Flags().StringVarP(&permissionUser, "user", "u", "", "Username")
+	markFlagRequired(permUserPermissionCmd.MarkFlagRequired("user"))
+
+	permSetUserPermCmd.Flags().StringVarP(&permissionUser, "user", "u", "", "Username")
+	permSetUserPermCmd.Flags().StringVarP(&permissionRole, "role", "R", "", "Permission role (read/write/admin)")
+	markFlagRequired(permSetUserPermCmd.MarkFlagRequired("user"))
+	markFlagRequired(permSetUserPermCmd.MarkFlagRequired("role"))
+
+	permDeleteUserPermCmd.Flags().StringVarP(&permissionUser, "user", "u", "", "Username")
+	permDeleteUserPermCmd.Flags().BoolVar(&confirmPermDeletion, "confirm", false, "Confirm permission removal")
+	markFlagRequired(permDeleteUserPermCmd.MarkFlagRequired("user"))
+
+	permUserTransitiveCmd.Flags().StringVarP(&permissionUser, "user", "u", "", "Username")
+	markFlagRequired(permUserTransitiveCmd.MarkFlagRequired("user"))
+}
+
+func initPermTeamFlags() {
+	permTeamPermissionCmd.Flags().StringVar(&permissionTeamName, "team", "", "Team name")
+	markFlagRequired(permTeamPermissionCmd.MarkFlagRequired("team"))
+
+	permSetTeamPermCmd.Flags().StringVar(&permissionTeamName, "team", "", "Team name")
+	permSetTeamPermCmd.Flags().StringVarP(&permissionRole, "role", "R", "", "Permission role (read/write/admin)")
+	markFlagRequired(permSetTeamPermCmd.MarkFlagRequired("team"))
+	markFlagRequired(permSetTeamPermCmd.MarkFlagRequired("role"))
+
+	permDeleteTeamPermCmd.Flags().StringVar(&permissionTeamName, "team", "", "Team name")
+	permDeleteTeamPermCmd.Flags().BoolVar(&confirmPermDeletion, "confirm", false, "Confirm permission removal")
+	markFlagRequired(permDeleteTeamPermCmd.MarkFlagRequired("team"))
 }

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -12,6 +12,10 @@ var (
 	repoVisibility  string
 	repoDescription string
 	confirmDeletion bool
+	repoPublic      bool
+	repoStarred     bool
+	repoPage        int
+	repoLimit       int
 )
 
 // repositoryCmd represents the repository command group
@@ -32,6 +36,11 @@ var repoInfoCmd = &cobra.Command{
 	Use:   "info",
 	Short: "Get repository information from Quay.io",
 	Run: func(cmd *cobra.Command, args []string) {
+		if repository == "" {
+			fmt.Println("Error: --repository is required")
+			os.Exit(1)
+		}
+
 		client, err := lib.NewClient(token)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
@@ -54,6 +63,11 @@ var repoCreateCmd = &cobra.Command{
 	Short: "Create a new repository",
 	Long:  `Create a new repository in the specified namespace with optional description and visibility settings.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if repository == "" {
+			fmt.Println("Error: --repository is required")
+			os.Exit(1)
+		}
+
 		client, err := lib.NewClient(token)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
@@ -77,6 +91,11 @@ var repoUpdateCmd = &cobra.Command{
 	Short: "Update repository settings",
 	Long:  `Update repository description and/or visibility settings.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if repository == "" {
+			fmt.Println("Error: --repository is required")
+			os.Exit(1)
+		}
+
 		client, err := lib.NewClient(token)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
@@ -100,6 +119,11 @@ var repoDeleteCmd = &cobra.Command{
 	Short: "Delete a repository",
 	Long:  `Delete a repository. This action is irreversible and will remove all images and tags.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if repository == "" {
+			fmt.Println("Error: --repository is required")
+			os.Exit(1)
+		}
+
 		if !confirmDeletion {
 			fmt.Printf("Are you sure you want to delete repository %s/%s? This action cannot be undone.\n", namespace, repository)
 			fmt.Print("Use --confirm to proceed with deletion.\n")
@@ -122,12 +146,61 @@ var repoDeleteCmd = &cobra.Command{
 	},
 }
 
+var repoListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List repositories in a namespace",
+	Long:  `List all repositories in a namespace with optional filters.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		repos, err := client.ListRepositories(namespace, repoPublic, repoStarred, repoPage, repoLimit)
+		if err != nil {
+			fmt.Printf("Error listing repositories: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(repos)
+	},
+}
+
+var repoChangeVisibilityCmd = &cobra.Command{
+	Use:   "change-visibility",
+	Short: "Change repository visibility",
+	Long:  `Change a repository's visibility between public and private.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if repository == "" {
+			fmt.Println("Error: --repository is required")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.ChangeRepositoryVisibility(namespace, repository, repoVisibility)
+		if err != nil {
+			fmt.Printf("Error changing repository visibility: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully changed visibility of %s/%s to %s\n", namespace, repository, repoVisibility)
+	},
+}
+
 func init() {
 	// Add subcommands to repository command
 	repositoryCmd.AddCommand(repoInfoCmd)
 	repositoryCmd.AddCommand(repoCreateCmd)
 	repositoryCmd.AddCommand(repoUpdateCmd)
 	repositoryCmd.AddCommand(repoDeleteCmd)
+	repositoryCmd.AddCommand(repoListCmd)
+	repositoryCmd.AddCommand(repoChangeVisibilityCmd)
 
 	// Global repository flags
 	repositoryCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
@@ -137,10 +210,6 @@ func init() {
 	// Mark global flags as required
 	if err := repositoryCmd.MarkPersistentFlagRequired("namespace"); err != nil {
 		fmt.Printf("Error marking namespace flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := repositoryCmd.MarkPersistentFlagRequired("repository"); err != nil {
-		fmt.Printf("Error marking repository flag as required: %v\n", err)
 		os.Exit(1)
 	}
 	if err := repositoryCmd.MarkPersistentFlagRequired("token"); err != nil {
@@ -159,6 +228,16 @@ func init() {
 	// Delete command specific flags
 	repoDeleteCmd.Flags().BoolVar(&confirmDeletion, "confirm", false, "Confirm repository deletion")
 
-	// Set default behavior to info command when no subcommand is specified
-	repositoryCmd.Run = repoInfoCmd.Run
+	// List command specific flags
+	repoListCmd.Flags().BoolVar(&repoPublic, "public", false, "Include public repositories")
+	repoListCmd.Flags().BoolVar(&repoStarred, "starred", false, "Only starred repositories")
+	repoListCmd.Flags().IntVar(&repoPage, "page", 1, "Page number")
+	repoListCmd.Flags().IntVar(&repoLimit, "limit", 10, "Maximum results per page")
+
+	// Change-visibility command specific flags
+	repoChangeVisibilityCmd.Flags().StringVarP(&repoVisibility, "visibility", "v", "", "New visibility (private/public)")
+	if err := repoChangeVisibilityCmd.MarkFlagRequired("visibility"); err != nil {
+		fmt.Printf("Error marking visibility flag as required: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,7 @@ func init() {
 	getCmd.AddCommand(messagesCmd)
 	getCmd.AddCommand(prototypeCmd)
 	getCmd.AddCommand(repotokenCmd)
+	getCmd.AddCommand(logsCmd)
 }
 
 // Execute executes the root command.

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -149,6 +149,27 @@ var tagRevertCmd = &cobra.Command{
 	},
 }
 
+var tagRestoreCmd = &cobra.Command{
+	Use:   "restore",
+	Short: "Restore a tag from a previous state",
+	Long:  `Restore a previously deleted or modified tag using its manifest digest.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.RestoreTag(namespace, repository, tagName, manifestDigest)
+		if err != nil {
+			fmt.Printf("Error restoring tag: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully restored tag %s/%s:%s from manifest %s\n", namespace, repository, tagName, manifestDigest)
+	},
+}
+
 func init() {
 	// Add subcommands to tag command
 	tagCmd.AddCommand(tagInfoCmd)
@@ -156,6 +177,7 @@ func init() {
 	tagCmd.AddCommand(tagDeleteCmd)
 	tagCmd.AddCommand(tagHistoryCmd)
 	tagCmd.AddCommand(tagRevertCmd)
+	tagCmd.AddCommand(tagRestoreCmd)
 
 	// Global tag flags (repository context)
 	tagCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
@@ -190,6 +212,13 @@ func init() {
 	// Revert command specific flags
 	tagRevertCmd.Flags().StringVarP(&manifestDigest, "manifest", "m", "", "Manifest digest to revert to")
 	if err := tagRevertCmd.MarkFlagRequired("manifest"); err != nil {
+		fmt.Printf("Error marking manifest flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Restore command specific flags
+	tagRestoreCmd.Flags().StringVarP(&manifestDigest, "manifest", "m", "", "Manifest digest to restore")
+	if err := tagRestoreCmd.MarkFlagRequired("manifest"); err != nil {
 		fmt.Printf("Error marking manifest flag as required: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -345,76 +345,69 @@ func init() {
 func initTeamGlobalFlags() {
 	teamCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
 	teamCmd.PersistentFlags().StringVarP(&teamCmdOrgname, "organization", "o", "", "Organization name")
-	markTeamFlagRequired(teamCmd.MarkPersistentFlagRequired("token"))
-	markTeamFlagRequired(teamCmd.MarkPersistentFlagRequired("organization"))
+	markFlagRequired(teamCmd.MarkPersistentFlagRequired("token"))
+	markFlagRequired(teamCmd.MarkPersistentFlagRequired("organization"))
 }
 
 func initTeamCmdFlags() {
 	// Info command flags
 	teamCmdInfoCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
-	markTeamFlagRequired(teamCmdInfoCmd.MarkFlagRequired("name"))
+	markFlagRequired(teamCmdInfoCmd.MarkFlagRequired("name"))
 
 	// Create command flags
 	teamCreateCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
 	teamCreateCmd.Flags().StringVarP(&teamCmdDescription, "description", "d", "", "Team description")
 	teamCreateCmd.Flags().StringVarP(&teamCmdRole, "role", "r", "member", "Team role (member, creator, admin)")
-	markTeamFlagRequired(teamCreateCmd.MarkFlagRequired("name"))
+	markFlagRequired(teamCreateCmd.MarkFlagRequired("name"))
 
 	// Update command flags
 	teamUpdateCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
 	teamUpdateCmd.Flags().StringVarP(&teamCmdDescription, "description", "d", "", "Team description")
 	teamUpdateCmd.Flags().StringVarP(&teamCmdRole, "role", "r", "", "Team role (member, creator, admin)")
-	markTeamFlagRequired(teamUpdateCmd.MarkFlagRequired("name"))
+	markFlagRequired(teamUpdateCmd.MarkFlagRequired("name"))
 
 	// Delete command flags
 	teamDeleteCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
 	teamDeleteCmd.Flags().BoolVar(&confirmTeamDelete, "confirm", false, "Confirm team deletion")
-	markTeamFlagRequired(teamDeleteCmd.MarkFlagRequired("name"))
+	markFlagRequired(teamDeleteCmd.MarkFlagRequired("name"))
 }
 
 func initTeamMemberCmdFlags() {
 	// Members command flags
 	teamCmdMembersCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
-	markTeamFlagRequired(teamCmdMembersCmd.MarkFlagRequired("name"))
+	markFlagRequired(teamCmdMembersCmd.MarkFlagRequired("name"))
 
 	// Add member command flags
 	teamAddMemberCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
 	teamAddMemberCmd.Flags().StringVarP(&teamCmdMemberName, "member", "m", "", "Member name (username or robot)")
-	markTeamFlagRequired(teamAddMemberCmd.MarkFlagRequired("name"))
-	markTeamFlagRequired(teamAddMemberCmd.MarkFlagRequired("member"))
+	markFlagRequired(teamAddMemberCmd.MarkFlagRequired("name"))
+	markFlagRequired(teamAddMemberCmd.MarkFlagRequired("member"))
 
 	// Remove member command flags
 	teamRemoveMemberCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
 	teamRemoveMemberCmd.Flags().StringVarP(&teamCmdMemberName, "member", "m", "", "Member name (username or robot)")
 	teamRemoveMemberCmd.Flags().BoolVar(&confirmTeamMemberDel, "confirm", false, "Confirm member removal")
-	markTeamFlagRequired(teamRemoveMemberCmd.MarkFlagRequired("name"))
-	markTeamFlagRequired(teamRemoveMemberCmd.MarkFlagRequired("member"))
+	markFlagRequired(teamRemoveMemberCmd.MarkFlagRequired("name"))
+	markFlagRequired(teamRemoveMemberCmd.MarkFlagRequired("member"))
 }
 
 func initTeamPermissionCmdFlags() {
 	// Permissions command flags
 	teamPermissionsCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
-	markTeamFlagRequired(teamPermissionsCmd.MarkFlagRequired("name"))
+	markFlagRequired(teamPermissionsCmd.MarkFlagRequired("name"))
 
 	// Set permission command flags
 	teamSetPermissionCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
 	teamSetPermissionCmd.Flags().StringVarP(&teamCmdRepository, "repository", "R", "", "Repository name")
 	teamSetPermissionCmd.Flags().StringVarP(&teamCmdPermissionRole, "role", "r", "", "Permission role (read, write, admin)")
-	markTeamFlagRequired(teamSetPermissionCmd.MarkFlagRequired("name"))
-	markTeamFlagRequired(teamSetPermissionCmd.MarkFlagRequired("repository"))
-	markTeamFlagRequired(teamSetPermissionCmd.MarkFlagRequired("role"))
+	markFlagRequired(teamSetPermissionCmd.MarkFlagRequired("name"))
+	markFlagRequired(teamSetPermissionCmd.MarkFlagRequired("repository"))
+	markFlagRequired(teamSetPermissionCmd.MarkFlagRequired("role"))
 
 	// Remove permission command flags
 	teamRemovePermissionCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
 	teamRemovePermissionCmd.Flags().StringVarP(&teamCmdRepository, "repository", "R", "", "Repository name")
 	teamRemovePermissionCmd.Flags().BoolVar(&confirmTeamPermDel, "confirm", false, "Confirm permission removal")
-	markTeamFlagRequired(teamRemovePermissionCmd.MarkFlagRequired("name"))
-	markTeamFlagRequired(teamRemovePermissionCmd.MarkFlagRequired("repository"))
-}
-
-func markTeamFlagRequired(err error) {
-	if err != nil {
-		fmt.Printf("Error marking flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	markFlagRequired(teamRemovePermissionCmd.MarkFlagRequired("name"))
+	markFlagRequired(teamRemovePermissionCmd.MarkFlagRequired("repository"))
 }

--- a/cmd/trigger.go
+++ b/cmd/trigger.go
@@ -27,6 +27,7 @@ var (
 	triggerUUID       string
 	triggerCommitSHA  string
 	triggerPullRobot  string
+	triggerBuildLimit int
 )
 
 // triggerCmd represents the trigger command
@@ -265,16 +266,42 @@ var triggerActivateCmd = &cobra.Command{
 	},
 }
 
+var triggerBuildsCmd = &cobra.Command{
+	Use:   "builds",
+	Short: "List builds for a trigger",
+	Long:  `List builds that were started by a specific trigger.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		if triggerUUID == "" {
+			fmt.Println("Error: --uuid is required")
+			os.Exit(1)
+		}
+
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Println("Error creating client:", err)
+			os.Exit(1)
+		}
+
+		builds, err := client.GetTriggerBuilds(triggerNamespace, triggerRepository, triggerUUID, triggerBuildLimit)
+		if err != nil {
+			fmt.Println("Error getting trigger builds:", err)
+			os.Exit(1)
+		}
+
+		printJSON(builds)
+	},
+}
+
 func setupTriggerFlags() {
 	// Common flags for all subcommands
-	for _, cmd := range []*cobra.Command{triggerListCmd, triggerInfoCmd, triggerDeleteCmd, triggerEnableCmd, triggerDisableCmd, triggerStartCmd, triggerActivateCmd} {
+	for _, cmd := range []*cobra.Command{triggerListCmd, triggerInfoCmd, triggerDeleteCmd, triggerEnableCmd, triggerDisableCmd, triggerStartCmd, triggerActivateCmd, triggerBuildsCmd} {
 		cmd.Flags().StringVarP(&triggerNamespace, "namespace", "n", "", "Namespace/organization")
 		cmd.Flags().StringVarP(&triggerRepository, "repository", "r", "", "Repository name")
 		cmd.Flags().StringVarP(&token, "token", "t", "", "Quay.io API token")
 	}
 
 	// UUID flags for subcommands that need it
-	for _, cmd := range []*cobra.Command{triggerInfoCmd, triggerDeleteCmd, triggerEnableCmd, triggerDisableCmd, triggerStartCmd, triggerActivateCmd} {
+	for _, cmd := range []*cobra.Command{triggerInfoCmd, triggerDeleteCmd, triggerEnableCmd, triggerDisableCmd, triggerStartCmd, triggerActivateCmd, triggerBuildsCmd} {
 		cmd.Flags().StringVar(&triggerUUID, "uuid", "", "UUID of the build trigger")
 	}
 
@@ -283,6 +310,9 @@ func setupTriggerFlags() {
 
 	// Activate command specific flags
 	triggerActivateCmd.Flags().StringVar(&triggerPullRobot, "pull-robot", "", "Robot account to use for pulling base images (optional)")
+
+	// Builds command specific flags
+	triggerBuildsCmd.Flags().IntVarP(&triggerBuildLimit, "limit", "l", 10, "Maximum number of builds to return")
 }
 
 func init() {
@@ -294,6 +324,7 @@ func init() {
 	triggerCmd.AddCommand(triggerDisableCmd)
 	triggerCmd.AddCommand(triggerStartCmd)
 	triggerCmd.AddCommand(triggerActivateCmd)
+	triggerCmd.AddCommand(triggerBuildsCmd)
 
 	// Setup flags
 	setupTriggerFlags()

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -111,12 +111,102 @@ var unstarRepoCmd = &cobra.Command{
 	},
 }
 
+var lookupUsername string
+
+var userLookupCmd = &cobra.Command{
+	Use:   "lookup",
+	Short: "Look up a user by username",
+	Long:  `Get information about a specific user by their username.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		user, err := client.GetUserByUsername(lookupUsername)
+		if err != nil {
+			fmt.Printf("Error looking up user: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(user)
+	},
+}
+
+var userMarketplaceCmd = &cobra.Command{
+	Use:   "marketplace",
+	Short: "Get user marketplace information",
+	Long:  `Get marketplace subscription information for the current user.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		marketplace, err := client.GetUserMarketplace()
+		if err != nil {
+			fmt.Printf("Error getting user marketplace info: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(marketplace)
+	},
+}
+
+var starUserRepoCmd = &cobra.Command{
+	Use:   "star-user",
+	Short: "Star a repository (user endpoint)",
+	Long:  `Add a repository to your starred list using the user star endpoint.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.StarUserRepository(namespace, repository)
+		if err != nil {
+			fmt.Printf("Error starring repository: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully starred repository %s/%s\n", namespace, repository)
+	},
+}
+
+var unstarUserRepoCmd = &cobra.Command{
+	Use:   "unstar-user",
+	Short: "Unstar a repository (user endpoint)",
+	Long:  `Remove a repository from your starred list using the user star endpoint.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.UnstarUserRepository(namespace, repository)
+		if err != nil {
+			fmt.Printf("Error unstarring repository: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully unstarred repository %s/%s\n", namespace, repository)
+	},
+}
+
 func init() {
 	// Add subcommands to user command
 	userCmd.AddCommand(userInfoCmd)
 	userCmd.AddCommand(userStarredCmd)
 	userCmd.AddCommand(starRepoCmd)
 	userCmd.AddCommand(unstarRepoCmd)
+	userCmd.AddCommand(userLookupCmd)
+	userCmd.AddCommand(userMarketplaceCmd)
+	userCmd.AddCommand(starUserRepoCmd)
+	userCmd.AddCommand(unstarUserRepoCmd)
 
 	// Global user flags
 	userCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
@@ -147,6 +237,37 @@ func init() {
 		os.Exit(1)
 	}
 	if err := unstarRepoCmd.MarkFlagRequired("repository"); err != nil {
+		fmt.Printf("Error marking repository flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Lookup command flags
+	userLookupCmd.Flags().StringVarP(&lookupUsername, "username", "u", "", "Username to look up")
+	if err := userLookupCmd.MarkFlagRequired("username"); err != nil {
+		fmt.Printf("Error marking username flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Star-user command flags
+	starUserRepoCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
+	starUserRepoCmd.Flags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
+	if err := starUserRepoCmd.MarkFlagRequired("namespace"); err != nil {
+		fmt.Printf("Error marking namespace flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	if err := starUserRepoCmd.MarkFlagRequired("repository"); err != nil {
+		fmt.Printf("Error marking repository flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Unstar-user command flags
+	unstarUserRepoCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
+	unstarUserRepoCmd.Flags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
+	if err := unstarUserRepoCmd.MarkFlagRequired("namespace"); err != nil {
+		fmt.Printf("Error marking namespace flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	if err := unstarUserRepoCmd.MarkFlagRequired("repository"); err != nil {
 		fmt.Printf("Error marking repository flag as required: %v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary
- Adds CLI commands for all 74 previously unexposed lib client methods, achieving full lib/cmd parity
- Extracts shared markFlagRequired() helper into cmd/helpers.go, removing 4 duplicate copies
- Adds --confirm safety checks on all destructive operations (including new delete-user-permission, delete-team-permission)
- Uses printJSON() consistently for output across all commands
- Restructures discovery and messages commands into proper parent command groups with subcommands

## Details by area
- **Organization** (39 commands): CRUD, member mgmt, robots, applications, marketplace, auto-prune, quota, proxy cache, default permissions, team invites
- **Permissions** (9 commands): User/team-level repository permission CRUD and transitive lookups
- **Logs** (8 commands): Repo/org/user log retrieval, aggregation, and export
- **User** (4 commands): Lookup by username, marketplace info, star/unstar via user endpoint
- **Repository** (2 commands): List repositories, change visibility
- **Build/Trigger** (2 commands): Build status, trigger builds listing
- **Discovery** (2 commands): App info lookup, entity search
- **Notification** (1 command): Update notification
- **Tag** (1 command): Restore tag
- **Messages** (1 command): Create system message
- **Billing** (1 fix): User invoices now calls actual lib function instead of returning empty array
- **Shared** (new file): cmd/helpers.go with unified markFlagRequired()

## Test plan
- [x] go build ./... passes
- [x] make lint — 0 issues
- [x] make test — all 90 tests pass
- [x] Verified zero remaining uncalled lib functions via automated gap check

Tracks: CNFCERT-1399