### PR TITLE
feat: add Dockerfile, container image CI, and expanded install docs

### DIFF
--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -1,0 +1,42 @@
+name: Release container image
+
+on:
+  release:
+    types: [published]
+
+permissions: read-all
+
+jobs:
+  build-and-push:
+    name: Build and push container image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Extract version tag
+        id: version
+        run: echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            quay.io/bapalm/go-quay:${{ steps.version.outputs.tag }}
+            quay.io/bapalm/go-quay:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.26 AS builder
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /go-quay .
+
+FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /go-quay /go-quay
+ENTRYPOINT ["/go-quay"]

--- a/README.md
+++ b/README.md
@@ -11,8 +11,44 @@ A Go wrapper around Quay APIs
 
 ### Installation
 
+#### Prebuilt binary
+
+Download the latest release for your platform from [GitHub Releases](https://github.com/sebrandon1/go-quay/releases):
+
 ```bash
-go get github.com/sebrandon1/go-quay
+# Linux (amd64)
+curl -sL https://github.com/sebrandon1/go-quay/releases/latest/download/go-quay_$(curl -sL https://api.github.com/repos/sebrandon1/go-quay/releases/latest | grep tag_name | cut -d '"' -f4)_linux_amd64.tar.gz | tar xz
+sudo mv go-quay /usr/local/bin/
+
+# macOS (Apple Silicon)
+curl -sL https://github.com/sebrandon1/go-quay/releases/latest/download/go-quay_$(curl -sL https://api.github.com/repos/sebrandon1/go-quay/releases/latest | grep tag_name | cut -d '"' -f4)_darwin_arm64.tar.gz | tar xz
+sudo mv go-quay /usr/local/bin/
+```
+
+#### Container image
+
+```bash
+# Using podman
+podman run --rm quay.io/bapalm/go-quay get repository info \
+  -n myorg -r myapp -t "$QUAY_TOKEN"
+
+# Using docker
+docker run --rm quay.io/bapalm/go-quay get repository info \
+  -n myorg -r myapp -t "$QUAY_TOKEN"
+```
+
+#### Go install
+
+```bash
+go install github.com/sebrandon1/go-quay@latest
+```
+
+#### Build from source
+
+```bash
+git clone https://github.com/sebrandon1/go-quay.git
+cd go-quay
+make build
 ```
 
 ### Library Usage
@@ -54,11 +90,12 @@ func main() {
 ### CLI Usage
 
 ```bash
-# Build the CLI
-make build
-
 # Get repository info
-./go-quay get repository info --namespace myorg --repository myapp --token YOUR_TOKEN
+go-quay get repository info --namespace myorg --repository myapp --token YOUR_TOKEN
+
+# Or run via container
+podman run --rm quay.io/bapalm/go-quay get repository info \
+  -n myorg -r myapp -t "$QUAY_TOKEN"
 ```
 
 ## Documentation


### PR DESCRIPTION
## Summary

- Add multi-stage `Dockerfile` (golang:1.26 builder -> scratch runtime) with CA certs for HTTPS API calls
- Add `release-image.yaml` workflow that builds multi-arch images (linux/amd64 + linux/arm64) and pushes to `quay.io/bapalm/go-quay` on every GitHub release
- Expand README installation section with four options: prebuilt binary, container image, `go install`, and build from source
- Update CLI usage section to show container alternative

## Test plan

- [x] `docker build -t go-quay:test .` builds successfully
- [x] `docker run --rm go-quay:test --help` shows CLI help
- [x] `make lint` passes (0 issues)
- [x] `go test ./...` passes
- [ ] Verify release-image workflow triggers on next release and pushes to quay.io/bapalm/go-quay
