### PR TITLE
ci: add gosec security scanning to pre-main checks

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -93,6 +93,23 @@ jobs:
     - name: Validate example commands from README
       run: ./scripts/validate-readme-examples.sh
 
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Run gosec
+      uses: securego/gosec@master
+      with:
+        args: -exclude-dir=scripts ./...
+
   swagger-alignment:
     name: Check API Coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `gosec` security scanning as a new job in the pre-main checks workflow
- Runs on every PR and push to main alongside lint, test, and build
- Catches common Go security issues: hardcoded credentials, unsafe crypto, command injection, etc.

## Test plan

- [ ] Verify gosec job runs and passes in CI
