### PR TITLE
feat: add --version flag with embedded build info

### DIFF
--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -33,7 +33,7 @@ jobs:
           mkdir -p dist
           BINARY_NAME=go-quay
           OUTPUT="dist/${BINARY_NAME}"
-          go build -trimpath -ldflags "-s -w" -o "$OUTPUT" .
+          go build -trimpath -ldflags "-s -w -X main.version=${GITHUB_REF_NAME}" -o "$OUTPUT" .
 
       - name: Package
         run: |

--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -41,6 +41,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: VERSION=${{ steps.version.outputs.tag }}
           tags: |
             quay.io/bapalm/go-quay:${{ steps.version.outputs.tag }}
             quay.io/bapalm/go-quay:${{ steps.version.outputs.major }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /go-quay .
+ARG VERSION=dev
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" -o /go-quay .
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,10 @@ APP_NAME=go-quay
 vet:
 	go vet ./...
 
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+
 build:
-	go build -o $(APP_NAME)
+	go build -ldflags "-X main.version=$(VERSION)" -o $(APP_NAME)
 
 lint:
 	golangci-lint run ./...

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,10 @@ var rootCmd = &cobra.Command{
 	Short: "Quay CLI interacts with Quay.io API",
 }
 
+func SetVersion(v string) {
+	rootCmd.Version = v
+}
+
 var getCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Get objects from Quay.io",

--- a/main.go
+++ b/main.go
@@ -2,6 +2,9 @@ package main
 
 import "github.com/sebrandon1/go-quay/cmd"
 
+var version = "dev"
+
 func main() {
+	cmd.SetVersion(version)
 	_ = cmd.Execute()
 }


### PR DESCRIPTION
## Summary

- Add `--version` flag to the CLI via Cobra's built-in version support
- Embed version at build time via `-X main.version` ldflags
- Makefile uses `git describe --tags --always --dirty` for local builds
- Release binaries workflow injects `GITHUB_REF_NAME` (the release tag)
- Release image workflow passes version as Docker build arg
- Dockerfile accepts `VERSION` build arg and passes it through ldflags

```bash
$ go-quay --version
quay version v1.0.2
```

## Test plan

- [x] `make build && ./go-quay --version` shows version from git describe
- [x] `make lint` passes (0 issues)
- [x] `go test ./...` passes
