### PR TITLE
feat: add repo-aggregated-logs, date range filtering, and fix popularity field

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,80 +4,49 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-A comprehensive Go wrapper around Quay.io APIs. Provides both a CLI and a library for interacting with Quay container registries.
+A Go wrapper around the Quay.io REST API (`https://quay.io/api/v1`). Provides both a reusable library (`lib/`) and a CLI (`cmd/`) built with Cobra.
 
 ## Common Commands
 
-### Build
 ```bash
-make build
+make build                    # Build the go-quay binary
+make test                     # Run all unit tests (go test ./... -v)
+make lint                     # Run golangci-lint
+make vet                      # Run go vet
+make check-swagger-alignment  # Verify lib functions match Quay's Swagger spec
+go test ./lib/ -run TestCreateRepository -v  # Run a single test
 ```
 
-### Run
+Integration tests require `QUAY_TOKEN` and `QUAY_ORG` environment variables:
 ```bash
-./go-quay [command]
-```
-
-### Test
-```bash
-go test ./...
-make test
-```
-
-### Integration Test
-```bash
-# Requires QUAY_TOKEN and QUAY_ORG environment variables
 make integration-test
-```
-
-### Lint
-```bash
-make lint
-make vet
-```
-
-### Clean
-```bash
-make clean
-```
-
-### Check API Alignment
-```bash
-make check-swagger-alignment
 ```
 
 ## Architecture
 
-- **`cmd/`** - CLI command implementations using Cobra
-- **`lib/`** - Quay API client library with full API coverage
-- **`docs/`** - Documentation including library guide and tutorials
-- **`examples/`** - Runnable example programs
-- **`scripts/`** - Helper scripts for testing and validation
-- **`main.go`** - Application entry point
+### Two-layer design: lib → cmd
 
-## API Coverage
+Every API domain follows the same pattern:
 
-| API | Commands |
-|-----|----------|
-| Billing | user/plan, organization plans, invoices |
-| Build | repository builds, logs, request, cancel |
-| Discovery | API discovery endpoint |
-| Error | error type details |
-| Logs | aggregated logs, repository logs, organization logs |
-| Manifest | manifest info, labels (CRUD) |
-| Messages | system messages |
-| Organization | org details, members, teams, robots, quota, auto-prune, applications |
-| Permission | repository permissions (CRUD) |
-| Prototype | default permission prototypes |
-| Repository | CRUD operations, tags |
-| RepositoryNotification | webhooks for repository events |
-| Robot | user robots, permissions, regenerate |
-| Search | repository search, global search |
-| SecScan | security scanning results |
-| Tag | tag info, history, update, delete, revert |
-| Team | team CRUD, members, permissions |
-| Trigger | build triggers |
-| User | user info, starred repositories |
+1. **`lib/<domain>.go`** — API client methods on `*Client`. Each file's doc comment lists the HTTP endpoints it covers. All methods use the shared HTTP helpers in `client.go` (`get`, `post`, `put`, `delete`) and build URLs from the package-level `QuayURL` variable.
+
+2. **`lib/structs.go`** — All request/response types for the entire API in one file, with JSON tags matching the Quay API.
+
+3. **`cmd/<domain>.go`** — Cobra commands that parse flags, call `lib.NewClient(token)`, invoke the lib method, and print JSON output via `printJSON()`. Commands are registered in `cmd/root.go` under the `get` parent command.
+
+### Key patterns
+
+- **`lib.QuayURL`** is a package-level `var` (not `const`) set to `https://quay.io/api/v1` in `lib/logs.go`. Tests override it by pointing to `httptest.NewServer` and restoring with `defer`.
+- **`lib.NewClient(bearerToken)`** creates an authenticated client. The token is passed via `--token` / `-t` flag in CLI commands.
+- CLI commands use persistent flags (`--namespace`, `--repository`, `--token`) on parent commands so subcommands inherit them.
+- The `cmd/helpers.go` file contains shared CLI utilities like `markFlagRequired()`.
+
+### Adding a new API endpoint
+
+1. Add request/response structs to `lib/structs.go`
+2. Add client method(s) to `lib/<domain>.go` following the existing pattern
+3. Add unit tests to `lib/<domain>_test.go` using `httptest.NewServer` with the `QuayURL` override pattern
+4. Add Cobra command in `cmd/<domain>.go` and register it in `cmd/root.go`
 
 ## Configuration
 
@@ -89,10 +58,4 @@ export QUAY_TOKEN="your-token"
 ## Requirements
 
 - Go 1.26+
-- Quay.io API token with appropriate permissions
-
-## Code Style
-
-- Follow standard Go conventions
-- Use `go fmt` before committing
-- Run `golangci-lint` for linting (config in `.golangci.yml`)
+- golangci-lint (for `make lint`)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The following APIs are covered by the repo. Each API links to the corresponding 
 | [Discovery](https://docs.quay.io/api/swagger/#Discovery)              | Yes     | Yes     | /api/v1/discovery |
 | [Error](https://docs.quay.io/api/swagger/#Error)                  | Yes     | Yes     | /api/v1/error/{error_type} |
 | [Messages](https://docs.quay.io/api/swagger/#Messages)               | Yes     | Yes     | /api/v1/messages |
-| [Logs](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--aggregatelogs-get)                   | Partial | Partial | /api/v1/repository/{namespace}/{repository}/aggregatelogs, /api/v1/repository/{namespace}/{repository}/logs, /api/v1/organization/{orgname}/logs |
+| [Logs](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--aggregatelogs-get)                   | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/aggregatelogs, /api/v1/repository/{namespace}/{repository}/logs, /api/v1/organization/{orgname}/logs, /api/v1/organization/{orgname}/aggregatelogs, /api/v1/user/logs, /api/v1/user/aggregatelogs |
 | [Manifest](https://docs.quay.io/api/swagger/#Manifest)               | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}, /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/labels, /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/labels/{labelid} |
 | [Organization](https://docs.quay.io/api/swagger/#operation--api-v1-organization--orgname--get)           | Yes     | Yes     | /api/v1/organization/{orgname}, /api/v1/organization/{orgname}/members, /api/v1/organization/{orgname}/teams, /api/v1/organization/{orgname}/team/{teamname}, /api/v1/organization/{orgname}/robots, /api/v1/organization/{orgname}/quota, /api/v1/organization/{orgname}/autoprunepolicy, /api/v1/organization/{orgname}/applications |
 | [Permission](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--permissions-get)             | Yes     | Yes     | /api/v1/repository/{namespace}/{repository}/permissions, /api/v1/repository/{namespace}/{repository}/permissions/{username} |
@@ -374,29 +374,43 @@ The notification API allows you to manage webhooks for repository events.
 
 ### Logs API
 
-The logs API provides access to repository activity logs and aggregated statistics.
+The logs API provides access to repository, organization, and user activity logs with optional date range filtering.
 
 📖 **API Reference:** [Logs endpoints in Swagger](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--aggregatelogs-get)
 
 #### Get aggregated repository logs
 ```bash
-# Get logs for the last 7 days
-./go-quay get aggregatedlogs \
-  --namespace NAMESPACE \
-  --repository REPOSITORY \
-  --startdate "01/01/2024" \
-  --enddate "01/07/2024" \
-  --token YOUR_TOKEN
+./go-quay get logs repo-aggregated-logs \
+  -n NAMESPACE \
+  -r REPOSITORY \
+  -s "2024-01-01" \
+  -e "2024-01-07" \
+  -t YOUR_TOKEN
 ```
 
-#### Example with specific dates
+#### Get repository logs with date filtering
 ```bash
-./go-quay get aggregatedlogs \
-  -n quay \
-  -r my-app \
-  -s "12/01/2023" \
-  -e "12/31/2023" \
+./go-quay get logs repo-logs \
+  -n NAMESPACE \
+  -r REPOSITORY \
+  --startdate "2024-05-01" \
+  --enddate "2024-05-31" \
   -t YOUR_TOKEN
+```
+
+#### Get organization and user logs
+```bash
+# Organization logs
+./go-quay get logs org-logs -o ORG_NAME -t YOUR_TOKEN
+
+# Organization aggregated logs
+./go-quay get logs org-aggregated-logs -o ORG_NAME -s "2024-01-01" -e "2024-01-31" -t YOUR_TOKEN
+
+# User logs
+./go-quay get logs user-logs -t YOUR_TOKEN
+
+# User aggregated logs
+./go-quay get logs user-aggregated-logs -s "2024-01-01" -e "2024-01-31" -t YOUR_TOKEN
 ```
 
 ### Repository API

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -39,7 +39,7 @@ Available commands:
 
 // Build List
 var buildListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   subcmdList,
 	Short: "List builds for a repository",
 	Long:  `List all builds for the specified repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -62,7 +62,7 @@ var buildListCmd = &cobra.Command{
 
 // Build Info
 var buildInfoCmd = &cobra.Command{
-	Use:   "info",
+	Use:   subcmdInfo,
 	Short: "Get build details",
 	Long:  `Get detailed information about a specific build.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -1,0 +1,10 @@
+package cmd
+
+const (
+	subcmdInfo        = "info"
+	subcmdList        = "list"
+	subcmdCreate      = "create"
+	subcmdUpdate      = "update"
+	subcmdDelete      = "delete"
+	subcmdPermissions = "permissions"
+)

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -22,40 +21,6 @@ var (
 	callbackEmail string
 )
 
-var aggregatedLogsCmd = &cobra.Command{
-	Use:   "aggregatedlogs",
-	Short: "Get aggregated logs from Quay.io",
-	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			return
-		}
-
-		logs, err := client.GetAggregatedLogs(namespace, repository, startdate, enddate)
-		if err != nil {
-			fmt.Println("Error getting aggregated logs:", err)
-			return
-		}
-
-		jsonOutput, err := json.Marshal(logs)
-		if err != nil {
-			fmt.Println("Error marshaling JSON:", err)
-			return
-		}
-
-		fmt.Println(string(jsonOutput))
-	},
-}
-
-func init() {
-	aggregatedLogsCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
-	aggregatedLogsCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
-	aggregatedLogsCmd.PersistentFlags().StringVarP(&startdate, "startdate", "s", "", "Start date for the logs")
-	aggregatedLogsCmd.PersistentFlags().StringVarP(&enddate, "enddate", "e", "", "End date for the logs")
-	aggregatedLogsCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
-}
-
 // logsCmd is the parent command group for log management
 var logsCmd = &cobra.Command{
 	Use:   "logs",
@@ -73,9 +38,30 @@ var repoLogsCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		logs, err := client.GetLogs(namespace, repository, nextPage)
+		logs, err := client.GetLogs(namespace, repository, nextPage, startdate, enddate)
 		if err != nil {
 			fmt.Printf("Error getting repository logs: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(logs)
+	},
+}
+
+var repoAggregatedLogsCmd = &cobra.Command{
+	Use:   "repo-aggregated-logs",
+	Short: "Get aggregated repository logs",
+	Long:  `Get aggregated action logs for a specific repository.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClient(token)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		logs, err := client.GetAggregatedLogs(namespace, repository, startdate, enddate)
+		if err != nil {
+			fmt.Printf("Error getting repository aggregated logs: %v\n", err)
 			os.Exit(1)
 		}
 
@@ -94,7 +80,7 @@ var orgLogsCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		logs, err := client.GetOrganizationLogs(orgName, nextPage)
+		logs, err := client.GetOrganizationLogs(orgName, nextPage, startdate, enddate)
 		if err != nil {
 			fmt.Printf("Error getting organization logs: %v\n", err)
 			os.Exit(1)
@@ -136,7 +122,7 @@ var userLogsCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		logs, err := client.GetUserLogs(nextPage)
+		logs, err := client.GetUserLogs(nextPage, startdate, enddate)
 		if err != nil {
 			fmt.Printf("Error getting user logs: %v\n", err)
 			os.Exit(1)
@@ -247,6 +233,7 @@ var exportRepoLogsCmd = &cobra.Command{
 
 func init() {
 	logsCmd.AddCommand(repoLogsCmd)
+	logsCmd.AddCommand(repoAggregatedLogsCmd)
 	logsCmd.AddCommand(orgLogsCmd)
 	logsCmd.AddCommand(orgAggregatedLogsCmd)
 	logsCmd.AddCommand(userLogsCmd)
@@ -261,10 +248,20 @@ func init() {
 	repoLogsCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Repository namespace")
 	repoLogsCmd.Flags().StringVarP(&repository, "repository", "r", "", "Repository name")
 	repoLogsCmd.Flags().StringVar(&nextPage, "next-page", "", "Next page token for pagination")
+	repoLogsCmd.Flags().StringVarP(&startdate, "startdate", "s", "", "Start date for the logs")
+	repoLogsCmd.Flags().StringVarP(&enddate, "enddate", "e", "", "End date for the logs")
+
+	// repo-aggregated-logs flags
+	repoAggregatedLogsCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Repository namespace")
+	repoAggregatedLogsCmd.Flags().StringVarP(&repository, "repository", "r", "", "Repository name")
+	repoAggregatedLogsCmd.Flags().StringVarP(&startdate, "startdate", "s", "", "Start date")
+	repoAggregatedLogsCmd.Flags().StringVarP(&enddate, "enddate", "e", "", "End date")
 
 	// org-logs flags
 	orgLogsCmd.Flags().StringVarP(&orgName, "organization", "o", "", "Organization name")
 	orgLogsCmd.Flags().StringVar(&nextPage, "next-page", "", "Next page token for pagination")
+	orgLogsCmd.Flags().StringVarP(&startdate, "startdate", "s", "", "Start date for the logs")
+	orgLogsCmd.Flags().StringVarP(&enddate, "enddate", "e", "", "End date for the logs")
 
 	// org-aggregated-logs flags
 	orgAggregatedLogsCmd.Flags().StringVarP(&orgName, "organization", "o", "", "Organization name")
@@ -273,6 +270,8 @@ func init() {
 
 	// user-logs flags
 	userLogsCmd.Flags().StringVar(&nextPage, "next-page", "", "Next page token for pagination")
+	userLogsCmd.Flags().StringVarP(&startdate, "startdate", "s", "", "Start date for the logs")
+	userLogsCmd.Flags().StringVarP(&enddate, "enddate", "e", "", "End date for the logs")
 
 	// user-aggregated-logs flags
 	userAggregatedLogsCmd.Flags().StringVarP(&startdate, "startdate", "s", "", "Start date")

--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -34,7 +34,7 @@ Available commands:
 
 // Manifest Info
 var manifestInfoCmd = &cobra.Command{
-	Use:   "info",
+	Use:   subcmdInfo,
 	Short: "Get detailed manifest information",
 	Long:  `Get detailed information about a specific manifest including layers, config, and metadata.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -57,7 +57,7 @@ var manifestInfoCmd = &cobra.Command{
 
 // Manifest Delete
 var manifestDeleteCmd = &cobra.Command{
-	Use:   "delete",
+	Use:   subcmdDelete,
 	Short: "Delete a manifest",
 	Long:  `Delete a specific manifest from the repository. This action cannot be undone.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -20,7 +20,7 @@ var messagesCmd = &cobra.Command{
 }
 
 var messagesListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   subcmdList,
 	Short: "Get system messages",
 	Long:  `Get system-wide messages including maintenance notifications and announcements.`,
 	Run: func(_ *cobra.Command, _ []string) {
@@ -41,7 +41,7 @@ var messagesListCmd = &cobra.Command{
 }
 
 var messagesCreateCmd = &cobra.Command{
-	Use:   "create",
+	Use:   subcmdCreate,
 	Short: "Create a system message",
 	Long:  `Create a new system-wide message.`,
 	Run: func(_ *cobra.Command, _ []string) {

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -53,7 +53,7 @@ Available commands:
 
 // Notification List
 var notificationListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   subcmdList,
 	Short: "List notifications for a repository",
 	Long:  `List all notifications (webhooks) for the specified repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -76,7 +76,7 @@ var notificationListCmd = &cobra.Command{
 
 // Notification Info
 var notificationInfoCmd = &cobra.Command{
-	Use:   "info",
+	Use:   subcmdInfo,
 	Short: "Get notification details",
 	Long:  `Get detailed information about a specific notification.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -99,7 +99,7 @@ var notificationInfoCmd = &cobra.Command{
 
 // Notification Create
 var notificationCreateCmd = &cobra.Command{
-	Use:   "create",
+	Use:   subcmdCreate,
 	Short: "Create a new notification",
 	Long: `Create a new notification (webhook) for the repository.
 
@@ -143,7 +143,7 @@ For slack method, provide the --url flag with the Slack webhook URL.`,
 
 // Notification Delete
 var notificationDeleteCmd = &cobra.Command{
-	Use:   "delete",
+	Use:   subcmdDelete,
 	Short: "Delete a notification",
 	Long:  `Delete a notification from the repository. This action cannot be undone.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -214,7 +214,7 @@ var notificationResetCmd = &cobra.Command{
 }
 
 var notificationUpdateCmd = &cobra.Command{
-	Use:   "update",
+	Use:   subcmdUpdate,
 	Short: "Update a notification",
 	Long:  `Update an existing notification (webhook) configuration.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -58,7 +58,7 @@ Available commands:
 
 // Organization Info
 var orgInfoCmd = &cobra.Command{
-	Use:   "info",
+	Use:   subcmdInfo,
 	Short: "Get organization information",
 	Long:  `Get detailed information about an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/permissions.go
+++ b/cmd/permissions.go
@@ -17,7 +17,7 @@ var (
 
 // permissionsCmd represents the permissions command group
 var permissionsCmd = &cobra.Command{
-	Use:   "permissions",
+	Use:   subcmdPermissions,
 	Short: "Repository permissions management commands",
 	Long: `Commands for managing repository permissions including listing, setting, and removing user/robot access.
 
@@ -31,7 +31,7 @@ Supported roles: read, write, admin`,
 
 // Permissions List
 var permListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   subcmdList,
 	Short: "List repository permissions",
 	Long:  `List all users and robots that have permissions on this repository.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -41,7 +41,7 @@ templates for users, teams, or robot accounts.`,
 
 // prototypeListCmd lists all prototypes
 var prototypeListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   subcmdList,
 	Short: "List all permission prototypes",
 	Long:  `List all permission prototypes for an organization.`,
 	Run: func(_ *cobra.Command, _ []string) {
@@ -68,7 +68,7 @@ var prototypeListCmd = &cobra.Command{
 
 // prototypeInfoCmd gets a specific prototype
 var prototypeInfoCmd = &cobra.Command{
-	Use:   "info",
+	Use:   subcmdInfo,
 	Short: "Get a specific prototype",
 	Long:  `Get detailed information about a specific permission prototype.`,
 	Run: func(_ *cobra.Command, _ []string) {
@@ -100,7 +100,7 @@ var prototypeInfoCmd = &cobra.Command{
 
 // prototypeCreateCmd creates a new prototype
 var prototypeCreateCmd = &cobra.Command{
-	Use:   "create",
+	Use:   subcmdCreate,
 	Short: "Create a new prototype",
 	Long: `Create a new permission prototype for an organization.
 
@@ -158,7 +158,7 @@ Roles:
 
 // prototypeUpdateCmd updates a prototype
 var prototypeUpdateCmd = &cobra.Command{
-	Use:   "update",
+	Use:   subcmdUpdate,
 	Short: "Update a prototype",
 	Long:  `Update an existing permission prototype's role.`,
 	Run: func(_ *cobra.Command, _ []string) {
@@ -198,7 +198,7 @@ var prototypeUpdateCmd = &cobra.Command{
 
 // prototypeDeleteCmd deletes a prototype
 var prototypeDeleteCmd = &cobra.Command{
-	Use:   "delete",
+	Use:   subcmdDelete,
 	Short: "Delete a prototype",
 	Long:  `Delete a permission prototype from an organization.`,
 	Run: func(_ *cobra.Command, _ []string) {

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -33,7 +33,7 @@ Available commands:
 
 // Repository Info (existing functionality)
 var repoInfoCmd = &cobra.Command{
-	Use:   "info",
+	Use:   subcmdInfo,
 	Short: "Get repository information from Quay.io",
 	Run: func(cmd *cobra.Command, args []string) {
 		if repository == "" {
@@ -59,7 +59,7 @@ var repoInfoCmd = &cobra.Command{
 
 // Repository Creation
 var repoCreateCmd = &cobra.Command{
-	Use:   "create",
+	Use:   subcmdCreate,
 	Short: "Create a new repository",
 	Long:  `Create a new repository in the specified namespace with optional description and visibility settings.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -87,7 +87,7 @@ var repoCreateCmd = &cobra.Command{
 
 // Repository Update
 var repoUpdateCmd = &cobra.Command{
-	Use:   "update",
+	Use:   subcmdUpdate,
 	Short: "Update repository settings",
 	Long:  `Update repository description and/or visibility settings.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -115,7 +115,7 @@ var repoUpdateCmd = &cobra.Command{
 
 // Repository Deletion
 var repoDeleteCmd = &cobra.Command{
-	Use:   "delete",
+	Use:   subcmdDelete,
 	Short: "Delete a repository",
 	Long:  `Delete a repository. This action is irreversible and will remove all images and tags.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -147,7 +147,7 @@ var repoDeleteCmd = &cobra.Command{
 }
 
 var repoListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   subcmdList,
 	Short: "List repositories in a namespace",
 	Long:  `List all repositories in a namespace with optional filters.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/repotoken.go
+++ b/cmd/repotoken.go
@@ -42,7 +42,7 @@ better security, auditing, and permission management.`,
 
 // repotokenListCmd lists all tokens
 var repotokenListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   subcmdList,
 	Short: "List all repository tokens",
 	Long:  `List all tokens for a repository. (DEPRECATED - use robot accounts)`,
 	Run: func(_ *cobra.Command, _ []string) {
@@ -69,7 +69,7 @@ var repotokenListCmd = &cobra.Command{
 
 // repotokenInfoCmd gets a specific token
 var repotokenInfoCmd = &cobra.Command{
-	Use:   "info",
+	Use:   subcmdInfo,
 	Short: "Get a specific token",
 	Long:  `Get detailed information about a specific repository token. (DEPRECATED - use robot accounts)`,
 	Run: func(_ *cobra.Command, _ []string) {
@@ -101,7 +101,7 @@ var repotokenInfoCmd = &cobra.Command{
 
 // repotokenCreateCmd creates a new token
 var repotokenCreateCmd = &cobra.Command{
-	Use:   "create",
+	Use:   subcmdCreate,
 	Short: "Create a new token",
 	Long:  `Create a new repository token. (DEPRECATED - use robot accounts)`,
 	Run: func(_ *cobra.Command, _ []string) {
@@ -137,7 +137,7 @@ var repotokenCreateCmd = &cobra.Command{
 
 // repotokenUpdateCmd updates a token
 var repotokenUpdateCmd = &cobra.Command{
-	Use:   "update",
+	Use:   subcmdUpdate,
 	Short: "Update a token",
 	Long:  `Update a repository token's role. (DEPRECATED - use robot accounts)`,
 	Run: func(_ *cobra.Command, _ []string) {
@@ -177,7 +177,7 @@ var repotokenUpdateCmd = &cobra.Command{
 
 // repotokenDeleteCmd deletes a token
 var repotokenDeleteCmd = &cobra.Command{
-	Use:   "delete",
+	Use:   subcmdDelete,
 	Short: "Delete a token",
 	Long:  `Delete a repository token. (DEPRECATED - use robot accounts)`,
 	Run: func(_ *cobra.Command, _ []string) {

--- a/cmd/robot.go
+++ b/cmd/robot.go
@@ -34,7 +34,7 @@ Available commands:
 
 // Robot List
 var robotListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   subcmdList,
 	Short: "List all robot accounts",
 	Long:  `List all robot accounts associated with your user account.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -57,7 +57,7 @@ var robotListCmd = &cobra.Command{
 
 // Robot Info
 var robotInfoCmd = &cobra.Command{
-	Use:   "info",
+	Use:   subcmdInfo,
 	Short: "Get robot account details",
 	Long:  `Get detailed information about a specific robot account including its token.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -80,7 +80,7 @@ var robotInfoCmd = &cobra.Command{
 
 // Robot Create
 var robotCreateCmd = &cobra.Command{
-	Use:   "create",
+	Use:   subcmdCreate,
 	Short: "Create a new robot account",
 	Long:  `Create a new robot account with the specified name and description.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -104,7 +104,7 @@ var robotCreateCmd = &cobra.Command{
 
 // Robot Delete
 var robotDeleteCmd = &cobra.Command{
-	Use:   "delete",
+	Use:   subcmdDelete,
 	Short: "Delete a robot account",
 	Long:  `Delete a robot account. This action cannot be undone.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -156,7 +156,7 @@ var robotRegenerateCmd = &cobra.Command{
 
 // Robot Permissions
 var robotPermissionsCmd = &cobra.Command{
-	Use:   "permissions",
+	Use:   subcmdPermissions,
 	Short: "Get robot repository permissions",
 	Long:  `Get the repository permissions assigned to a robot account.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,6 @@ var getCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(getCmd)
-	getCmd.AddCommand(aggregatedLogsCmd)
 	getCmd.AddCommand(repositoryCmd)
 	getCmd.AddCommand(billingCmd)
 	getCmd.AddCommand(organizationCmd)

--- a/cmd/secscan.go
+++ b/cmd/secscan.go
@@ -28,7 +28,7 @@ Available commands:
 
 // SecScan Info
 var secscanInfoCmd = &cobra.Command{
-	Use:   "info",
+	Use:   subcmdInfo,
 	Short: "Get security scan results for a manifest",
 	Long: `Get security scan results for a specific manifest including vulnerability information.
 

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -31,7 +31,7 @@ Available commands:
 
 // Tag Info
 var tagInfoCmd = &cobra.Command{
-	Use:   "info",
+	Use:   subcmdInfo,
 	Short: "Get detailed tag information",
 	Long:  `Get detailed information about a specific tag including metadata, manifest digest, and size.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -54,7 +54,7 @@ var tagInfoCmd = &cobra.Command{
 
 // Tag Update
 var tagUpdateCmd = &cobra.Command{
-	Use:   "update",
+	Use:   subcmdUpdate,
 	Short: "Update tag metadata",
 	Long:  `Update tag metadata such as expiration date.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -77,7 +77,7 @@ var tagUpdateCmd = &cobra.Command{
 
 // Tag Delete
 var tagDeleteCmd = &cobra.Command{
-	Use:   "delete",
+	Use:   subcmdDelete,
 	Short: "Delete a tag",
 	Long:  `Delete a specific tag from the repository. This action cannot be undone.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -45,7 +45,7 @@ Available commands:
 
 // Team List
 var teamListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   subcmdList,
 	Short: "List all teams in an organization",
 	Long:  `List all teams within the specified organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -68,7 +68,7 @@ var teamListCmd = &cobra.Command{
 
 // Team Info
 var teamCmdInfoCmd = &cobra.Command{
-	Use:   "info",
+	Use:   subcmdInfo,
 	Short: "Get team details",
 	Long:  `Get detailed information about a specific team.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -91,7 +91,7 @@ var teamCmdInfoCmd = &cobra.Command{
 
 // Team Create
 var teamCreateCmd = &cobra.Command{
-	Use:   "create",
+	Use:   subcmdCreate,
 	Short: "Create a new team",
 	Long: `Create a new team within an organization.
 
@@ -119,7 +119,7 @@ Roles:
 
 // Team Update
 var teamUpdateCmd = &cobra.Command{
-	Use:   "update",
+	Use:   subcmdUpdate,
 	Short: "Update team settings",
 	Long:  `Update team description and role.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -142,7 +142,7 @@ var teamUpdateCmd = &cobra.Command{
 
 // Team Delete
 var teamDeleteCmd = &cobra.Command{
-	Use:   "delete",
+	Use:   subcmdDelete,
 	Short: "Delete a team",
 	Long:  `Delete a team from an organization. This action cannot be undone.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -243,7 +243,7 @@ var teamRemoveMemberCmd = &cobra.Command{
 
 // Team Permissions
 var teamPermissionsCmd = &cobra.Command{
-	Use:   "permissions",
+	Use:   subcmdPermissions,
 	Short: "List team repository permissions",
 	Long:  `List all repository permissions for a team.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/trigger.go
+++ b/cmd/trigger.go
@@ -42,7 +42,7 @@ connected source repositories like GitHub, GitLab, or Bitbucket.`,
 
 // triggerListCmd represents the trigger list command
 var triggerListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   subcmdList,
 	Short: "List all build triggers for a repository",
 	Long:  `List all build triggers configured for a repository.`,
 	Run: func(_ *cobra.Command, _ []string) {
@@ -69,7 +69,7 @@ var triggerListCmd = &cobra.Command{
 
 // triggerInfoCmd represents the trigger info command
 var triggerInfoCmd = &cobra.Command{
-	Use:   "info",
+	Use:   subcmdInfo,
 	Short: "Get details of a specific build trigger",
 	Long:  `Get detailed information about a specific build trigger by its UUID.`,
 	Run: func(_ *cobra.Command, _ []string) {
@@ -101,7 +101,7 @@ var triggerInfoCmd = &cobra.Command{
 
 // triggerDeleteCmd represents the trigger delete command
 var triggerDeleteCmd = &cobra.Command{
-	Use:   "delete",
+	Use:   subcmdDelete,
 	Short: "Delete a build trigger",
 	Long:  `Delete a build trigger from a repository.`,
 	Run: func(_ *cobra.Command, _ []string) {

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -23,7 +23,7 @@ Available commands:
 
 // User Info
 var userInfoCmd = &cobra.Command{
-	Use:   "info",
+	Use:   subcmdInfo,
 	Short: "Get current user information",
 	Long:  `Get detailed information about the currently authenticated user account.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/lib/build_test.go
+++ b/lib/build_test.go
@@ -8,14 +8,8 @@ import (
 )
 
 const (
-	httpGetBuild    = "GET"
-	httpPostBuild   = "POST"
-	httpDeleteBuild = "DELETE"
-
-	testBuildNamespace  = "testorg"
-	testBuildRepository = "testrepo"
-	testBuildUUID       = "build-uuid-123"
-	testBuildPhase      = "complete"
+	testBuildUUID  = "build-uuid-123"
+	testBuildPhase = "complete"
 )
 
 func TestGetBuilds(t *testing.T) {
@@ -28,10 +22,10 @@ func TestGetBuilds(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetBuild {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testBuildNamespace + "/" + testBuildRepository + "/build/"
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/build/"
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -49,7 +43,7 @@ func TestGetBuilds(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	builds, err := client.GetBuilds(testBuildNamespace, testBuildRepository, 0)
+	builds, err := client.GetBuilds(testNamespace, testRepository, 0)
 	if err != nil {
 		t.Fatalf("GetBuilds returned error: %v", err)
 	}
@@ -67,15 +61,15 @@ func TestGetBuild(t *testing.T) {
 		ID:          testBuildUUID,
 		Phase:       testBuildPhase,
 		DisplayName: "Test Build",
-		Started:     "2024-01-15T10:30:00Z",
+		Started:     testTimestamp,
 	}
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetBuild {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testBuildNamespace + "/" + testBuildRepository + "/build/" + testBuildUUID
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/build/" + testBuildUUID
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -93,7 +87,7 @@ func TestGetBuild(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	build, err := client.GetBuild(testBuildNamespace, testBuildRepository, testBuildUUID)
+	build, err := client.GetBuild(testNamespace, testRepository, testBuildUUID)
 	if err != nil {
 		t.Fatalf("GetBuild returned error: %v", err)
 	}
@@ -118,10 +112,10 @@ func TestGetBuildLogs(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetBuild {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testBuildNamespace + "/" + testBuildRepository + "/build/" + testBuildUUID + "/logs"
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/build/" + testBuildUUID + "/logs"
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -139,7 +133,7 @@ func TestGetBuildLogs(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	logs, err := client.GetBuildLogs(testBuildNamespace, testBuildRepository, testBuildUUID)
+	logs, err := client.GetBuildLogs(testNamespace, testRepository, testBuildUUID)
 	if err != nil {
 		t.Fatalf("GetBuildLogs returned error: %v", err)
 	}
@@ -156,15 +150,15 @@ func TestRequestBuild(t *testing.T) {
 	mockResponse := Build{
 		ID:    testBuildUUID,
 		Phase: "waiting",
-		Tags:  []string{"latest"},
+		Tags:  []string{testTagNameLatest},
 	}
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPostBuild {
+		if r.Method != httpMethodPost {
 			t.Errorf("Expected POST request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testBuildNamespace + "/" + testBuildRepository + "/build/"
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/build/"
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -185,10 +179,10 @@ func TestRequestBuild(t *testing.T) {
 
 	buildReq := &RequestBuildRequest{
 		ArchiveURL: "https://example.com/archive.tar.gz",
-		Tags:       []string{"latest"},
+		Tags:       []string{testTagNameLatest},
 	}
 
-	build, err := client.RequestBuild(testBuildNamespace, testBuildRepository, buildReq)
+	build, err := client.RequestBuild(testNamespace, testRepository, buildReq)
 	if err != nil {
 		t.Fatalf("RequestBuild returned error: %v", err)
 	}
@@ -200,10 +194,10 @@ func TestRequestBuild(t *testing.T) {
 
 func TestCancelBuild(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpDeleteBuild {
+		if r.Method != httpMethodDelete {
 			t.Errorf("Expected DELETE request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testBuildNamespace + "/" + testBuildRepository + "/build/" + testBuildUUID
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/build/" + testBuildUUID
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -220,7 +214,7 @@ func TestCancelBuild(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.CancelBuild(testBuildNamespace, testBuildRepository, testBuildUUID)
+	err = client.CancelBuild(testNamespace, testRepository, testBuildUUID)
 	if err != nil {
 		t.Fatalf("CancelBuild returned error: %v", err)
 	}
@@ -241,7 +235,7 @@ func TestGetBuildsError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetBuilds(testBuildNamespace, testBuildRepository, 0)
+	_, err = client.GetBuilds(testNamespace, testRepository, 0)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -262,7 +256,7 @@ func TestGetBuildError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetBuild(testBuildNamespace, testBuildRepository, "nonexistent-uuid")
+	_, err = client.GetBuild(testNamespace, testRepository, "nonexistent-uuid")
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}

--- a/lib/discovery_test.go
+++ b/lib/discovery_test.go
@@ -7,10 +7,6 @@ import (
 	"testing"
 )
 
-const (
-	httpGetDiscovery = "GET"
-)
-
 func TestGetDiscovery(t *testing.T) {
 	mockResponse := Discovery{
 		Version: "v1",
@@ -25,7 +21,7 @@ func TestGetDiscovery(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetDiscovery {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/discovery"

--- a/lib/error_test.go
+++ b/lib/error_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 const (
-	httpGetError  = "GET"
 	testErrorType = "invalid_token"
 )
 
@@ -22,7 +21,7 @@ func TestGetErrorType(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetError {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/error/" + testErrorType

--- a/lib/logs.go
+++ b/lib/logs.go
@@ -19,6 +19,11 @@ import (
 	"net/http"
 )
 
+const (
+	startTimeParam = "starttime"
+	endTimeParam   = "endtime"
+)
+
 var (
 	QuayURL = "https://quay.io/api/v1"
 )
@@ -32,6 +37,23 @@ func addQueryParams(req *http.Request, params map[string]string) {
 	req.URL.RawQuery = q.Encode()
 }
 
+// addLogQueryParams adds optional pagination and date range params to a log request.
+func addLogQueryParams(req *http.Request, nextPage, startDate, endDate string) {
+	params := map[string]string{}
+	if nextPage != "" {
+		params["next_page"] = nextPage
+	}
+	if startDate != "" {
+		params[startTimeParam] = startDate
+	}
+	if endDate != "" {
+		params[endTimeParam] = endDate
+	}
+	if len(params) > 0 {
+		addQueryParams(req, params)
+	}
+}
+
 // GetAggregatedLogs returns the aggregated logs for a repository
 func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate string) (*AggregatedLogs, error) {
 	// Get new request
@@ -42,8 +64,8 @@ func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate str
 
 	// Set query parameters
 	addQueryParams(req, map[string]string{
-		"starttime": startDate,
-		"endtime":   endDate,
+		startTimeParam: startDate,
+		endTimeParam:   endDate,
 	})
 
 	var logs AggregatedLogs
@@ -55,16 +77,13 @@ func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate str
 }
 
 // GetLogs returns the logs for a repository
-func (c *Client) GetLogs(namespace, repository, nextPage string) (*Logs, error) {
+func (c *Client) GetLogs(namespace, repository, nextPage, startDate, endDate string) (*Logs, error) {
 	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/logs", QuayURL, namespace, repository), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	// Set query parameters
-	if nextPage != "" {
-		addQueryParams(req, map[string]string{"next_page": nextPage})
-	}
+	addLogQueryParams(req, nextPage, startDate, endDate)
 
 	var logs Logs
 	if err := c.get(req, &logs); err != nil {
@@ -75,15 +94,13 @@ func (c *Client) GetLogs(namespace, repository, nextPage string) (*Logs, error) 
 }
 
 // GetOrganizationLogs returns the logs for an organization
-func (c *Client) GetOrganizationLogs(orgname, nextPage string) (*Logs, error) {
+func (c *Client) GetOrganizationLogs(orgname, nextPage, startDate, endDate string) (*Logs, error) {
 	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/logs", QuayURL, orgname), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	if nextPage != "" {
-		addQueryParams(req, map[string]string{"next_page": nextPage})
-	}
+	addLogQueryParams(req, nextPage, startDate, endDate)
 
 	var logs Logs
 	if err := c.get(req, &logs); err != nil {
@@ -101,8 +118,8 @@ func (c *Client) GetOrganizationAggregatedLogs(orgname, startDate, endDate strin
 	}
 
 	addQueryParams(req, map[string]string{
-		"starttime": startDate,
-		"endtime":   endDate,
+		startTimeParam: startDate,
+		endTimeParam:   endDate,
 	})
 
 	var logs AggregatedLogs
@@ -128,15 +145,13 @@ func (c *Client) ExportOrganizationLogs(orgname string, request *ExportLogsReque
 }
 
 // GetUserLogs returns the logs for the current user
-func (c *Client) GetUserLogs(nextPage string) (*Logs, error) {
+func (c *Client) GetUserLogs(nextPage, startDate, endDate string) (*Logs, error) {
 	req, err := newRequest("GET", fmt.Sprintf("%s/user/logs", QuayURL), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	if nextPage != "" {
-		addQueryParams(req, map[string]string{"next_page": nextPage})
-	}
+	addLogQueryParams(req, nextPage, startDate, endDate)
 
 	var logs Logs
 	if err := c.get(req, &logs); err != nil {
@@ -154,8 +169,8 @@ func (c *Client) GetUserAggregatedLogs(startDate, endDate string) (*AggregatedLo
 	}
 
 	addQueryParams(req, map[string]string{
-		"starttime": startDate,
-		"endtime":   endDate,
+		startTimeParam: startDate,
+		endTimeParam:   endDate,
 	})
 
 	var logs AggregatedLogs

--- a/lib/logs_test.go
+++ b/lib/logs_test.go
@@ -1,0 +1,308 @@
+package lib
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const (
+	testStartDate    = "2026-05-01"
+	testEndDate      = "2026-05-21"
+	testEndDateMay   = "2026-05-31"
+	testDatetime     = "Mon, 19 May 2026 00:00:00 -0000"
+	testNextPage     = "abc123"
+	testKindPullRepo = "pull_repo"
+)
+
+func TestGetAggregatedLogs(t *testing.T) {
+	mockResponse := AggregatedLogs{
+		Aggregated: []AggregatedLogEntry{
+			{Kind: testKindPullRepo, Count: 10, Datetime: testDatetime},
+			{Kind: "push_repo", Count: 2, Datetime: testDatetime},
+		},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/testorg/testrepo/aggregatelogs"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		if r.URL.Query().Get("starttime") != testStartDate {
+			t.Errorf("Expected starttime '%s', got '%s'", testStartDate, r.URL.Query().Get("starttime"))
+		}
+		if r.URL.Query().Get("endtime") != testEndDate {
+			t.Errorf("Expected endtime '%s', got '%s'", testEndDate, r.URL.Query().Get("endtime"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	logs, err := client.GetAggregatedLogs(testNamespace, testRepository, testStartDate, testEndDate)
+	if err != nil {
+		t.Fatalf("GetAggregatedLogs returned error: %v", err)
+	}
+
+	if len(logs.Aggregated) != 2 {
+		t.Errorf("Expected 2 aggregated entries, got %d", len(logs.Aggregated))
+	}
+	if logs.Aggregated[0].Kind != testKindPullRepo {
+		t.Errorf("Expected kind 'pull_repo', got '%s'", logs.Aggregated[0].Kind)
+	}
+	if logs.Aggregated[0].Count != 10 {
+		t.Errorf("Expected count 10, got %d", logs.Aggregated[0].Count)
+	}
+}
+
+func TestGetLogs(t *testing.T) {
+	mockResponse := Logs{
+		StartTime: testDatetime,
+		EndTime:   "Wed, 21 May 2026 00:00:00 -0000",
+		Logs: []LogEntry{
+			{
+				Kind:     testKindPullRepo,
+				Datetime: "Wed, 21 May 2026 10:57:43 -0000",
+				Metadata: Metadata{Repo: testRepository, Tag: testTagNameLatest},
+			},
+		},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/testorg/testrepo/logs"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	logs, err := client.GetLogs(testNamespace, testRepository, "", "", "")
+	if err != nil {
+		t.Fatalf("GetLogs returned error: %v", err)
+	}
+
+	if len(logs.Logs) != 1 {
+		t.Errorf("Expected 1 log entry, got %d", len(logs.Logs))
+	}
+	if logs.Logs[0].Kind != testKindPullRepo {
+		t.Errorf("Expected kind 'pull_repo', got '%s'", logs.Logs[0].Kind)
+	}
+	if logs.Logs[0].Metadata.Tag != testTagNameLatest {
+		t.Errorf("Expected tag 'latest', got '%s'", logs.Logs[0].Metadata.Tag)
+	}
+}
+
+func TestGetLogsWithDateRange(t *testing.T) {
+	mockResponseJSON, _ := json.Marshal(Logs{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("starttime") != testStartDate {
+			t.Errorf("Expected starttime '%s', got '%s'", testStartDate, r.URL.Query().Get("starttime"))
+		}
+		if r.URL.Query().Get("endtime") != testEndDate {
+			t.Errorf("Expected endtime '%s', got '%s'", testEndDate, r.URL.Query().Get("endtime"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetLogs(testNamespace, testRepository, "", testStartDate, testEndDate)
+	if err != nil {
+		t.Fatalf("GetLogs with date range returned error: %v", err)
+	}
+}
+
+func TestGetLogsWithNextPage(t *testing.T) {
+	mockResponseJSON, _ := json.Marshal(Logs{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("next_page") != testNextPage {
+			t.Errorf("Expected next_page 'abc123', got '%s'", r.URL.Query().Get("next_page"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetLogs(testNamespace, testRepository, testNextPage, "", "")
+	if err != nil {
+		t.Fatalf("GetLogs with next page returned error: %v", err)
+	}
+}
+
+func TestGetOrganizationLogsWithDateRange(t *testing.T) {
+	mockResponseJSON, _ := json.Marshal(Logs{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expectedPath := "/api/v1/organization/testorg/logs"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		if r.URL.Query().Get("starttime") != testStartDate {
+			t.Errorf("Expected starttime '%s', got '%s'", testStartDate, r.URL.Query().Get("starttime"))
+		}
+		if r.URL.Query().Get("endtime") != testEndDateMay {
+			t.Errorf("Expected endtime '%s', got '%s'", testEndDateMay, r.URL.Query().Get("endtime"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetOrganizationLogs(testNamespace, "", testStartDate, testEndDateMay)
+	if err != nil {
+		t.Fatalf("GetOrganizationLogs with date range returned error: %v", err)
+	}
+}
+
+func TestGetUserLogsWithDateRange(t *testing.T) {
+	mockResponseJSON, _ := json.Marshal(Logs{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expectedPath := "/api/v1/user/logs"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		if r.URL.Query().Get("starttime") != testStartDate {
+			t.Errorf("Expected starttime '%s', got '%s'", testStartDate, r.URL.Query().Get("starttime"))
+		}
+		if r.URL.Query().Get("endtime") != testEndDateMay {
+			t.Errorf("Expected endtime '%s', got '%s'", testEndDateMay, r.URL.Query().Get("endtime"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetUserLogs("", testStartDate, testEndDateMay)
+	if err != nil {
+		t.Fatalf("GetUserLogs with date range returned error: %v", err)
+	}
+}
+
+func TestGetAggregatedLogsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetAggregatedLogs(testNamespace, testRepository, "", "")
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}
+
+func TestGetLogsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	originalURL := QuayURL
+	QuayURL = server.URL + "/api/v1"
+	defer func() { QuayURL = originalURL }()
+
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetLogs(testNamespace, testRepository, "", "", "")
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}
+
+func TestOrganizationRepositoryPopularityZero(t *testing.T) {
+	repo := OrganizationRepository{
+		Name:       testRepository,
+		Namespace:  testNamespace,
+		Popularity: 0,
+	}
+
+	data, err := json.Marshal(repo)
+	if err != nil {
+		t.Fatalf("Failed to marshal: %v", err)
+	}
+
+	output := string(data)
+	if !strings.Contains(output, `"popularity":0`) && !strings.Contains(output, `"popularity": 0`) {
+		t.Errorf("Expected popularity field in JSON output even when zero, got: %s", output)
+	}
+}

--- a/lib/manifest_test.go
+++ b/lib/manifest_test.go
@@ -8,11 +8,8 @@ import (
 )
 
 const (
-	testManifestRef    = "sha256:abc123def456789"
-	testLabelID        = "label-123"
-	httpGetManifest    = "GET"
-	httpPostManifest   = "POST"
-	httpDeleteManifest = "DELETE"
+	testManifestRef = "sha256:abc123def456789"
+	testLabelID     = "label-123"
 )
 
 func TestGetManifest(t *testing.T) {
@@ -46,7 +43,7 @@ func TestGetManifest(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockManifest)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetManifest {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/repository/testorg/testrepo/manifest/"+testManifestRef {
@@ -68,7 +65,7 @@ func TestGetManifest(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	manifest, err := client.GetManifest("testorg", "testrepo", testManifestRef)
+	manifest, err := client.GetManifest(testNamespace, testRepository, testManifestRef)
 	if err != nil {
 		t.Fatalf("GetManifest failed: %v", err)
 	}
@@ -89,7 +86,7 @@ func TestGetManifest(t *testing.T) {
 
 func TestDeleteManifest(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpDeleteManifest {
+		if r.Method != httpMethodDelete {
 			t.Errorf("Expected DELETE request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/repository/testorg/testrepo/manifest/"+testManifestRef {
@@ -109,7 +106,7 @@ func TestDeleteManifest(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteManifest("testorg", "testrepo", testManifestRef)
+	err = client.DeleteManifest(testNamespace, testRepository, testManifestRef)
 	if err != nil {
 		t.Fatalf("DeleteManifest failed: %v", err)
 	}
@@ -120,17 +117,17 @@ func TestGetManifestLabels(t *testing.T) {
 		Labels: []ManifestLabel{
 			{
 				ID:         "label-1",
-				Key:        "version",
+				Key:        testLabelKeyVersion,
 				Value:      "1.0.0",
-				SourceType: "api",
-				MediaType:  "text/plain",
+				SourceType: testLabelKeyAPI,
+				MediaType:  testMediaTypePlain,
 			},
 			{
 				ID:         "label-2",
 				Key:        "maintainer",
-				Value:      "test@example.com",
-				SourceType: "api",
-				MediaType:  "text/plain",
+				Value:      testEmailAddress,
+				SourceType: testLabelKeyAPI,
+				MediaType:  testMediaTypePlain,
 			},
 		},
 	}
@@ -138,7 +135,7 @@ func TestGetManifestLabels(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockLabels)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetManifest {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/repository/testorg/testrepo/manifest/"+testManifestRef+"/labels" {
@@ -160,7 +157,7 @@ func TestGetManifestLabels(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	labels, err := client.GetManifestLabels("testorg", "testrepo", testManifestRef)
+	labels, err := client.GetManifestLabels(testNamespace, testRepository, testManifestRef)
 	if err != nil {
 		t.Fatalf("GetManifestLabels failed: %v", err)
 	}
@@ -168,10 +165,10 @@ func TestGetManifestLabels(t *testing.T) {
 	if len(labels.Labels) != 2 {
 		t.Errorf("Expected 2 labels, got %d", len(labels.Labels))
 	}
-	if labels.Labels[0].Key != "version" {
+	if labels.Labels[0].Key != testLabelKeyVersion {
 		t.Errorf("Expected first label key 'version', got '%s'", labels.Labels[0].Key)
 	}
-	if labels.Labels[1].Value != "test@example.com" {
+	if labels.Labels[1].Value != testEmailAddress {
 		t.Errorf("Expected second label value 'test@example.com', got '%s'", labels.Labels[1].Value)
 	}
 }
@@ -179,16 +176,16 @@ func TestGetManifestLabels(t *testing.T) {
 func TestAddManifestLabel(t *testing.T) {
 	mockLabel := ManifestLabel{
 		ID:         "new-label-123",
-		Key:        "environment",
-		Value:      "production",
-		SourceType: "api",
-		MediaType:  "text/plain",
+		Key:        testLabelKeyEnvironment,
+		Value:      testLabelValProduction,
+		SourceType: testLabelKeyAPI,
+		MediaType:  testMediaTypePlain,
 	}
 
 	mockResponseJSON, _ := json.Marshal(mockLabel)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPostManifest {
+		if r.Method != httpMethodPost {
 			t.Errorf("Expected POST request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/repository/testorg/testrepo/manifest/"+testManifestRef+"/labels" {
@@ -201,10 +198,10 @@ func TestAddManifestLabel(t *testing.T) {
 			t.Errorf("Failed to decode request body: %v", err)
 		}
 
-		if req.Key != "environment" {
+		if req.Key != testLabelKeyEnvironment {
 			t.Errorf("Expected key 'environment', got '%s'", req.Key)
 		}
-		if req.Value != "production" {
+		if req.Value != testLabelValProduction {
 			t.Errorf("Expected value 'production', got '%s'", req.Value)
 		}
 
@@ -223,15 +220,15 @@ func TestAddManifestLabel(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	label, err := client.AddManifestLabel("testorg", "testrepo", testManifestRef, "environment", "production", "text/plain")
+	label, err := client.AddManifestLabel(testNamespace, testRepository, testManifestRef, testLabelKeyEnvironment, testLabelValProduction, testMediaTypePlain)
 	if err != nil {
 		t.Fatalf("AddManifestLabel failed: %v", err)
 	}
 
-	if label.Key != "environment" {
+	if label.Key != testLabelKeyEnvironment {
 		t.Errorf("Expected label key 'environment', got '%s'", label.Key)
 	}
-	if label.Value != "production" {
+	if label.Value != testLabelValProduction {
 		t.Errorf("Expected label value 'production', got '%s'", label.Value)
 	}
 	if label.ID != "new-label-123" {
@@ -242,16 +239,16 @@ func TestAddManifestLabel(t *testing.T) {
 func TestGetManifestLabel(t *testing.T) {
 	mockLabel := ManifestLabel{
 		ID:         testLabelID,
-		Key:        "version",
+		Key:        testLabelKeyVersion,
 		Value:      "2.0.0",
-		SourceType: "api",
-		MediaType:  "text/plain",
+		SourceType: testLabelKeyAPI,
+		MediaType:  testMediaTypePlain,
 	}
 
 	mockResponseJSON, _ := json.Marshal(mockLabel)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetManifest {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/repository/testorg/testrepo/manifest/" + testManifestRef + "/labels/" + testLabelID
@@ -274,7 +271,7 @@ func TestGetManifestLabel(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	label, err := client.GetManifestLabel("testorg", "testrepo", testManifestRef, testLabelID)
+	label, err := client.GetManifestLabel(testNamespace, testRepository, testManifestRef, testLabelID)
 	if err != nil {
 		t.Fatalf("GetManifestLabel failed: %v", err)
 	}
@@ -282,14 +279,14 @@ func TestGetManifestLabel(t *testing.T) {
 	if label.ID != testLabelID {
 		t.Errorf("Expected label ID '%s', got '%s'", testLabelID, label.ID)
 	}
-	if label.Key != "version" {
+	if label.Key != testLabelKeyVersion {
 		t.Errorf("Expected label key 'version', got '%s'", label.Key)
 	}
 }
 
 func TestDeleteManifestLabel(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpDeleteManifest {
+		if r.Method != httpMethodDelete {
 			t.Errorf("Expected DELETE request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/repository/testorg/testrepo/manifest/" + testManifestRef + "/labels/" + testLabelID
@@ -310,7 +307,7 @@ func TestDeleteManifestLabel(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteManifestLabel("testorg", "testrepo", testManifestRef, testLabelID)
+	err = client.DeleteManifestLabel(testNamespace, testRepository, testManifestRef, testLabelID)
 	if err != nil {
 		t.Fatalf("DeleteManifestLabel failed: %v", err)
 	}
@@ -334,37 +331,37 @@ func TestManifestErrorHandling(t *testing.T) {
 	}
 
 	// Test GetManifest error
-	_, err = client.GetManifest("testorg", "testrepo", "nonexistent")
+	_, err = client.GetManifest(testNamespace, testRepository, "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent manifest, got nil")
 	}
 
 	// Test DeleteManifest error
-	err = client.DeleteManifest("testorg", "testrepo", "nonexistent")
+	err = client.DeleteManifest(testNamespace, testRepository, "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent manifest, got nil")
 	}
 
 	// Test GetManifestLabels error
-	_, err = client.GetManifestLabels("testorg", "testrepo", "nonexistent")
+	_, err = client.GetManifestLabels(testNamespace, testRepository, "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent manifest, got nil")
 	}
 
 	// Test AddManifestLabel error
-	_, err = client.AddManifestLabel("testorg", "testrepo", "nonexistent", "key", "value", "")
+	_, err = client.AddManifestLabel(testNamespace, testRepository, "nonexistent", "key", "value", "")
 	if err == nil {
 		t.Error("Expected error for non-existent manifest, got nil")
 	}
 
 	// Test GetManifestLabel error
-	_, err = client.GetManifestLabel("testorg", "testrepo", "nonexistent", "labelid")
+	_, err = client.GetManifestLabel(testNamespace, testRepository, "nonexistent", "labelid")
 	if err == nil {
 		t.Error("Expected error for non-existent manifest label, got nil")
 	}
 
 	// Test DeleteManifestLabel error
-	err = client.DeleteManifestLabel("testorg", "testrepo", "nonexistent", "labelid")
+	err = client.DeleteManifestLabel(testNamespace, testRepository, "nonexistent", "labelid")
 	if err == nil {
 		t.Error("Expected error for non-existent manifest label, got nil")
 	}

--- a/lib/messages_test.go
+++ b/lib/messages_test.go
@@ -7,10 +7,6 @@ import (
 	"testing"
 )
 
-const (
-	httpGetMessages = "GET"
-)
-
 func TestGetMessages(t *testing.T) {
 	mockResponse := Messages{
 		Messages: []Message{
@@ -18,20 +14,20 @@ func TestGetMessages(t *testing.T) {
 				UUID:      "msg-uuid-123",
 				Content:   "Scheduled maintenance on Sunday",
 				Severity:  "info",
-				MediaType: "text/plain",
+				MediaType: testMediaTypePlain,
 			},
 			{
 				UUID:      "msg-uuid-456",
 				Content:   "New feature available",
 				Severity:  "info",
-				MediaType: "text/plain",
+				MediaType: testMediaTypePlain,
 			},
 		},
 	}
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetMessages {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/messages"

--- a/lib/notification_test.go
+++ b/lib/notification_test.go
@@ -8,15 +8,9 @@ import (
 )
 
 const (
-	httpGetNotification    = "GET"
-	httpPostNotification   = "POST"
-	httpDeleteNotification = "DELETE"
-
-	testNotificationNamespace  = "testorg"
-	testNotificationRepository = "testrepo"
-	testNotificationUUID       = "notification-uuid-123"
-	testNotificationEvent      = "repo_push"
-	testNotificationMethod     = "webhook"
+	testNotificationUUID   = "notification-uuid-123"
+	testNotificationEvent  = "repo_push"
+	testNotificationMethod = "webhook"
 )
 
 func TestGetNotifications(t *testing.T) {
@@ -29,10 +23,10 @@ func TestGetNotifications(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetNotification {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testNotificationNamespace + "/" + testNotificationRepository + "/notification/"
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/notification/"
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -50,7 +44,7 @@ func TestGetNotifications(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	notifications, err := client.GetNotifications(testNotificationNamespace, testNotificationRepository)
+	notifications, err := client.GetNotifications(testNamespace, testRepository)
 	if err != nil {
 		t.Fatalf("GetNotifications returned error: %v", err)
 	}
@@ -74,10 +68,10 @@ func TestGetNotification(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetNotification {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testNotificationNamespace + "/" + testNotificationRepository + "/notification/" + testNotificationUUID
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/notification/" + testNotificationUUID
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -95,7 +89,7 @@ func TestGetNotification(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	notification, err := client.GetNotification(testNotificationNamespace, testNotificationRepository, testNotificationUUID)
+	notification, err := client.GetNotification(testNamespace, testRepository, testNotificationUUID)
 	if err != nil {
 		t.Fatalf("GetNotification returned error: %v", err)
 	}
@@ -118,10 +112,10 @@ func TestCreateNotification(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPostNotification {
+		if r.Method != httpMethodPost {
 			t.Errorf("Expected POST request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testNotificationNamespace + "/" + testNotificationRepository + "/notification/"
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/notification/"
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -147,7 +141,7 @@ func TestCreateNotification(t *testing.T) {
 		Title:  "New Webhook",
 	}
 
-	notification, err := client.CreateNotification(testNotificationNamespace, testNotificationRepository, notificationReq)
+	notification, err := client.CreateNotification(testNamespace, testRepository, notificationReq)
 	if err != nil {
 		t.Fatalf("CreateNotification returned error: %v", err)
 	}
@@ -159,10 +153,10 @@ func TestCreateNotification(t *testing.T) {
 
 func TestDeleteNotification(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpDeleteNotification {
+		if r.Method != httpMethodDelete {
 			t.Errorf("Expected DELETE request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testNotificationNamespace + "/" + testNotificationRepository + "/notification/" + testNotificationUUID
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/notification/" + testNotificationUUID
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -179,7 +173,7 @@ func TestDeleteNotification(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteNotification(testNotificationNamespace, testNotificationRepository, testNotificationUUID)
+	err = client.DeleteNotification(testNamespace, testRepository, testNotificationUUID)
 	if err != nil {
 		t.Fatalf("DeleteNotification returned error: %v", err)
 	}
@@ -187,10 +181,10 @@ func TestDeleteNotification(t *testing.T) {
 
 func TestTestNotification(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPostNotification {
+		if r.Method != httpMethodPost {
 			t.Errorf("Expected POST request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testNotificationNamespace + "/" + testNotificationRepository + "/notification/" + testNotificationUUID + "/test"
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/notification/" + testNotificationUUID + "/test"
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -207,7 +201,7 @@ func TestTestNotification(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.TestNotification(testNotificationNamespace, testNotificationRepository, testNotificationUUID)
+	err = client.TestNotification(testNamespace, testRepository, testNotificationUUID)
 	if err != nil {
 		t.Fatalf("TestNotification returned error: %v", err)
 	}
@@ -215,10 +209,10 @@ func TestTestNotification(t *testing.T) {
 
 func TestResetNotification(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPostNotification {
+		if r.Method != httpMethodPost {
 			t.Errorf("Expected POST request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testNotificationNamespace + "/" + testNotificationRepository + "/notification/" + testNotificationUUID + "/reset"
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/notification/" + testNotificationUUID + "/reset"
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -235,7 +229,7 @@ func TestResetNotification(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.ResetNotification(testNotificationNamespace, testNotificationRepository, testNotificationUUID)
+	err = client.ResetNotification(testNamespace, testRepository, testNotificationUUID)
 	if err != nil {
 		t.Fatalf("ResetNotification returned error: %v", err)
 	}
@@ -256,7 +250,7 @@ func TestGetNotificationsError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetNotifications(testNotificationNamespace, testNotificationRepository)
+	_, err = client.GetNotifications(testNamespace, testRepository)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -277,7 +271,7 @@ func TestGetNotificationError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetNotification(testNotificationNamespace, testNotificationRepository, "nonexistent-uuid")
+	_, err = client.GetNotification(testNamespace, testRepository, "nonexistent-uuid")
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}

--- a/lib/organization.go
+++ b/lib/organization.go
@@ -83,6 +83,8 @@ import (
 	"fmt"
 )
 
+const fieldRole = "role"
+
 // Organization Management
 
 // CreateOrganization creates a new organization
@@ -219,7 +221,7 @@ func (c *Client) GetDefaultPermissions(orgname string) (*DefaultPermissions, err
 // CreateDefaultPermission creates a default permission for an organization
 func (c *Client) CreateDefaultPermission(orgname, role, delegateType, delegateName string) (*DefaultPermission, error) {
 	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/prototypes", QuayURL, orgname), map[string]interface{}{
-		"role": role,
+		fieldRole: role,
 		"delegate": map[string]interface{}{
 			"kind": delegateType,
 			"name": delegateName,
@@ -360,7 +362,7 @@ func (c *Client) DeleteTeam(orgname, teamname string) error {
 func (c *Client) UpdateTeam(orgname, teamname, description, role string) (*Team, error) {
 	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/team/%s", QuayURL, orgname, teamname), map[string]interface{}{
 		"description": description,
-		"role":        role,
+		fieldRole:     role,
 	})
 	if err != nil {
 		return nil, err
@@ -431,7 +433,7 @@ func (c *Client) GetTeamPermissions(orgname, teamname string) (*TeamPermissions,
 // SetTeamRepositoryPermission sets repository permission for a team
 func (c *Client) SetTeamRepositoryPermission(orgname, teamname, repository, role string) error {
 	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/team/%s/permissions/%s", QuayURL, orgname, teamname, repository), map[string]interface{}{
-		"role": role,
+		fieldRole: role,
 	})
 	if err != nil {
 		return err
@@ -543,7 +545,7 @@ func (c *Client) GetRobotPermissions(orgname, robotShortname string) (*RobotPerm
 // SetRobotRepositoryPermission sets repository permission for a robot account
 func (c *Client) SetRobotRepositoryPermission(orgname, robotShortname, repository, role string) error {
 	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/robots/%s/permissions/%s", QuayURL, orgname, robotShortname, repository), map[string]interface{}{
-		"role": role,
+		fieldRole: role,
 	})
 	if err != nil {
 		return err

--- a/lib/permissions_test.go
+++ b/lib/permissions_test.go
@@ -7,35 +7,27 @@ import (
 	"testing"
 )
 
-const (
-	httpGetPerms    = "GET"
-	httpPutPerms    = "PUT"
-	httpDeletePerms = "DELETE"
-
-	permRoleWrite = "write"
-)
-
 func TestGetRepositoryPermissions(t *testing.T) {
 	mockPermissions := RepositoryPermissions{
 		Permissions: []RepositoryPermission{
 			{
-				Name: "john.doe",
-				Kind: "user",
-				Role: permRoleWrite,
+				Name: testPermUserName,
+				Kind: testKindUser,
+				Role: testRoleWrite,
 				Avatar: Avatar{
-					Name: "john.doe",
-					Kind: "user",
+					Name: testPermUserName,
+					Kind: testKindUser,
 				},
 				IsRobot:    false,
 				IsOrgAdmin: false,
 			},
 			{
 				Name: "testorg+deploybot",
-				Kind: "robot",
-				Role: "read",
+				Kind: testKindRobot,
+				Role: testRoleRead,
 				Avatar: Avatar{
 					Name: "deploybot",
-					Kind: "robot",
+					Kind: testKindRobot,
 				},
 				IsRobot:    true,
 				IsOrgAdmin: false,
@@ -46,7 +38,7 @@ func TestGetRepositoryPermissions(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockPermissions)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetPerms {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/repository/testorg/testrepo/permissions" {
@@ -68,7 +60,7 @@ func TestGetRepositoryPermissions(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	permissions, err := client.GetRepositoryPermissions("testorg", "testrepo")
+	permissions, err := client.GetRepositoryPermissions(testNamespace, testRepository)
 	if err != nil {
 		t.Fatalf("GetRepositoryPermissions failed: %v", err)
 	}
@@ -79,10 +71,10 @@ func TestGetRepositoryPermissions(t *testing.T) {
 
 	// Check first permission (user)
 	userPerm := permissions.Permissions[0]
-	if userPerm.Name != "john.doe" {
+	if userPerm.Name != testPermUserName {
 		t.Errorf("Expected user name 'john.doe', got '%s'", userPerm.Name)
 	}
-	if userPerm.Role != permRoleWrite {
+	if userPerm.Role != testRoleWrite {
 		t.Errorf("Expected role 'write', got '%s'", userPerm.Role)
 	}
 	if userPerm.IsRobot != false {
@@ -94,7 +86,7 @@ func TestGetRepositoryPermissions(t *testing.T) {
 	if robotPerm.Name != "testorg+deploybot" {
 		t.Errorf("Expected robot name 'testorg+deploybot', got '%s'", robotPerm.Name)
 	}
-	if robotPerm.Role != "read" {
+	if robotPerm.Role != testRoleRead {
 		t.Errorf("Expected role 'read', got '%s'", robotPerm.Role)
 	}
 	if robotPerm.IsRobot != true {
@@ -104,10 +96,10 @@ func TestGetRepositoryPermissions(t *testing.T) {
 
 func TestSetRepositoryPermission(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPutPerms {
+		if r.Method != httpMethodPut {
 			t.Errorf("Expected PUT request, got %s", r.Method)
 		}
-		if r.URL.Path != "/api/v1/repository/testorg/testrepo/permissions/john.doe" {
+		if r.URL.Path != "/api/v1/repository/testorg/testrepo/permissions/"+testPermUserName {
 			t.Errorf("Expected path /api/v1/repository/testorg/testrepo/permissions/john.doe, got %s", r.URL.Path)
 		}
 
@@ -117,7 +109,7 @@ func TestSetRepositoryPermission(t *testing.T) {
 			t.Errorf("Failed to decode request body: %v", err)
 		}
 
-		if req.Role != permRoleWrite {
+		if req.Role != testRoleWrite {
 			t.Errorf("Expected role 'write', got '%s'", req.Role)
 		}
 
@@ -134,7 +126,7 @@ func TestSetRepositoryPermission(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.SetRepositoryPermission("testorg", "testrepo", "john.doe", permRoleWrite)
+	err = client.SetRepositoryPermission(testNamespace, testRepository, testPermUserName, testRoleWrite)
 	if err != nil {
 		t.Fatalf("SetRepositoryPermission failed: %v", err)
 	}
@@ -157,9 +149,9 @@ func TestSetRepositoryPermissionInvalidRole(t *testing.T) {
 	}
 
 	// Test with valid roles
-	validRoles := []string{"read", "write", "admin"}
+	validRoles := []string{testRoleRead, testRoleWrite, "admin"}
 	for _, role := range validRoles {
-		err = client.SetRepositoryPermission("testorg", "testrepo", "user", role)
+		err = client.SetRepositoryPermission(testNamespace, testRepository, testKindUser, role)
 		if err != nil {
 			t.Errorf("SetRepositoryPermission failed for valid role '%s': %v", role, err)
 		}
@@ -168,10 +160,10 @@ func TestSetRepositoryPermissionInvalidRole(t *testing.T) {
 
 func TestRemoveRepositoryPermission(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpDeletePerms {
+		if r.Method != httpMethodDelete {
 			t.Errorf("Expected DELETE request, got %s", r.Method)
 		}
-		if r.URL.Path != "/api/v1/repository/testorg/testrepo/permissions/john.doe" {
+		if r.URL.Path != "/api/v1/repository/testorg/testrepo/permissions/"+testPermUserName {
 			t.Errorf("Expected path /api/v1/repository/testorg/testrepo/permissions/john.doe, got %s", r.URL.Path)
 		}
 
@@ -188,7 +180,7 @@ func TestRemoveRepositoryPermission(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.RemoveRepositoryPermission("testorg", "testrepo", "john.doe")
+	err = client.RemoveRepositoryPermission(testNamespace, testRepository, testPermUserName)
 	if err != nil {
 		t.Fatalf("RemoveRepositoryPermission failed: %v", err)
 	}
@@ -212,19 +204,19 @@ func TestPermissionsErrorHandling(t *testing.T) {
 	}
 
 	// Test GetRepositoryPermissions error
-	_, err = client.GetRepositoryPermissions("testorg", "nonexistent")
+	_, err = client.GetRepositoryPermissions(testNamespace, "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent repository, got nil")
 	}
 
 	// Test SetRepositoryPermission error
-	err = client.SetRepositoryPermission("testorg", "nonexistent", "user", "read")
+	err = client.SetRepositoryPermission(testNamespace, "nonexistent", testKindUser, testRoleRead)
 	if err == nil {
 		t.Error("Expected error for non-existent repository, got nil")
 	}
 
 	// Test RemoveRepositoryPermission error
-	err = client.RemoveRepositoryPermission("testorg", "nonexistent", "user")
+	err = client.RemoveRepositoryPermission(testNamespace, "nonexistent", testKindUser)
 	if err == nil {
 		t.Error("Expected error for non-existent repository, got nil")
 	}

--- a/lib/prototype_test.go
+++ b/lib/prototype_test.go
@@ -8,14 +8,7 @@ import (
 )
 
 const (
-	httpGetPrototype    = "GET"
-	httpPostPrototype   = "POST"
-	httpPutPrototype    = "PUT"
-	httpDeletePrototype = "DELETE"
-
-	testPrototypeOrg  = "testorg"
 	testPrototypeUUID = "proto-uuid-123"
-	prototypeRoleRead = "read"
 )
 
 func TestGetPrototypes(t *testing.T) {
@@ -23,10 +16,10 @@ func TestGetPrototypes(t *testing.T) {
 		Prototypes: []Prototype{
 			{
 				ID:   testPrototypeUUID,
-				Role: prototypeRoleRead,
+				Role: testRoleRead,
 				Delegate: PrototypeDelegate{
-					Name: "devteam",
-					Kind: "team",
+					Name: testPrototypeTeamName,
+					Kind: testKindTeam,
 				},
 			},
 		},
@@ -34,10 +27,10 @@ func TestGetPrototypes(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetPrototype {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/organization/" + testPrototypeOrg + "/prototypes"
+		expectedPath := "/api/v1/organization/" + testNamespace + "/prototypes"
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -55,7 +48,7 @@ func TestGetPrototypes(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	prototypes, err := client.GetPrototypes(testPrototypeOrg)
+	prototypes, err := client.GetPrototypes(testNamespace)
 	if err != nil {
 		t.Fatalf("GetPrototypes returned error: %v", err)
 	}
@@ -71,16 +64,16 @@ func TestGetPrototypes(t *testing.T) {
 func TestCreatePrototype(t *testing.T) {
 	mockResponse := Prototype{
 		ID:   testPrototypeUUID,
-		Role: prototypeRoleRead,
+		Role: testRoleRead,
 		Delegate: PrototypeDelegate{
-			Name: "devteam",
-			Kind: "team",
+			Name: testPrototypeTeamName,
+			Kind: testKindTeam,
 		},
 	}
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPostPrototype {
+		if r.Method != httpMethodPost {
 			t.Errorf("Expected POST request, got %s", r.Method)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -100,13 +93,13 @@ func TestCreatePrototype(t *testing.T) {
 
 	createReq := &CreatePrototypeRequest{
 		Delegate: PrototypeDelegateRequest{
-			Name: "devteam",
-			Kind: "team",
+			Name: testPrototypeTeamName,
+			Kind: testKindTeam,
 		},
-		Role: prototypeRoleRead,
+		Role: testRoleRead,
 	}
 
-	prototype, err := client.CreatePrototype(testPrototypeOrg, createReq)
+	prototype, err := client.CreatePrototype(testNamespace, createReq)
 	if err != nil {
 		t.Fatalf("CreatePrototype returned error: %v", err)
 	}
@@ -119,19 +112,19 @@ func TestCreatePrototype(t *testing.T) {
 func TestGetPrototype(t *testing.T) {
 	mockResponse := Prototype{
 		ID:   testPrototypeUUID,
-		Role: prototypeRoleRead,
+		Role: testRoleRead,
 		Delegate: PrototypeDelegate{
-			Name: "devteam",
-			Kind: "team",
+			Name: testPrototypeTeamName,
+			Kind: testKindTeam,
 		},
 	}
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetPrototype {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/organization/" + testPrototypeOrg + "/prototypes/" + testPrototypeUUID
+		expectedPath := "/api/v1/organization/" + testNamespace + "/prototypes/" + testPrototypeUUID
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -149,7 +142,7 @@ func TestGetPrototype(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	prototype, err := client.GetPrototype(testPrototypeOrg, testPrototypeUUID)
+	prototype, err := client.GetPrototype(testNamespace, testPrototypeUUID)
 	if err != nil {
 		t.Fatalf("GetPrototype returned error: %v", err)
 	}
@@ -162,12 +155,12 @@ func TestGetPrototype(t *testing.T) {
 func TestUpdatePrototype(t *testing.T) {
 	mockResponse := Prototype{
 		ID:   testPrototypeUUID,
-		Role: "write",
+		Role: testRoleWrite,
 	}
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPutPrototype {
+		if r.Method != httpMethodPut {
 			t.Errorf("Expected PUT request, got %s", r.Method)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -185,25 +178,25 @@ func TestUpdatePrototype(t *testing.T) {
 	}
 
 	updateReq := &UpdatePrototypeRequest{
-		Role: "write",
+		Role: testRoleWrite,
 	}
 
-	prototype, err := client.UpdatePrototype(testPrototypeOrg, testPrototypeUUID, updateReq)
+	prototype, err := client.UpdatePrototype(testNamespace, testPrototypeUUID, updateReq)
 	if err != nil {
 		t.Fatalf("UpdatePrototype returned error: %v", err)
 	}
 
-	if prototype.Role != "write" {
+	if prototype.Role != testRoleWrite {
 		t.Errorf("Expected role 'write', got %s", prototype.Role)
 	}
 }
 
 func TestDeletePrototype(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpDeletePrototype {
+		if r.Method != httpMethodDelete {
 			t.Errorf("Expected DELETE request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/organization/" + testPrototypeOrg + "/prototypes/" + testPrototypeUUID
+		expectedPath := "/api/v1/organization/" + testNamespace + "/prototypes/" + testPrototypeUUID
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -220,7 +213,7 @@ func TestDeletePrototype(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeletePrototype(testPrototypeOrg, testPrototypeUUID)
+	err = client.DeletePrototype(testNamespace, testPrototypeUUID)
 	if err != nil {
 		t.Fatalf("DeletePrototype returned error: %v", err)
 	}
@@ -241,7 +234,7 @@ func TestGetPrototypesError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetPrototypes(testPrototypeOrg)
+	_, err = client.GetPrototypes(testNamespace)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}

--- a/lib/repository_test.go
+++ b/lib/repository_test.go
@@ -10,18 +10,17 @@ import (
 const (
 	testRepoPath       = "/api/v1/repository/testorg/testrepo"
 	testTagPath        = "/api/v1/repository/testorg/testrepo/tag"
-	httpGetRepo        = "GET"
 	updatedDescription = "Updated description"
 )
 
 func TestCreateRepository(t *testing.T) {
 	// Mock response
 	mockRepo := Repository{
-		Namespace:   "testorg",
-		Name:        "testrepo",
-		Description: "Test repository",
+		Namespace:   testNamespace,
+		Name:        testRepository,
+		Description: testRepoDescription,
 		IsPublic:    false,
-		Kind:        "image",
+		Kind:        testKindImage,
 	}
 
 	mockResponseJSON, _ := json.Marshal(mockRepo)
@@ -29,7 +28,7 @@ func TestCreateRepository(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify request method and path
-		if r.Method != "POST" {
+		if r.Method != httpMethodPost {
 			t.Errorf("Expected POST request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/repository" {
@@ -43,10 +42,10 @@ func TestCreateRepository(t *testing.T) {
 		}
 
 		expectedReq := CreateRepositoryRequest{
-			Repository:  "testrepo",
-			Namespace:   "testorg",
+			Repository:  testRepository,
+			Namespace:   testNamespace,
 			Visibility:  "private",
-			Description: "Test repository",
+			Description: testRepoDescription,
 		}
 
 		if req != expectedReq {
@@ -70,24 +69,24 @@ func TestCreateRepository(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	repo, err := client.CreateRepository("testorg", "testrepo", "private", "Test repository")
+	repo, err := client.CreateRepository(testNamespace, testRepository, "private", "Test repository")
 	if err != nil {
 		t.Fatalf("CreateRepository failed: %v", err)
 	}
 
 	// Verify response
-	if repo.Name != "testrepo" {
+	if repo.Name != testRepository {
 		t.Errorf("Expected repository name 'testrepo', got '%s'", repo.Name)
 	}
-	if repo.Namespace != "testorg" {
+	if repo.Namespace != testNamespace {
 		t.Errorf("Expected namespace 'testorg', got '%s'", repo.Namespace)
 	}
 }
 
 func TestUpdateRepository(t *testing.T) {
 	mockRepo := Repository{
-		Namespace:   "testorg",
-		Name:        "testrepo",
+		Namespace:   testNamespace,
+		Name:        testRepository,
 		Description: updatedDescription,
 		IsPublic:    true,
 	}
@@ -95,7 +94,7 @@ func TestUpdateRepository(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockRepo)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "PUT" {
+		if r.Method != httpMethodPut {
 			t.Errorf("Expected PUT request, got %s", r.Method)
 		}
 		if r.URL.Path != testRepoPath {
@@ -129,7 +128,7 @@ func TestUpdateRepository(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	repo, err := client.UpdateRepository("testorg", "testrepo", updatedDescription, "public")
+	repo, err := client.UpdateRepository(testNamespace, testRepository, updatedDescription, "public")
 	if err != nil {
 		t.Fatalf("UpdateRepository failed: %v", err)
 	}
@@ -141,7 +140,7 @@ func TestUpdateRepository(t *testing.T) {
 
 func TestDeleteRepository(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "DELETE" {
+		if r.Method != httpMethodDelete {
 			t.Errorf("Expected DELETE request, got %s", r.Method)
 		}
 		if r.URL.Path != testRepoPath {
@@ -161,7 +160,7 @@ func TestDeleteRepository(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteRepository("testorg", "testrepo")
+	err = client.DeleteRepository(testNamespace, testRepository)
 	if err != nil {
 		t.Fatalf("DeleteRepository failed: %v", err)
 	}
@@ -169,11 +168,11 @@ func TestDeleteRepository(t *testing.T) {
 
 func TestGetRepository(t *testing.T) {
 	mockRepo := Repository{
-		Namespace:   "testorg",
-		Name:        "testrepo",
-		Description: "Test repository",
+		Namespace:   testNamespace,
+		Name:        testRepository,
+		Description: testRepoDescription,
 		IsPublic:    false,
-		Kind:        "image",
+		Kind:        testKindImage,
 	}
 
 	mockTags := RepositoryTags{
@@ -188,8 +187,8 @@ func TestGetRepository(t *testing.T) {
 			EndTs          int    `json:"end_ts,omitempty"`
 			Expiration     string `json:"expiration,omitempty"`
 		}{
-			{Name: "latest", ManifestDigest: "sha256:abc123"},
-			{Name: "v1.0.0", ManifestDigest: "sha256:def456"},
+			{Name: testTagNameLatest, ManifestDigest: testDigestSHA256},
+			{Name: testTagNameV1, ManifestDigest: "sha256:def456"},
 		},
 		Page:          1,
 		HasAdditional: false,
@@ -199,7 +198,7 @@ func TestGetRepository(t *testing.T) {
 	mockTagsJSON, _ := json.Marshal(mockTags)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetRepo {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 
@@ -228,15 +227,15 @@ func TestGetRepository(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	repoWithTags, err := client.GetRepository("testorg", "testrepo")
+	repoWithTags, err := client.GetRepository(testNamespace, testRepository)
 	if err != nil {
 		t.Fatalf("GetRepository failed: %v", err)
 	}
 
-	if repoWithTags.Name != "testrepo" {
+	if repoWithTags.Name != testRepository {
 		t.Errorf("Expected repository name 'testrepo', got '%s'", repoWithTags.Name)
 	}
-	if repoWithTags.Namespace != "testorg" {
+	if repoWithTags.Namespace != testNamespace {
 		t.Errorf("Expected namespace 'testorg', got '%s'", repoWithTags.Namespace)
 	}
 	if len(repoWithTags.Tags.Tags) != 2 {

--- a/lib/repotoken_test.go
+++ b/lib/repotoken_test.go
@@ -8,31 +8,23 @@ import (
 )
 
 const (
-	httpGetRepoToken    = "GET"
-	httpPostRepoToken   = "POST"
-	httpPutRepoToken    = "PUT"
-	httpDeleteRepoToken = "DELETE"
-
-	testTokenNamespace  = "testorg"
-	testTokenRepository = "testrepo"
-	testTokenCode       = "ABCD1234"
-	testTokenRole       = "read"
+	testTokenCode = "ABCD1234"
 )
 
 func TestGetRepoTokens(t *testing.T) {
 	mockResponse := RepoTokens{
 		Tokens: []RepoToken{
-			{Code: testTokenCode, FriendlyName: "CI Token", Role: testTokenRole},
-			{Code: "EFGH5678", FriendlyName: "Deploy Token", Role: "write"},
+			{Code: testTokenCode, FriendlyName: testRepoTokenName, Role: testRoleRead},
+			{Code: "EFGH5678", FriendlyName: "Deploy Token", Role: testRoleWrite},
 		},
 	}
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetRepoToken {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testTokenNamespace + "/" + testTokenRepository + "/tokens"
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/tokens"
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -50,7 +42,7 @@ func TestGetRepoTokens(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	tokens, err := client.GetRepoTokens(testTokenNamespace, testTokenRepository)
+	tokens, err := client.GetRepoTokens(testNamespace, testRepository)
 	if err != nil {
 		t.Fatalf("GetRepoTokens returned error: %v", err)
 	}
@@ -67,12 +59,12 @@ func TestCreateRepoToken(t *testing.T) {
 	mockResponse := RepoToken{
 		Code:         testTokenCode,
 		FriendlyName: "New CI Token",
-		Role:         testTokenRole,
+		Role:         testRoleRead,
 	}
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPostRepoToken {
+		if r.Method != httpMethodPost {
 			t.Errorf("Expected POST request, got %s", r.Method)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -94,7 +86,7 @@ func TestCreateRepoToken(t *testing.T) {
 		FriendlyName: "New CI Token",
 	}
 
-	token, err := client.CreateRepoToken(testTokenNamespace, testTokenRepository, createReq)
+	token, err := client.CreateRepoToken(testNamespace, testRepository, createReq)
 	if err != nil {
 		t.Fatalf("CreateRepoToken returned error: %v", err)
 	}
@@ -107,16 +99,16 @@ func TestCreateRepoToken(t *testing.T) {
 func TestGetRepoToken(t *testing.T) {
 	mockResponse := RepoToken{
 		Code:         testTokenCode,
-		FriendlyName: "CI Token",
-		Role:         testTokenRole,
+		FriendlyName: testRepoTokenName,
+		Role:         testRoleRead,
 	}
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetRepoToken {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testTokenNamespace + "/" + testTokenRepository + "/tokens/" + testTokenCode
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/tokens/" + testTokenCode
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -134,7 +126,7 @@ func TestGetRepoToken(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	token, err := client.GetRepoToken(testTokenNamespace, testTokenRepository, testTokenCode)
+	token, err := client.GetRepoToken(testNamespace, testRepository, testTokenCode)
 	if err != nil {
 		t.Fatalf("GetRepoToken returned error: %v", err)
 	}
@@ -147,13 +139,13 @@ func TestGetRepoToken(t *testing.T) {
 func TestUpdateRepoToken(t *testing.T) {
 	mockResponse := RepoToken{
 		Code:         testTokenCode,
-		FriendlyName: "CI Token",
+		FriendlyName: testRepoTokenName,
 		Role:         "write",
 	}
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPutRepoToken {
+		if r.Method != httpMethodPut {
 			t.Errorf("Expected PUT request, got %s", r.Method)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -171,25 +163,25 @@ func TestUpdateRepoToken(t *testing.T) {
 	}
 
 	updateReq := &UpdateRepoTokenRequest{
-		Role: "write",
+		Role: testRoleWrite,
 	}
 
-	token, err := client.UpdateRepoToken(testTokenNamespace, testTokenRepository, testTokenCode, updateReq)
+	token, err := client.UpdateRepoToken(testNamespace, testRepository, testTokenCode, updateReq)
 	if err != nil {
 		t.Fatalf("UpdateRepoToken returned error: %v", err)
 	}
 
-	if token.Role != "write" {
+	if token.Role != testRoleWrite {
 		t.Errorf("Expected role 'write', got %s", token.Role)
 	}
 }
 
 func TestDeleteRepoToken(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpDeleteRepoToken {
+		if r.Method != httpMethodDelete {
 			t.Errorf("Expected DELETE request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testTokenNamespace + "/" + testTokenRepository + "/tokens/" + testTokenCode
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/tokens/" + testTokenCode
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -206,7 +198,7 @@ func TestDeleteRepoToken(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteRepoToken(testTokenNamespace, testTokenRepository, testTokenCode)
+	err = client.DeleteRepoToken(testNamespace, testRepository, testTokenCode)
 	if err != nil {
 		t.Fatalf("DeleteRepoToken returned error: %v", err)
 	}
@@ -227,7 +219,7 @@ func TestGetRepoTokensError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetRepoTokens(testTokenNamespace, testTokenRepository)
+	_, err = client.GetRepoTokens(testNamespace, testRepository)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}

--- a/lib/robot_test.go
+++ b/lib/robot_test.go
@@ -9,20 +9,15 @@ import (
 
 const (
 	testRobotShortname = "deploybot"
-	httpGetRobot       = "GET"
-	httpPutRobot       = "PUT"
-	httpPostRobot      = "POST"
-	httpDeleteRobot    = "DELETE"
-	roleWrite          = "write"
 )
 
 func TestGetUserRobotAccounts(t *testing.T) {
 	mockRobots := RobotAccounts{
 		Robots: []RobotAccount{
 			{
-				Name:        "testuser+deploybot",
-				Description: "Deployment robot",
-				Created:     "2024-01-15T10:30:00Z",
+				Name:        testRobotFullName,
+				Description: testRobotDescValue,
+				Created:     testTimestamp,
 			},
 			{
 				Name:        "testuser+cibot",
@@ -35,7 +30,7 @@ func TestGetUserRobotAccounts(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockRobots)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetRobot {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/user/robots" {
@@ -65,23 +60,23 @@ func TestGetUserRobotAccounts(t *testing.T) {
 	if len(robots.Robots) != 2 {
 		t.Errorf("Expected 2 robots, got %d", len(robots.Robots))
 	}
-	if robots.Robots[0].Name != "testuser+deploybot" {
+	if robots.Robots[0].Name != testRobotFullName {
 		t.Errorf("Expected robot name 'testuser+deploybot', got '%s'", robots.Robots[0].Name)
 	}
 }
 
 func TestGetUserRobotAccount(t *testing.T) {
 	mockRobot := RobotAccount{
-		Name:        "testuser+deploybot",
-		Description: "Deployment robot",
+		Name:        testRobotFullName,
+		Description: testRobotDescValue,
 		Token:       "secret-token-123",
-		Created:     "2024-01-15T10:30:00Z",
+		Created:     testTimestamp,
 	}
 
 	mockResponseJSON, _ := json.Marshal(mockRobot)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetRobot {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/user/robots/" + testRobotShortname
@@ -109,7 +104,7 @@ func TestGetUserRobotAccount(t *testing.T) {
 		t.Fatalf("GetUserRobotAccount failed: %v", err)
 	}
 
-	if robot.Name != "testuser+deploybot" {
+	if robot.Name != testRobotFullName {
 		t.Errorf("Expected robot name 'testuser+deploybot', got '%s'", robot.Name)
 	}
 	if robot.Token != "secret-token-123" {
@@ -128,7 +123,7 @@ func TestCreateUserRobotAccount(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockRobot)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPutRobot {
+		if r.Method != httpMethodPut {
 			t.Errorf("Expected PUT request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/user/robots/newbot" {
@@ -174,7 +169,7 @@ func TestCreateUserRobotAccount(t *testing.T) {
 
 func TestDeleteUserRobotAccount(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpDeleteRobot {
+		if r.Method != httpMethodDelete {
 			t.Errorf("Expected DELETE request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/user/robots/" + testRobotShortname
@@ -203,16 +198,16 @@ func TestDeleteUserRobotAccount(t *testing.T) {
 
 func TestRegenerateUserRobotToken(t *testing.T) {
 	mockRobot := RobotAccount{
-		Name:        "testuser+deploybot",
-		Description: "Deployment robot",
+		Name:        testRobotFullName,
+		Description: testRobotDescValue,
 		Token:       "regenerated-token-456",
-		Created:     "2024-01-15T10:30:00Z",
+		Created:     testTimestamp,
 	}
 
 	mockResponseJSON, _ := json.Marshal(mockRobot)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPostRobot {
+		if r.Method != httpMethodPost {
 			t.Errorf("Expected POST request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/user/robots/" + testRobotShortname + "/regenerate"
@@ -250,11 +245,11 @@ func TestGetUserRobotPermissions(t *testing.T) {
 		Permissions: []RobotPermission{
 			{
 				Repository: Repository{Name: "myrepo"},
-				Role:       roleWrite,
+				Role:       testRoleWrite,
 			},
 			{
 				Repository: Repository{Name: "otherrepo"},
-				Role:       "read",
+				Role:       testRoleRead,
 			},
 		},
 	}
@@ -262,7 +257,7 @@ func TestGetUserRobotPermissions(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockPermissions)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetRobot {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/user/robots/" + testRobotShortname + "/permissions"
@@ -293,7 +288,7 @@ func TestGetUserRobotPermissions(t *testing.T) {
 	if len(permissions.Permissions) != 2 {
 		t.Errorf("Expected 2 permissions, got %d", len(permissions.Permissions))
 	}
-	if permissions.Permissions[0].Role != roleWrite {
+	if permissions.Permissions[0].Role != testRoleWrite {
 		t.Errorf("Expected role 'write', got '%s'", permissions.Permissions[0].Role)
 	}
 }

--- a/lib/search_test.go
+++ b/lib/search_test.go
@@ -7,20 +7,15 @@ import (
 	"testing"
 )
 
-const (
-	httpGetSearch   = "GET"
-	testSearchQuery = "quay"
-)
-
 func TestSearchRepositories(t *testing.T) {
 	mockResult := SearchRepositoryResult{
 		Results: []SearchRepository{
 			{
-				Namespace:   testSearchQuery,
-				Name:        testSearchQuery,
+				Namespace:   testSearchQueryValue,
+				Name:        testSearchQueryValue,
 				Description: "Quay container registry",
 				IsPublic:    true,
-				Kind:        "image",
+				Kind:        testKindImage,
 				Popularity:  100.5,
 				Score:       0.95,
 			},
@@ -29,7 +24,7 @@ func TestSearchRepositories(t *testing.T) {
 				Name:        "quay-operator",
 				Description: "Quay Operator for OpenShift",
 				IsPublic:    true,
-				Kind:        "image",
+				Kind:        testKindImage,
 				Popularity:  50.2,
 				Score:       0.85,
 			},
@@ -42,14 +37,14 @@ func TestSearchRepositories(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResult)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetSearch {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/find/repositories" {
 			t.Errorf("Expected path /api/v1/find/repositories, got %s", r.URL.Path)
 		}
-		if r.URL.Query().Get("query") != testSearchQuery {
-			t.Errorf("Expected query '%s', got '%s'", testSearchQuery, r.URL.Query().Get("query"))
+		if r.URL.Query().Get("query") != testSearchQueryValue {
+			t.Errorf("Expected query '%s', got '%s'", testSearchQueryValue, r.URL.Query().Get("query"))
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -67,7 +62,7 @@ func TestSearchRepositories(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	result, err := client.SearchRepositories(testSearchQuery, 0)
+	result, err := client.SearchRepositories(testSearchQueryValue, 0)
 	if err != nil {
 		t.Fatalf("SearchRepositories failed: %v", err)
 	}
@@ -75,11 +70,11 @@ func TestSearchRepositories(t *testing.T) {
 	if len(result.Results) != 2 {
 		t.Errorf("Expected 2 results, got %d", len(result.Results))
 	}
-	if result.Results[0].Namespace != testSearchQuery {
-		t.Errorf("Expected namespace '%s', got '%s'", testSearchQuery, result.Results[0].Namespace)
+	if result.Results[0].Namespace != testSearchQueryValue {
+		t.Errorf("Expected namespace '%s', got '%s'", testSearchQueryValue, result.Results[0].Namespace)
 	}
-	if result.Results[0].Name != testSearchQuery {
-		t.Errorf("Expected name '%s', got '%s'", testSearchQuery, result.Results[0].Name)
+	if result.Results[0].Name != testSearchQueryValue {
+		t.Errorf("Expected name '%s', got '%s'", testSearchQueryValue, result.Results[0].Name)
 	}
 	if !result.HasAdditional {
 		t.Error("Expected HasAdditional to be true")
@@ -144,7 +139,7 @@ func TestSearchAll(t *testing.T) {
 			{
 				Name:        "quayuser",
 				Description: "Quay developer",
-				Kind:        "user",
+				Kind:        testKindUser,
 				Score:       0.75,
 			},
 			{
@@ -159,14 +154,14 @@ func TestSearchAll(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResult)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetSearch {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/find/all" {
 			t.Errorf("Expected path /api/v1/find/all, got %s", r.URL.Path)
 		}
-		if r.URL.Query().Get("query") != testSearchQuery {
-			t.Errorf("Expected query '%s', got '%s'", testSearchQuery, r.URL.Query().Get("query"))
+		if r.URL.Query().Get("query") != testSearchQueryValue {
+			t.Errorf("Expected query '%s', got '%s'", testSearchQueryValue, r.URL.Query().Get("query"))
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -184,7 +179,7 @@ func TestSearchAll(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	result, err := client.SearchAll(testSearchQuery)
+	result, err := client.SearchAll(testSearchQueryValue)
 	if err != nil {
 		t.Fatalf("SearchAll failed: %v", err)
 	}

--- a/lib/secscan_test.go
+++ b/lib/secscan_test.go
@@ -9,28 +9,27 @@ import (
 
 const (
 	testSecScanManifestRef = "sha256:abc123def456789"
-	httpGetSecScan         = "GET"
 )
 
 func TestGetManifestSecurity(t *testing.T) {
 	mockSecurityScan := SecurityScan{
-		Status: "scanned",
+		Status: testSecScanStatus,
 		Data: &SecurityData{
 			Layer: &SecurityLayer{
-				Name:             "sha256:abc123",
-				NamespaceName:    "centos:8",
+				Name:             testDigestSHA256,
+				NamespaceName:    testSecScanImageName,
 				IndexedByVersion: 4,
 				Features: []SecurityFeature{
 					{
 						Name:          "openssl",
 						Version:       "1.1.1k",
 						VersionFormat: "rpm",
-						NamespaceName: "centos:8",
+						NamespaceName: testSecScanImageName,
 						AddedBy:       "sha256:layer1",
 						Vulnerabilities: []SecurityVulnerability{
 							{
 								Name:          "CVE-2021-3712",
-								NamespaceName: "centos:8",
+								NamespaceName: testSecScanImageName,
 								Description:   "OpenSSL vulnerability in ASN.1 parsing",
 								Link:          "https://access.redhat.com/security/cve/CVE-2021-3712",
 								Severity:      "Medium",
@@ -42,7 +41,7 @@ func TestGetManifestSecurity(t *testing.T) {
 						Name:          "curl",
 						Version:       "7.61.1",
 						VersionFormat: "rpm",
-						NamespaceName: "centos:8",
+						NamespaceName: testSecScanImageName,
 						AddedBy:       "sha256:layer2",
 					},
 				},
@@ -53,7 +52,7 @@ func TestGetManifestSecurity(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockSecurityScan)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetSecScan {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/repository/testorg/testrepo/manifest/" + testSecScanManifestRef + "/security"
@@ -81,12 +80,12 @@ func TestGetManifestSecurity(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	securityScan, err := client.GetManifestSecurity("testorg", "testrepo", testSecScanManifestRef, true)
+	securityScan, err := client.GetManifestSecurity(testNamespace, testRepository, testSecScanManifestRef, true)
 	if err != nil {
 		t.Fatalf("GetManifestSecurity failed: %v", err)
 	}
 
-	if securityScan.Status != "scanned" {
+	if securityScan.Status != testSecScanStatus {
 		t.Errorf("Expected status 'scanned', got '%s'", securityScan.Status)
 	}
 	if securityScan.Data == nil {
@@ -117,10 +116,10 @@ func TestGetManifestSecurity(t *testing.T) {
 
 func TestGetManifestSecurityWithoutVulnerabilities(t *testing.T) {
 	mockSecurityScan := SecurityScan{
-		Status: "scanned",
+		Status: testSecScanStatus,
 		Data: &SecurityData{
 			Layer: &SecurityLayer{
-				Name:             "sha256:abc123",
+				Name:             testDigestSHA256,
 				IndexedByVersion: 4,
 			},
 		},
@@ -129,7 +128,7 @@ func TestGetManifestSecurityWithoutVulnerabilities(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockSecurityScan)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetSecScan {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 
@@ -153,12 +152,12 @@ func TestGetManifestSecurityWithoutVulnerabilities(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	securityScan, err := client.GetManifestSecurity("testorg", "testrepo", testSecScanManifestRef, false)
+	securityScan, err := client.GetManifestSecurity(testNamespace, testRepository, testSecScanManifestRef, false)
 	if err != nil {
 		t.Fatalf("GetManifestSecurity failed: %v", err)
 	}
 
-	if securityScan.Status != "scanned" {
+	if securityScan.Status != testSecScanStatus {
 		t.Errorf("Expected status 'scanned', got '%s'", securityScan.Status)
 	}
 }
@@ -187,7 +186,7 @@ func TestGetManifestSecurityQueued(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	securityScan, err := client.GetManifestSecurity("testorg", "testrepo", testSecScanManifestRef, true)
+	securityScan, err := client.GetManifestSecurity(testNamespace, testRepository, testSecScanManifestRef, true)
 	if err != nil {
 		t.Fatalf("GetManifestSecurity failed: %v", err)
 	}
@@ -217,7 +216,7 @@ func TestGetManifestSecurityErrorHandling(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetManifestSecurity("testorg", "testrepo", "nonexistent", true)
+	_, err = client.GetManifestSecurity(testNamespace, testRepository, "nonexistent", true)
 	if err == nil {
 		t.Error("Expected error for non-existent manifest, got nil")
 	}
@@ -247,7 +246,7 @@ func TestGetManifestSecurityUnsupported(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	securityScan, err := client.GetManifestSecurity("testorg", "testrepo", testSecScanManifestRef, true)
+	securityScan, err := client.GetManifestSecurity(testNamespace, testRepository, testSecScanManifestRef, true)
 	if err != nil {
 		t.Fatalf("GetManifestSecurity failed: %v", err)
 	}

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -410,7 +410,7 @@ type OrganizationRepository struct {
 	Kind         string  `json:"kind,omitempty"`
 	Namespace    string  `json:"namespace,omitempty"`
 	LastModified string  `json:"last_modified,omitempty"`
-	Popularity   float64 `json:"popularity,omitempty"`
+	Popularity   float64 `json:"popularity"`
 	TagsCount    int     `json:"tags_count,omitempty"`
 }
 
@@ -554,7 +554,7 @@ type StarredRepository struct {
 	IsPublic     bool    `json:"is_public,omitempty"`
 	Kind         string  `json:"kind,omitempty"`
 	LastModified string  `json:"last_modified,omitempty"`
-	Popularity   float64 `json:"popularity,omitempty"`
+	Popularity   float64 `json:"popularity"`
 }
 
 // StarredRepositories represents the response for starred repositories
@@ -571,7 +571,7 @@ type SearchRepository struct {
 	Description string  `json:"description,omitempty"`
 	IsPublic    bool    `json:"is_public,omitempty"`
 	Kind        string  `json:"kind,omitempty"`
-	Popularity  float64 `json:"popularity,omitempty"`
+	Popularity  float64 `json:"popularity"`
 	Score       float64 `json:"score,omitempty"`
 	Href        string  `json:"href,omitempty"`
 }

--- a/lib/tag_test.go
+++ b/lib/tag_test.go
@@ -13,10 +13,10 @@ const (
 
 func TestGetTag(t *testing.T) {
 	mockTag := Tag{
-		Name:           "v1.0.0",
+		Name:           testTagNameV1,
 		ManifestDigest: "sha256:abc123def456",
 		Size:           1024000,
-		LastModified:   "2024-01-15T10:30:00Z",
+		LastModified:   testTimestamp,
 		IsManifestList: false,
 		DockerImageID:  "abc123",
 		ImageID:        "def456",
@@ -29,7 +29,7 @@ func TestGetTag(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockTag)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "GET" {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/repository/testorg/testrepo/tag/v1.0.0" {
@@ -51,12 +51,12 @@ func TestGetTag(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	tag, err := client.GetTag("testorg", "testrepo", "v1.0.0")
+	tag, err := client.GetTag(testNamespace, testRepository, testTagNameV1)
 	if err != nil {
 		t.Fatalf("GetTag failed: %v", err)
 	}
 
-	if tag.Name != "v1.0.0" {
+	if tag.Name != testTagNameV1 {
 		t.Errorf("Expected tag name 'v1.0.0', got '%s'", tag.Name)
 	}
 	if tag.ManifestDigest != "sha256:abc123def456" {
@@ -72,15 +72,15 @@ func TestGetTag(t *testing.T) {
 
 func TestUpdateTag(t *testing.T) {
 	mockTag := Tag{
-		Name:         "v1.0.0",
-		Expiration:   "2024-12-31T23:59:59Z",
-		LastModified: "2024-01-15T10:30:00Z",
+		Name:         testTagNameV1,
+		Expiration:   testExpirationTime,
+		LastModified: testTimestamp,
 	}
 
 	mockResponseJSON, _ := json.Marshal(mockTag)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "PUT" {
+		if r.Method != httpMethodPut {
 			t.Errorf("Expected PUT request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/repository/testorg/testrepo/tag/v1.0.0" {
@@ -93,7 +93,7 @@ func TestUpdateTag(t *testing.T) {
 			t.Errorf("Failed to decode request body: %v", err)
 		}
 
-		if req.Expiration != "2024-12-31T23:59:59Z" {
+		if req.Expiration != testExpirationTime {
 			t.Errorf("Expected expiration '2024-12-31T23:59:59Z', got '%s'", req.Expiration)
 		}
 
@@ -112,19 +112,19 @@ func TestUpdateTag(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	tag, err := client.UpdateTag("testorg", "testrepo", "v1.0.0", "2024-12-31T23:59:59Z")
+	tag, err := client.UpdateTag(testNamespace, testRepository, testTagNameV1, testExpirationTime)
 	if err != nil {
 		t.Fatalf("UpdateTag failed: %v", err)
 	}
 
-	if tag.Expiration != "2024-12-31T23:59:59Z" {
+	if tag.Expiration != testExpirationTime {
 		t.Errorf("Expected expiration '2024-12-31T23:59:59Z', got '%s'", tag.Expiration)
 	}
 }
 
 func TestDeleteTag(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "DELETE" {
+		if r.Method != httpMethodDelete {
 			t.Errorf("Expected DELETE request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/repository/testorg/testrepo/tag/old-version" {
@@ -144,7 +144,7 @@ func TestDeleteTag(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteTag("testorg", "testrepo", "old-version")
+	err = client.DeleteTag(testNamespace, testRepository, "old-version")
 	if err != nil {
 		t.Fatalf("DeleteTag failed: %v", err)
 	}
@@ -154,13 +154,13 @@ func TestGetTagHistory(t *testing.T) {
 	mockHistory := TagHistory{
 		Tags: []Tag{
 			{
-				Name:           "latest",
-				ManifestDigest: "sha256:abc123",
-				LastModified:   "2024-01-15T10:30:00Z",
+				Name:           testTagNameLatest,
+				ManifestDigest: testDigestSHA256,
+				LastModified:   testTimestamp,
 				Size:           1024000,
 			},
 			{
-				Name:           "latest",
+				Name:           testTagNameLatest,
 				ManifestDigest: testManifestDigest,
 				LastModified:   "2024-01-10T08:15:00Z",
 				Size:           1020000,
@@ -171,7 +171,7 @@ func TestGetTagHistory(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockHistory)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "GET" {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/repository/testorg/testrepo/tag/latest/history" {
@@ -193,7 +193,7 @@ func TestGetTagHistory(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	history, err := client.GetTagHistory("testorg", "testrepo", "latest")
+	history, err := client.GetTagHistory(testNamespace, testRepository, testTagNameLatest)
 	if err != nil {
 		t.Fatalf("GetTagHistory failed: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestGetTagHistory(t *testing.T) {
 	}
 
 	// Check first tag (most recent)
-	if history.Tags[0].ManifestDigest != "sha256:abc123" {
+	if history.Tags[0].ManifestDigest != testDigestSHA256 {
 		t.Errorf("Expected first tag manifest 'sha256:abc123', got '%s'", history.Tags[0].ManifestDigest)
 	}
 
@@ -215,7 +215,7 @@ func TestGetTagHistory(t *testing.T) {
 
 func TestRevertTag(t *testing.T) {
 	mockTag := Tag{
-		Name:           "latest",
+		Name:           testTagNameLatest,
 		ManifestDigest: testManifestDigest,
 		LastModified:   "2024-01-15T11:00:00Z",
 	}
@@ -223,7 +223,7 @@ func TestRevertTag(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockTag)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "POST" {
+		if r.Method != httpMethodPost {
 			t.Errorf("Expected POST request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/repository/testorg/testrepo/tag/latest/revert" {
@@ -255,7 +255,7 @@ func TestRevertTag(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	tag, err := client.RevertTag("testorg", "testrepo", "latest", testManifestDigest)
+	tag, err := client.RevertTag(testNamespace, testRepository, testTagNameLatest, testManifestDigest)
 	if err != nil {
 		t.Fatalf("RevertTag failed: %v", err)
 	}
@@ -283,31 +283,31 @@ func TestTagErrorHandling(t *testing.T) {
 	}
 
 	// Test GetTag error
-	_, err = client.GetTag("testorg", "testrepo", "nonexistent")
+	_, err = client.GetTag(testNamespace, testRepository, "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent tag, got nil")
 	}
 
 	// Test UpdateTag error
-	_, err = client.UpdateTag("testorg", "testrepo", "nonexistent", "2024-12-31T23:59:59Z")
+	_, err = client.UpdateTag(testNamespace, testRepository, "nonexistent", testExpirationTime)
 	if err == nil {
 		t.Error("Expected error for non-existent tag, got nil")
 	}
 
 	// Test DeleteTag error
-	err = client.DeleteTag("testorg", "testrepo", "nonexistent")
+	err = client.DeleteTag(testNamespace, testRepository, "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent tag, got nil")
 	}
 
 	// Test GetTagHistory error
-	_, err = client.GetTagHistory("testorg", "testrepo", "nonexistent")
+	_, err = client.GetTagHistory(testNamespace, testRepository, "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent tag, got nil")
 	}
 
 	// Test RevertTag error
-	_, err = client.RevertTag("testorg", "testrepo", "nonexistent", "sha256:abc123")
+	_, err = client.RevertTag(testNamespace, testRepository, "nonexistent", testDigestSHA256)
 	if err == nil {
 		t.Error("Expected error for non-existent tag, got nil")
 	}

--- a/lib/team_test.go
+++ b/lib/team_test.go
@@ -8,17 +8,11 @@ import (
 )
 
 const (
-	httpGetTeam    = "GET"
-	httpPutTeam    = "PUT"
-	httpDeleteTeam = "DELETE"
-
-	testOrgName    = "test-org"
-	testTeamName   = "developers"
-	testMemberName = "testuser"
-	testRepoName   = "test-repo"
-	roleAdmin      = "admin"
-	roleMember     = "member"
-	roleRead       = "read"
+	testOrgName  = "test-org"
+	testTeamName = "developers"
+	testRepoName = "test-repo"
+	roleAdmin    = "admin"
+	roleMember   = "member"
 )
 
 func TestGetTeams(t *testing.T) {
@@ -33,7 +27,7 @@ func TestGetTeams(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetTeam {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/organization/" + testOrgName + "/teams"
@@ -81,7 +75,7 @@ func TestGetTeam(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetTeam {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName
@@ -127,7 +121,7 @@ func TestCreateTeam(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPutTeam {
+		if r.Method != httpMethodPut {
 			t.Errorf("Expected PUT request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName
@@ -170,7 +164,7 @@ func TestUpdateTeam(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPutTeam {
+		if r.Method != httpMethodPut {
 			t.Errorf("Expected PUT request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName
@@ -209,7 +203,7 @@ func TestUpdateTeam(t *testing.T) {
 
 func TestDeleteTeam(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpDeleteTeam {
+		if r.Method != httpMethodDelete {
 			t.Errorf("Expected DELETE request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName
@@ -238,14 +232,14 @@ func TestDeleteTeam(t *testing.T) {
 func TestGetTeamMembers(t *testing.T) {
 	mockResponse := TeamMembers{
 		Members: []TeamMember{
-			{Name: testMemberName, Kind: "user", IsRobot: false},
-			{Name: "robot+builder", Kind: "robot", IsRobot: true},
+			{Name: testUserName, Kind: testKindUser, IsRobot: false},
+			{Name: "robot+builder", Kind: testKindRobot, IsRobot: true},
 		},
 	}
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetTeam {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName + "/members"
@@ -274,8 +268,8 @@ func TestGetTeamMembers(t *testing.T) {
 	if len(members.Members) != 2 {
 		t.Errorf("Expected 2 members, got %d", len(members.Members))
 	}
-	if members.Members[0].Name != testMemberName {
-		t.Errorf("Expected first member name %s, got %s", testMemberName, members.Members[0].Name)
+	if members.Members[0].Name != testUserName {
+		t.Errorf("Expected first member name %s, got %s", testUserName, members.Members[0].Name)
 	}
 	if members.Members[0].IsRobot {
 		t.Errorf("Expected first member to not be a robot")
@@ -287,10 +281,10 @@ func TestGetTeamMembers(t *testing.T) {
 
 func TestAddTeamMember(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPutTeam {
+		if r.Method != httpMethodPut {
 			t.Errorf("Expected PUT request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName + "/members/" + testMemberName
+		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName + "/members/" + testUserName
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -307,7 +301,7 @@ func TestAddTeamMember(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.AddTeamMember(testOrgName, testTeamName, testMemberName)
+	err = client.AddTeamMember(testOrgName, testTeamName, testUserName)
 	if err != nil {
 		t.Fatalf("AddTeamMember returned error: %v", err)
 	}
@@ -315,10 +309,10 @@ func TestAddTeamMember(t *testing.T) {
 
 func TestRemoveTeamMember(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpDeleteTeam {
+		if r.Method != httpMethodDelete {
 			t.Errorf("Expected DELETE request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName + "/members/" + testMemberName
+		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName + "/members/" + testUserName
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -335,7 +329,7 @@ func TestRemoveTeamMember(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.RemoveTeamMember(testOrgName, testTeamName, testMemberName)
+	err = client.RemoveTeamMember(testOrgName, testTeamName, testUserName)
 	if err != nil {
 		t.Fatalf("RemoveTeamMember returned error: %v", err)
 	}
@@ -344,14 +338,14 @@ func TestRemoveTeamMember(t *testing.T) {
 func TestGetTeamPermissions(t *testing.T) {
 	mockResponse := TeamPermissions{
 		Permissions: []TeamPermission{
-			{Repository: Repository{Name: testRepoName}, Role: roleRead},
-			{Repository: Repository{Name: "another-repo"}, Role: "write"},
+			{Repository: Repository{Name: testRepoName}, Role: testRoleRead},
+			{Repository: Repository{Name: "another-repo"}, Role: testRoleWrite},
 		},
 	}
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetTeam {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName + "/permissions"
@@ -383,14 +377,14 @@ func TestGetTeamPermissions(t *testing.T) {
 	if perms.Permissions[0].Repository.Name != testRepoName {
 		t.Errorf("Expected first repo name %s, got %s", testRepoName, perms.Permissions[0].Repository.Name)
 	}
-	if perms.Permissions[0].Role != roleRead {
-		t.Errorf("Expected first role %s, got %s", roleRead, perms.Permissions[0].Role)
+	if perms.Permissions[0].Role != testRoleRead {
+		t.Errorf("Expected first role %s, got %s", testRoleRead, perms.Permissions[0].Role)
 	}
 }
 
 func TestSetTeamRepositoryPermission(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPutTeam {
+		if r.Method != httpMethodPut {
 			t.Errorf("Expected PUT request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName + "/permissions/" + testRepoName
@@ -410,7 +404,7 @@ func TestSetTeamRepositoryPermission(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.SetTeamRepositoryPermission(testOrgName, testTeamName, testRepoName, "write")
+	err = client.SetTeamRepositoryPermission(testOrgName, testTeamName, testRepoName, testRoleWrite)
 	if err != nil {
 		t.Fatalf("SetTeamRepositoryPermission returned error: %v", err)
 	}
@@ -418,7 +412,7 @@ func TestSetTeamRepositoryPermission(t *testing.T) {
 
 func TestRemoveTeamRepositoryPermission(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpDeleteTeam {
+		if r.Method != httpMethodDelete {
 			t.Errorf("Expected DELETE request, got %s", r.Method)
 		}
 		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName + "/permissions/" + testRepoName

--- a/lib/test_constants_test.go
+++ b/lib/test_constants_test.go
@@ -1,0 +1,71 @@
+package lib
+
+// Shared test constants used across all test files in the lib package.
+// Organized by category to avoid duplication and satisfy goconst linter.
+
+const (
+	// HTTP methods
+	httpMethodGet    = "GET"
+	httpMethodPost   = "POST"
+	httpMethodPut    = "PUT"
+	httpMethodDelete = "DELETE"
+
+	// Common test namespaces and repositories
+	testNamespace  = "testorg"
+	testRepository = "testrepo"
+
+	// Common test roles
+	testRoleRead  = "read"
+	testRoleWrite = "write"
+
+	// Common test tag names
+	testTagNameLatest = "latest"
+	testTagNameV1     = "v1.0.0"
+
+	// Common test timestamps
+	testTimestamp      = "2024-01-15T10:30:00Z"
+	testExpirationTime = "2024-12-31T23:59:59Z"
+
+	// Common test digests
+	testDigestSHA256 = "sha256:abc123"
+
+	// Common test media types
+	testMediaTypePlain = "text/plain"
+
+	// Common test kinds
+	testKindImage = "image"
+	testKindUser  = "user"
+	testKindRobot = "robot"
+	testKindTeam  = "team"
+
+	// Common test entity names
+	testEmailAddress     = "test@example.com"
+	testUserName         = "testuser"
+	testSearchQueryValue = "quay"
+
+	// Manifest label keys and values
+	testLabelKeyVersion     = "version"
+	testLabelKeyAPI         = "api"
+	testLabelKeyEnvironment = "environment"
+	testLabelValProduction  = "production"
+
+	// Permissions test values
+	testPermUserName = "john.doe"
+
+	// Prototype test values
+	testPrototypeTeamName = "devteam"
+
+	// Repository test values
+	testRepoDescription = "Test repository"
+
+	// Repo token test values
+	testRepoTokenName = "CI Token"
+
+	// Robot test values
+	testRobotFullName  = "testuser+deploybot"
+	testRobotDescValue = "Deployment robot"
+
+	// Security scan test values
+	testSecScanStatus    = "scanned"
+	testSecScanImageName = "centos:8"
+)

--- a/lib/trigger_test.go
+++ b/lib/trigger_test.go
@@ -8,15 +8,8 @@ import (
 )
 
 const (
-	httpGetTrigger    = "GET"
-	httpPutTrigger    = "PUT"
-	httpPostTrigger   = "POST"
-	httpDeleteTrigger = "DELETE"
-
-	testTriggerNamespace  = "testorg"
-	testTriggerRepository = "testrepo"
-	testTriggerUUID       = "trigger-uuid-123"
-	testTriggerService    = "github"
+	testTriggerUUID    = "trigger-uuid-123"
+	testTriggerService = "github"
 )
 
 func TestGetTriggers(t *testing.T) {
@@ -29,10 +22,10 @@ func TestGetTriggers(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetTrigger {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testTriggerNamespace + "/" + testTriggerRepository + "/trigger/"
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/trigger/"
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -50,7 +43,7 @@ func TestGetTriggers(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	triggers, err := client.GetTriggers(testTriggerNamespace, testTriggerRepository)
+	triggers, err := client.GetTriggers(testNamespace, testRepository)
 	if err != nil {
 		t.Fatalf("GetTriggers returned error: %v", err)
 	}
@@ -79,10 +72,10 @@ func TestGetTrigger(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGetTrigger {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testTriggerNamespace + "/" + testTriggerRepository + "/trigger/" + testTriggerUUID
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/trigger/" + testTriggerUUID
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -100,7 +93,7 @@ func TestGetTrigger(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	trigger, err := client.GetTrigger(testTriggerNamespace, testTriggerRepository, testTriggerUUID)
+	trigger, err := client.GetTrigger(testNamespace, testRepository, testTriggerUUID)
 	if err != nil {
 		t.Fatalf("GetTrigger returned error: %v", err)
 	}
@@ -118,10 +111,10 @@ func TestGetTrigger(t *testing.T) {
 
 func TestDeleteTrigger(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpDeleteTrigger {
+		if r.Method != httpMethodDelete {
 			t.Errorf("Expected DELETE request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testTriggerNamespace + "/" + testTriggerRepository + "/trigger/" + testTriggerUUID
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/trigger/" + testTriggerUUID
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -138,7 +131,7 @@ func TestDeleteTrigger(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteTrigger(testTriggerNamespace, testTriggerRepository, testTriggerUUID)
+	err = client.DeleteTrigger(testNamespace, testRepository, testTriggerUUID)
 	if err != nil {
 		t.Fatalf("DeleteTrigger returned error: %v", err)
 	}
@@ -154,10 +147,10 @@ func TestUpdateTrigger(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPutTrigger {
+		if r.Method != httpMethodPut {
 			t.Errorf("Expected PUT request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testTriggerNamespace + "/" + testTriggerRepository + "/trigger/" + testTriggerUUID
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/trigger/" + testTriggerUUID
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -175,7 +168,7 @@ func TestUpdateTrigger(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	trigger, err := client.UpdateTrigger(testTriggerNamespace, testTriggerRepository, testTriggerUUID, false)
+	trigger, err := client.UpdateTrigger(testNamespace, testRepository, testTriggerUUID, false)
 	if err != nil {
 		t.Fatalf("UpdateTrigger returned error: %v", err)
 	}
@@ -193,10 +186,10 @@ func TestStartTriggerBuild(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPostTrigger {
+		if r.Method != httpMethodPost {
 			t.Errorf("Expected POST request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testTriggerNamespace + "/" + testTriggerRepository + "/trigger/" + testTriggerUUID + "/start"
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/trigger/" + testTriggerUUID + "/start"
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -219,7 +212,7 @@ func TestStartTriggerBuild(t *testing.T) {
 		CommitSHA: "abc123def456",
 	}
 
-	build, err := client.StartTriggerBuild(testTriggerNamespace, testTriggerRepository, testTriggerUUID, triggerReq)
+	build, err := client.StartTriggerBuild(testNamespace, testRepository, testTriggerUUID, triggerReq)
 	if err != nil {
 		t.Fatalf("StartTriggerBuild returned error: %v", err)
 	}
@@ -239,10 +232,10 @@ func TestActivateTrigger(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockResponse)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPostTrigger {
+		if r.Method != httpMethodPost {
 			t.Errorf("Expected POST request, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/repository/" + testTriggerNamespace + "/" + testTriggerRepository + "/trigger/" + testTriggerUUID + "/activate"
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/trigger/" + testTriggerUUID + "/activate"
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -267,7 +260,7 @@ func TestActivateTrigger(t *testing.T) {
 		},
 	}
 
-	trigger, err := client.ActivateTrigger(testTriggerNamespace, testTriggerRepository, testTriggerUUID, activateReq)
+	trigger, err := client.ActivateTrigger(testNamespace, testRepository, testTriggerUUID, activateReq)
 	if err != nil {
 		t.Fatalf("ActivateTrigger returned error: %v", err)
 	}
@@ -295,7 +288,7 @@ func TestGetTriggersError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetTriggers(testTriggerNamespace, testTriggerRepository)
+	_, err = client.GetTriggers(testNamespace, testRepository)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -316,7 +309,7 @@ func TestGetTriggerError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetTrigger(testTriggerNamespace, testTriggerRepository, "nonexistent-uuid")
+	_, err = client.GetTrigger(testNamespace, testRepository, "nonexistent-uuid")
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}

--- a/lib/user_test.go
+++ b/lib/user_test.go
@@ -7,30 +7,23 @@ import (
 	"testing"
 )
 
-const (
-	httpGet    = "GET"
-	httpPut    = "PUT"
-	httpDelete = "DELETE"
-	testOrg    = "testorg"
-)
-
 func TestGetUser(t *testing.T) {
 	mockUser := UserDetails{
 		Anonymous:      false,
-		Username:       "testuser",
-		Email:          "test@example.com",
+		Username:       testUserName,
+		Email:          testEmailAddress,
 		Verified:       true,
 		CanCreateRepo:  true,
 		PreferredUsers: false,
 		TagExpirationS: 2592000, // 30 days
 		Avatar: Avatar{
-			Name: "testuser",
-			Kind: "user",
+			Name: testUserName,
+			Kind: testKindUser,
 		},
 		Organizations: []User{
 			{
-				Name:     testOrg,
-				Username: testOrg,
+				Name:     testNamespace,
+				Username: testNamespace,
 				Kind:     "organization",
 			},
 		},
@@ -39,7 +32,7 @@ func TestGetUser(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockUser)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGet {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/user" {
@@ -72,10 +65,10 @@ func TestGetUser(t *testing.T) {
 		t.Fatalf("GetUser failed: %v", err)
 	}
 
-	if user.Username != "testuser" {
+	if user.Username != testUserName {
 		t.Errorf("Expected username 'testuser', got '%s'", user.Username)
 	}
-	if user.Email != "test@example.com" {
+	if user.Email != testEmailAddress {
 		t.Errorf("Expected email 'test@example.com', got '%s'", user.Email)
 	}
 	if user.Anonymous != false {
@@ -90,7 +83,7 @@ func TestGetUser(t *testing.T) {
 	if len(user.Organizations) != 1 {
 		t.Errorf("Expected 1 organization, got %d", len(user.Organizations))
 	}
-	if user.Organizations[0].Name != testOrg {
+	if user.Organizations[0].Name != testNamespace {
 		t.Errorf("Expected organization name 'testorg', got '%s'", user.Organizations[0].Name)
 	}
 }
@@ -99,20 +92,20 @@ func TestGetStarredRepositories(t *testing.T) {
 	mockStarred := StarredRepositories{
 		Repositories: []StarredRepository{
 			{
-				Namespace:    "quay",
-				Name:         "quay",
+				Namespace:    testSearchQueryValue,
+				Name:         testSearchQueryValue,
 				Description:  "Container registry and security scanner",
 				IsPublic:     true,
-				Kind:         "image",
+				Kind:         testKindImage,
 				LastModified: "2024-01-15T10:30:00Z",
 				Popularity:   95.5,
 			},
 			{
-				Namespace:    testOrg,
+				Namespace:    testNamespace,
 				Name:         "myapp",
 				Description:  "My test application",
 				IsPublic:     false,
-				Kind:         "image",
+				Kind:         testKindImage,
 				LastModified: "2024-01-10T08:15:00Z",
 				Popularity:   10.2,
 			},
@@ -122,7 +115,7 @@ func TestGetStarredRepositories(t *testing.T) {
 	mockResponseJSON, _ := json.Marshal(mockStarred)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpGet {
+		if r.Method != httpMethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/user/starred" {
@@ -155,7 +148,7 @@ func TestGetStarredRepositories(t *testing.T) {
 
 	// Check first repository
 	repo1 := starred.Repositories[0]
-	if repo1.Namespace != "quay" || repo1.Name != "quay" {
+	if repo1.Namespace != testSearchQueryValue || repo1.Name != testSearchQueryValue {
 		t.Errorf("Expected first repository 'quay/quay', got '%s/%s'", repo1.Namespace, repo1.Name)
 	}
 	if repo1.IsPublic != true {
@@ -167,7 +160,7 @@ func TestGetStarredRepositories(t *testing.T) {
 
 	// Check second repository
 	repo2 := starred.Repositories[1]
-	if repo2.Namespace != testOrg || repo2.Name != "myapp" {
+	if repo2.Namespace != testNamespace || repo2.Name != "myapp" {
 		t.Errorf("Expected second repository 'testorg/myapp', got '%s/%s'", repo2.Namespace, repo2.Name)
 	}
 	if repo2.IsPublic != false {
@@ -177,7 +170,7 @@ func TestGetStarredRepositories(t *testing.T) {
 
 func TestStarRepository(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpPut {
+		if r.Method != httpMethodPut {
 			t.Errorf("Expected PUT request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/repository/quay/quay/star" {
@@ -197,7 +190,7 @@ func TestStarRepository(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.StarRepository("quay", "quay")
+	err = client.StarRepository(testSearchQueryValue, testSearchQueryValue)
 	if err != nil {
 		t.Fatalf("StarRepository failed: %v", err)
 	}
@@ -205,7 +198,7 @@ func TestStarRepository(t *testing.T) {
 
 func TestUnstarRepository(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpDelete {
+		if r.Method != httpMethodDelete {
 			t.Errorf("Expected DELETE request, got %s", r.Method)
 		}
 		if r.URL.Path != "/api/v1/repository/quay/quay/star" {
@@ -225,7 +218,7 @@ func TestUnstarRepository(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.UnstarRepository("quay", "quay")
+	err = client.UnstarRepository(testSearchQueryValue, testSearchQueryValue)
 	if err != nil {
 		t.Fatalf("UnstarRepository failed: %v", err)
 	}
@@ -261,13 +254,13 @@ func TestUserErrorHandling(t *testing.T) {
 	}
 
 	// Test StarRepository error
-	err = client.StarRepository("quay", "quay")
+	err = client.StarRepository(testSearchQueryValue, testSearchQueryValue)
 	if err == nil {
 		t.Error("Expected error for invalid token, got nil")
 	}
 
 	// Test UnstarRepository error
-	err = client.UnstarRepository("quay", "quay")
+	err = client.UnstarRepository(testSearchQueryValue, testSearchQueryValue)
 	if err == nil {
 		t.Error("Expected error for invalid token, got nil")
 	}


### PR DESCRIPTION
## Summary

- Add `repo-aggregated-logs` CLI command under the `logs` group, exposing the existing `GetAggregatedLogs` lib function that previously only had a legacy standalone command
- Add `--startdate`/`--enddate` flags to `repo-logs`, `org-logs`, and `user-logs` commands, with corresponding lib function signature updates to pass `starttime`/`endtime` query params to the Quay API
- Remove `omitempty` from the `Popularity` JSON tag on `OrganizationRepository`, `StarredRepository`, and `SearchRepository` so zero values appear in output instead of being silently dropped
- Improve CLAUDE.md with architectural details and remove redundant content

## Test plan

- [x] `make lint` passes (0 issues)
- [x] `go test ./...` passes (all existing + 8 new tests in `lib/logs_test.go`)
- [x] Manual verification: `repo-aggregated-logs` returns aggregated pull counts
- [x] Manual verification: `repo-logs --startdate --enddate` filters by date range
- [x] Manual verification: `repository list` now shows `"popularity": 0` instead of omitting the field