### PR TITLE
feat: read token from QUAY_TOKEN env var by default

### DIFF
--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -11,7 +11,6 @@ import (
 
 var (
 	billingOrgName string
-	billingToken   string
 )
 
 // billingCmd represents the billing command
@@ -26,7 +25,7 @@ var orgBillingCmd = &cobra.Command{
 	Use:   "org-info",
 	Short: "Get billing information for an organization",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(billingToken)
+		client, err := lib.NewClient(token)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			return
@@ -53,7 +52,7 @@ var userBillingCmd = &cobra.Command{
 	Use:   "user-info",
 	Short: "Get billing information for the current user",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(billingToken)
+		client, err := lib.NewClient(token)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			return
@@ -80,7 +79,7 @@ var orgSubscriptionCmd = &cobra.Command{
 	Use:   "org-subscription",
 	Short: "Get subscription details for an organization",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(billingToken)
+		client, err := lib.NewClient(token)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			return
@@ -107,7 +106,7 @@ var userSubscriptionCmd = &cobra.Command{
 	Use:   "user-subscription",
 	Short: "Get subscription details for the current user",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(billingToken)
+		client, err := lib.NewClient(token)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			return
@@ -134,7 +133,7 @@ var orgInvoicesCmd = &cobra.Command{
 	Use:   "org-invoices",
 	Short: "Get invoices for an organization",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(billingToken)
+		client, err := lib.NewClient(token)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			return
@@ -161,7 +160,7 @@ var userInvoicesCmd = &cobra.Command{
 	Use:   "user-invoices",
 	Short: "Get invoices for the current user",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(billingToken)
+		client, err := lib.NewClient(token)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -182,7 +181,7 @@ var plansCmd = &cobra.Command{
 	Use:   "plans",
 	Short: "Get available subscription plans",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(billingToken)
+		client, err := lib.NewClient(token)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			return
@@ -207,60 +206,20 @@ var plansCmd = &cobra.Command{
 func init() {
 	// Add persistent flags for commands that need organization name
 	orgBillingCmd.PersistentFlags().StringVarP(&billingOrgName, "organization", "o", "", "Organization name")
-	orgBillingCmd.PersistentFlags().StringVarP(&billingToken, "token", "t", "", "Bearer token")
 	if err := orgBillingCmd.MarkPersistentFlagRequired("organization"); err != nil {
 		fmt.Printf("Error marking organization flag required: %v\n", err)
 		os.Exit(1)
 	}
-	if err := orgBillingCmd.MarkPersistentFlagRequired("token"); err != nil {
-		fmt.Printf("Error marking token flag required: %v\n", err)
-		os.Exit(1)
-	}
 
 	orgSubscriptionCmd.PersistentFlags().StringVarP(&billingOrgName, "organization", "o", "", "Organization name")
-	orgSubscriptionCmd.PersistentFlags().StringVarP(&billingToken, "token", "t", "", "Bearer token")
 	if err := orgSubscriptionCmd.MarkPersistentFlagRequired("organization"); err != nil {
 		fmt.Printf("Error marking organization flag required: %v\n", err)
 		os.Exit(1)
 	}
-	if err := orgSubscriptionCmd.MarkPersistentFlagRequired("token"); err != nil {
-		fmt.Printf("Error marking token flag required: %v\n", err)
-		os.Exit(1)
-	}
 
 	orgInvoicesCmd.PersistentFlags().StringVarP(&billingOrgName, "organization", "o", "", "Organization name")
-	orgInvoicesCmd.PersistentFlags().StringVarP(&billingToken, "token", "t", "", "Bearer token")
 	if err := orgInvoicesCmd.MarkPersistentFlagRequired("organization"); err != nil {
 		fmt.Printf("Error marking organization flag required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := orgInvoicesCmd.MarkPersistentFlagRequired("token"); err != nil {
-		fmt.Printf("Error marking token flag required: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Add persistent flags for user commands
-	userBillingCmd.PersistentFlags().StringVarP(&billingToken, "token", "t", "", "Bearer token")
-	if err := userBillingCmd.MarkPersistentFlagRequired("token"); err != nil {
-		fmt.Printf("Error marking token flag required: %v\n", err)
-		os.Exit(1)
-	}
-
-	userSubscriptionCmd.PersistentFlags().StringVarP(&billingToken, "token", "t", "", "Bearer token")
-	if err := userSubscriptionCmd.MarkPersistentFlagRequired("token"); err != nil {
-		fmt.Printf("Error marking token flag required: %v\n", err)
-		os.Exit(1)
-	}
-
-	userInvoicesCmd.PersistentFlags().StringVarP(&billingToken, "token", "t", "", "Bearer token")
-	if err := userInvoicesCmd.MarkPersistentFlagRequired("token"); err != nil {
-		fmt.Printf("Error marking token flag required: %v\n", err)
-		os.Exit(1)
-	}
-
-	plansCmd.PersistentFlags().StringVarP(&billingToken, "token", "t", "", "Bearer token")
-	if err := plansCmd.MarkPersistentFlagRequired("token"); err != nil {
-		fmt.Printf("Error marking token flag required: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -198,10 +198,8 @@ func init() {
 	buildCmd.AddCommand(buildStatusCmd)
 
 	// Global build flags
-	buildCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
 	buildCmd.PersistentFlags().StringVarP(&buildNamespace, "namespace", "n", "", "Repository namespace")
 	buildCmd.PersistentFlags().StringVarP(&buildRepository, "repository", "r", "", "Repository name")
-	markFlagRequired(buildCmd.MarkPersistentFlagRequired("token"))
 	markFlagRequired(buildCmd.MarkPersistentFlagRequired("namespace"))
 	markFlagRequired(buildCmd.MarkPersistentFlagRequired("repository"))
 

--- a/cmd/discovery.go
+++ b/cmd/discovery.go
@@ -88,8 +88,6 @@ func init() {
 	discoveryCmd.AddCommand(discoveryAppInfoCmd)
 	discoveryCmd.AddCommand(discoveryEntitiesCmd)
 
-	discoveryCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Quay.io API token")
-
 	discoveryAppInfoCmd.Flags().StringVar(&discoveryClientID, "client-id", "", "OAuth application client ID")
 	if err := discoveryAppInfoCmd.MarkFlagRequired("client-id"); err != nil {
 		fmt.Printf("Error marking client-id flag as required: %v\n", err)

--- a/cmd/errortype.go
+++ b/cmd/errortype.go
@@ -54,6 +54,5 @@ This endpoint provides details about error types that can be returned by the Qua
 }
 
 func init() {
-	errorTypeCmd.Flags().StringVarP(&token, "token", "t", "", "Quay.io API token")
 	errorTypeCmd.Flags().StringVar(&errorTypeName, "type", "", "Error type to look up (e.g., 'invalid_token')")
 }

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -242,8 +242,6 @@ func init() {
 	logsCmd.AddCommand(exportUserLogsCmd)
 	logsCmd.AddCommand(exportRepoLogsCmd)
 
-	logsCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
-
 	// repo-logs flags
 	repoLogsCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Repository namespace")
 	repoLogsCmd.Flags().StringVarP(&repository, "repository", "r", "", "Repository name")

--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -187,7 +187,6 @@ func init() {
 	manifestCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
 	manifestCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
 	manifestCmd.PersistentFlags().StringVarP(&manifestRef, "manifest", "m", "", "Manifest reference (digest like sha256:...)")
-	manifestCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
 
 	// Mark global flags as required
 	if err := manifestCmd.MarkPersistentFlagRequired("namespace"); err != nil {
@@ -200,10 +199,6 @@ func init() {
 	}
 	if err := manifestCmd.MarkPersistentFlagRequired("manifest"); err != nil {
 		fmt.Printf("Error marking manifest flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := manifestCmd.MarkPersistentFlagRequired("token"); err != nil {
-		fmt.Printf("Error marking token flag as required: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -66,8 +66,6 @@ func init() {
 	messagesCmd.AddCommand(messagesListCmd)
 	messagesCmd.AddCommand(messagesCreateCmd)
 
-	messagesCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Quay.io API token")
-
 	messagesCreateCmd.Flags().StringVar(&messageContent, "content", "", "Message content")
 	messagesCreateCmd.Flags().StringVar(&messageSeverity, "severity", "", "Message severity (info, warning, error)")
 	messagesCreateCmd.Flags().StringVar(&messageMediaType, "media-type", "", "Media type for the message")

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -263,10 +263,8 @@ func init() {
 	notificationCmd.AddCommand(notificationUpdateCmd)
 
 	// Global notification flags
-	notificationCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
 	notificationCmd.PersistentFlags().StringVarP(&notificationNamespace, "namespace", "n", "", "Repository namespace")
 	notificationCmd.PersistentFlags().StringVarP(&notificationRepository, "repository", "r", "", "Repository name")
-	markFlagRequired(notificationCmd.MarkPersistentFlagRequired("token"))
 	markFlagRequired(notificationCmd.MarkPersistentFlagRequired("namespace"))
 	markFlagRequired(notificationCmd.MarkPersistentFlagRequired("repository"))
 

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -1130,14 +1130,9 @@ func init() {
 
 func initOrgPersistentFlags() {
 	organizationCmd.PersistentFlags().StringVarP(&orgName, "organization", "o", "", "Organization name")
-	organizationCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Authentication token")
 
 	if err := organizationCmd.MarkPersistentFlagRequired("organization"); err != nil {
 		fmt.Printf("Error marking organization flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := organizationCmd.MarkPersistentFlagRequired("token"); err != nil {
-		fmt.Printf("Error marking token flag as required: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/permissions.go
+++ b/cmd/permissions.go
@@ -314,7 +314,6 @@ func init() {
 	// Global permissions flags (repository context)
 	permissionsCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
 	permissionsCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
-	permissionsCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
 
 	// Mark global flags as required
 	if err := permissionsCmd.MarkPersistentFlagRequired("namespace"); err != nil {
@@ -323,10 +322,6 @@ func init() {
 	}
 	if err := permissionsCmd.MarkPersistentFlagRequired("repository"); err != nil {
 		fmt.Printf("Error marking repository flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := permissionsCmd.MarkPersistentFlagRequired("token"); err != nil {
-		fmt.Printf("Error marking token flag as required: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -231,7 +231,6 @@ func setupPrototypeFlags() {
 	// Common flags
 	for _, cmd := range []*cobra.Command{prototypeListCmd, prototypeInfoCmd, prototypeCreateCmd, prototypeUpdateCmd, prototypeDeleteCmd} {
 		cmd.Flags().StringVarP(&prototypeOrg, "organization", "o", "", "Organization name")
-		cmd.Flags().StringVarP(&token, "token", "t", "", "Quay.io API token")
 	}
 
 	// UUID flags

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -205,15 +205,10 @@ func init() {
 	// Global repository flags
 	repositoryCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
 	repositoryCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
-	repositoryCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
 
 	// Mark global flags as required
 	if err := repositoryCmd.MarkPersistentFlagRequired("namespace"); err != nil {
 		fmt.Printf("Error marking namespace flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := repositoryCmd.MarkPersistentFlagRequired("token"); err != nil {
-		fmt.Printf("Error marking token flag as required: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/cmd/repotoken.go
+++ b/cmd/repotoken.go
@@ -211,7 +211,6 @@ func setupRepoTokenFlags() {
 	for _, cmd := range []*cobra.Command{repotokenListCmd, repotokenInfoCmd, repotokenCreateCmd, repotokenUpdateCmd, repotokenDeleteCmd} {
 		cmd.Flags().StringVarP(&repoTokenNamespace, "namespace", "n", "", "Namespace/organization")
 		cmd.Flags().StringVarP(&repoTokenRepository, "repository", "r", "", "Repository name")
-		cmd.Flags().StringVarP(&token, "token", "t", "", "Quay.io API token")
 	}
 
 	// Code flags

--- a/cmd/robot.go
+++ b/cmd/robot.go
@@ -186,13 +186,6 @@ func init() {
 	robotCmd.AddCommand(robotRegenerateCmd)
 	robotCmd.AddCommand(robotPermissionsCmd)
 
-	// Global robot flags
-	robotCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
-	if err := robotCmd.MarkPersistentFlagRequired("token"); err != nil {
-		fmt.Printf("Error marking token flag as required: %v\n", err)
-		os.Exit(1)
-	}
-
 	// Info command flags
 	robotInfoCmd.Flags().StringVarP(&robotShortname, "name", "n", "", "Robot short name (without username prefix)")
 	if err := robotInfoCmd.MarkFlagRequired("name"); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
@@ -19,6 +21,7 @@ var getCmd = &cobra.Command{
 }
 
 func init() {
+	getCmd.PersistentFlags().StringVarP(&token, "token", "t", os.Getenv("QUAY_TOKEN"), "Quay.io API token (default: $QUAY_TOKEN)")
 	rootCmd.AddCommand(getCmd)
 	getCmd.AddCommand(repositoryCmd)
 	getCmd.AddCommand(billingCmd)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestTokenFlagExistsOnGetCmd(t *testing.T) {
+	flag := getCmd.PersistentFlags().Lookup("token")
+	if flag == nil {
+		t.Fatal("Expected --token flag on getCmd, not found")
+	}
+
+	if flag.Annotations != nil {
+		if _, found := flag.Annotations["cobra_annotation_bash_completion_one_required_flag"]; found {
+			t.Error("Token flag should not be marked as required — it defaults to $QUAY_TOKEN")
+		}
+	}
+}
+
+func TestTokenFlagOverridesEnvVar(t *testing.T) {
+	flag := getCmd.PersistentFlags().Lookup("token")
+	if flag == nil {
+		t.Fatal("Expected --token flag on getCmd, not found")
+	}
+
+	err := flag.Value.Set("explicit-token")
+	if err != nil {
+		t.Fatalf("Failed to set token flag: %v", err)
+	}
+
+	if token != "explicit-token" {
+		t.Errorf("Expected token to be 'explicit-token', got '%s'", token)
+	}
+}
+
+func TestSetVersion(t *testing.T) {
+	SetVersion("v1.2.3")
+	if rootCmd.Version != "v1.2.3" {
+		t.Errorf("Expected version 'v1.2.3', got '%s'", rootCmd.Version)
+	}
+}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -83,12 +83,7 @@ func init() {
 	searchCmd.AddCommand(searchAllCmd)
 
 	// Global search flags
-	searchCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
 	searchCmd.PersistentFlags().StringVarP(&searchQuery, "query", "q", "", "Search query")
-	if err := searchCmd.MarkPersistentFlagRequired("token"); err != nil {
-		fmt.Printf("Error marking token flag as required: %v\n", err)
-		os.Exit(1)
-	}
 	if err := searchCmd.MarkPersistentFlagRequired("query"); err != nil {
 		fmt.Printf("Error marking query flag as required: %v\n", err)
 		os.Exit(1)

--- a/cmd/secscan.go
+++ b/cmd/secscan.go
@@ -64,7 +64,6 @@ func init() {
 	secscanCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
 	secscanCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
 	secscanCmd.PersistentFlags().StringVarP(&secScanManifestRef, "manifest", "m", "", "Manifest reference (digest like sha256:...)")
-	secscanCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
 
 	// Mark global flags as required
 	if err := secscanCmd.MarkPersistentFlagRequired("namespace"); err != nil {
@@ -77,10 +76,6 @@ func init() {
 	}
 	if err := secscanCmd.MarkPersistentFlagRequired("manifest"); err != nil {
 		fmt.Printf("Error marking manifest flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := secscanCmd.MarkPersistentFlagRequired("token"); err != nil {
-		fmt.Printf("Error marking token flag as required: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -183,7 +183,6 @@ func init() {
 	tagCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
 	tagCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
 	tagCmd.PersistentFlags().StringVarP(&tagName, "tag", "T", "", "Name of the tag")
-	tagCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
 
 	// Mark global flags as required
 	if err := tagCmd.MarkPersistentFlagRequired("namespace"); err != nil {
@@ -196,10 +195,6 @@ func init() {
 	}
 	if err := tagCmd.MarkPersistentFlagRequired("tag"); err != nil {
 		fmt.Printf("Error marking tag flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := tagCmd.MarkPersistentFlagRequired("token"); err != nil {
-		fmt.Printf("Error marking token flag as required: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -343,9 +343,7 @@ func init() {
 }
 
 func initTeamGlobalFlags() {
-	teamCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
 	teamCmd.PersistentFlags().StringVarP(&teamCmdOrgname, "organization", "o", "", "Organization name")
-	markFlagRequired(teamCmd.MarkPersistentFlagRequired("token"))
 	markFlagRequired(teamCmd.MarkPersistentFlagRequired("organization"))
 }
 

--- a/cmd/trigger.go
+++ b/cmd/trigger.go
@@ -297,7 +297,6 @@ func setupTriggerFlags() {
 	for _, cmd := range []*cobra.Command{triggerListCmd, triggerInfoCmd, triggerDeleteCmd, triggerEnableCmd, triggerDisableCmd, triggerStartCmd, triggerActivateCmd, triggerBuildsCmd} {
 		cmd.Flags().StringVarP(&triggerNamespace, "namespace", "n", "", "Namespace/organization")
 		cmd.Flags().StringVarP(&triggerRepository, "repository", "r", "", "Repository name")
-		cmd.Flags().StringVarP(&token, "token", "t", "", "Quay.io API token")
 	}
 
 	// UUID flags for subcommands that need it

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -208,15 +208,6 @@ func init() {
 	userCmd.AddCommand(starUserRepoCmd)
 	userCmd.AddCommand(unstarUserRepoCmd)
 
-	// Global user flags
-	userCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Bearer token")
-
-	// Mark token as required for all user commands
-	if err := userCmd.MarkPersistentFlagRequired("token"); err != nil {
-		fmt.Printf("Error marking token flag as required: %v\n", err)
-		os.Exit(1)
-	}
-
 	// Star command specific flags (requires repository context)
 	starRepoCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
 	starRepoCmd.Flags().StringVarP(&repository, "repository", "r", "", "Name of the repository")


### PR DESCRIPTION
## Summary

- Define `--token` flag once on the root `get` command with `os.Getenv("QUAY_TOKEN")` as default
- Remove all 19 per-command token flag definitions and required markers — flag is now inherited via Cobra's persistent flags
- Net result: **-115 lines** of boilerplate removed across 21 files

### Behavior
- `QUAY_TOKEN=xxx go-quay get user info` — uses env var
- `go-quay get user info --token xxx` — flag overrides env var
- `go-quay get user info` (no env var, no flag) — fails with "bearer token is required"

## Test plan

- [x] `make build && ./go-quay get user info` with no token → "bearer token is required"
- [x] `QUAY_TOKEN=fake ./go-quay get user info` → sends token (401 confirms it was read)
- [x] `./go-quay get --help` shows `(default: $QUAY_TOKEN)`
- [x] `make lint` passes (0 issues)
- [x] `go test ./...` passes
