### PR TITLE
ci: add major version tag, unstable image, and major version image tag

### DIFF
--- a/.github/workflows/unstable-image.yaml
+++ b/.github/workflows/unstable-image.yaml
@@ -1,14 +1,14 @@
-name: Release container image
+name: Unstable container image
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
 
 permissions: read-all
 
 jobs:
   build-and-push:
-    name: Build and push container image
+    name: Build and push unstable image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,21 +27,10 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Extract version tags
-        id: version
-        run: |
-          TAG="${GITHUB_REF_NAME}"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          MAJOR=$(echo "$TAG" | grep -oE '^v[0-9]+')
-          echo "major=${MAJOR}" >> "$GITHUB_OUTPUT"
-
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            quay.io/bapalm/go-quay:${{ steps.version.outputs.tag }}
-            quay.io/bapalm/go-quay:${{ steps.version.outputs.major }}
-            quay.io/bapalm/go-quay:latest
+          tags: quay.io/bapalm/go-quay:unstable

--- a/.github/workflows/update-major-tag.yaml
+++ b/.github/workflows/update-major-tag.yaml
@@ -1,0 +1,39 @@
+name: Update Major Version Tag
+
+on:
+  release:
+    types: [published]
+
+permissions: read-all
+
+jobs:
+  update-major-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Update major version tag
+        run: |
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          echo "Release tag: $TAG_NAME"
+
+          if [[ $TAG_NAME =~ ^v([0-9]+)\. ]]; then
+            MAJOR_VERSION="v${BASH_REMATCH[1]}"
+            echo "Major version: $MAJOR_VERSION"
+
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            git tag -d "$MAJOR_VERSION" 2>/dev/null || true
+            git tag -fa "$MAJOR_VERSION" -m "Update $MAJOR_VERSION to $TAG_NAME"
+            git push origin "$MAJOR_VERSION" --force
+
+            echo "Successfully updated $MAJOR_VERSION tag to point to $TAG_NAME"
+          else
+            echo "Tag $TAG_NAME does not match expected format (vX.Y.Z), skipping"
+          fi


### PR DESCRIPTION
## Summary

- Add `update-major-tag.yaml` workflow — on release, moves the major version git tag (e.g., `v1`) to point to the latest release
- Update `release-image.yaml` — also tags the container image with the major version (e.g., `quay.io/bapalm/go-quay:v1`)
- Add `unstable-image.yaml` workflow — builds and pushes `quay.io/bapalm/go-quay:unstable` on every push to main

### Image tags after a v1.0.2 release:
- `quay.io/bapalm/go-quay:v1.0.2` — exact version
- `quay.io/bapalm/go-quay:v1` — latest v1.x
- `quay.io/bapalm/go-quay:latest` — latest release
- `quay.io/bapalm/go-quay:unstable` — latest main (built on every merge)

## Test plan

- [ ] Verify `unstable` tag is built on merge to main
- [ ] Verify `v1` git tag and image tag are created on next release
