### PR TITLE
fix: use consistent error handling and printJSON in billing commands

### DIFF
--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -13,149 +12,112 @@ var (
 	billingOrgName string
 )
 
-// billingCmd represents the billing command
 var billingCmd = &cobra.Command{
 	Use:   "billing",
 	Short: "Billing-related commands",
 	Long:  `Commands for managing and viewing billing information, subscriptions, invoices, and usage statistics.`,
 }
 
-// orgBillingCmd gets billing information for an organization
 var orgBillingCmd = &cobra.Command{
 	Use:   "org-info",
 	Short: "Get billing information for an organization",
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := lib.NewClient(token)
 		if err != nil {
-			fmt.Println("Error creating client:", err)
-			return
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
 		}
 
 		billing, err := client.GetOrganizationBilling(billingOrgName)
 		if err != nil {
-			fmt.Println("Error getting organization billing:", err)
-			return
+			fmt.Printf("Error getting organization billing: %v\n", err)
+			os.Exit(1)
 		}
 
-		jsonOutput, err := json.Marshal(billing)
-		if err != nil {
-			fmt.Println("Error marshaling JSON:", err)
-			return
-		}
-
-		fmt.Println(string(jsonOutput))
+		printJSON(billing)
 	},
 }
 
-// userBillingCmd gets billing information for the current user
 var userBillingCmd = &cobra.Command{
 	Use:   "user-info",
 	Short: "Get billing information for the current user",
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := lib.NewClient(token)
 		if err != nil {
-			fmt.Println("Error creating client:", err)
-			return
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
 		}
 
 		billing, err := client.GetUserBilling()
 		if err != nil {
-			fmt.Println("Error getting user billing:", err)
-			return
+			fmt.Printf("Error getting user billing: %v\n", err)
+			os.Exit(1)
 		}
 
-		jsonOutput, err := json.Marshal(billing)
-		if err != nil {
-			fmt.Println("Error marshaling JSON:", err)
-			return
-		}
-
-		fmt.Println(string(jsonOutput))
+		printJSON(billing)
 	},
 }
 
-// orgSubscriptionCmd gets subscription details for an organization
 var orgSubscriptionCmd = &cobra.Command{
 	Use:   "org-subscription",
 	Short: "Get subscription details for an organization",
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := lib.NewClient(token)
 		if err != nil {
-			fmt.Println("Error creating client:", err)
-			return
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
 		}
 
 		subscription, err := client.GetOrganizationSubscription(billingOrgName)
 		if err != nil {
-			fmt.Println("Error getting organization subscription:", err)
-			return
+			fmt.Printf("Error getting organization subscription: %v\n", err)
+			os.Exit(1)
 		}
 
-		jsonOutput, err := json.Marshal(subscription)
-		if err != nil {
-			fmt.Println("Error marshaling JSON:", err)
-			return
-		}
-
-		fmt.Println(string(jsonOutput))
+		printJSON(subscription)
 	},
 }
 
-// userSubscriptionCmd gets subscription details for the current user
 var userSubscriptionCmd = &cobra.Command{
 	Use:   "user-subscription",
 	Short: "Get subscription details for the current user",
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := lib.NewClient(token)
 		if err != nil {
-			fmt.Println("Error creating client:", err)
-			return
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
 		}
 
 		subscription, err := client.GetUserSubscription()
 		if err != nil {
-			fmt.Println("Error getting user subscription:", err)
-			return
+			fmt.Printf("Error getting user subscription: %v\n", err)
+			os.Exit(1)
 		}
 
-		jsonOutput, err := json.Marshal(subscription)
-		if err != nil {
-			fmt.Println("Error marshaling JSON:", err)
-			return
-		}
-
-		fmt.Println(string(jsonOutput))
+		printJSON(subscription)
 	},
 }
 
-// orgInvoicesCmd gets invoices for an organization
 var orgInvoicesCmd = &cobra.Command{
 	Use:   "org-invoices",
 	Short: "Get invoices for an organization",
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := lib.NewClient(token)
 		if err != nil {
-			fmt.Println("Error creating client:", err)
-			return
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
 		}
 
 		invoices, err := client.GetOrganizationInvoices(billingOrgName)
 		if err != nil {
-			fmt.Println("Error getting organization invoices:", err)
-			return
+			fmt.Printf("Error getting organization invoices: %v\n", err)
+			os.Exit(1)
 		}
 
-		jsonOutput, err := json.Marshal(invoices)
-		if err != nil {
-			fmt.Println("Error marshaling JSON:", err)
-			return
-		}
-
-		fmt.Println(string(jsonOutput))
+		printJSON(invoices)
 	},
 }
 
-// userInvoicesCmd gets invoices for the current user
 var userInvoicesCmd = &cobra.Command{
 	Use:   "user-invoices",
 	Short: "Get invoices for the current user",
@@ -176,35 +138,27 @@ var userInvoicesCmd = &cobra.Command{
 	},
 }
 
-// plansCmd gets available subscription plans
 var plansCmd = &cobra.Command{
 	Use:   "plans",
 	Short: "Get available subscription plans",
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := lib.NewClient(token)
 		if err != nil {
-			fmt.Println("Error creating client:", err)
-			return
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
 		}
 
 		plans, err := client.GetAvailablePlans()
 		if err != nil {
-			fmt.Println("Error getting available plans:", err)
-			return
+			fmt.Printf("Error getting available plans: %v\n", err)
+			os.Exit(1)
 		}
 
-		jsonOutput, err := json.Marshal(plans)
-		if err != nil {
-			fmt.Println("Error marshaling JSON:", err)
-			return
-		}
-
-		fmt.Println(string(jsonOutput))
+		printJSON(plans)
 	},
 }
 
 func init() {
-	// Add persistent flags for commands that need organization name
 	orgBillingCmd.PersistentFlags().StringVarP(&billingOrgName, "organization", "o", "", "Organization name")
 	if err := orgBillingCmd.MarkPersistentFlagRequired("organization"); err != nil {
 		fmt.Printf("Error marking organization flag required: %v\n", err)
@@ -223,7 +177,6 @@ func init() {
 		os.Exit(1)
 	}
 
-	// Add subcommands to the billing command
 	billingCmd.AddCommand(orgBillingCmd)
 	billingCmd.AddCommand(userBillingCmd)
 	billingCmd.AddCommand(orgSubscriptionCmd)


### PR DESCRIPTION
## Summary

- Fix 6 billing commands that used `fmt.Println` + `return` on error (exits with code 0, breaking scripts)
- Now use `fmt.Printf` + `os.Exit(1)` matching every other command in the codebase
- Replace inline `json.Marshal` + `fmt.Println` with shared `printJSON()` helper
- Remove unused `encoding/json` import
- Net: **-47 lines**

## Test plan

- [x] `make lint` passes (0 issues)
- [x] `go test ./...` passes
- [x] `go build ./...` compiles
