### PR TITLE
feat: move QuayURL from global var to Client struct, add --quay-url flag

### DIFF
--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -22,7 +22,7 @@ var orgBillingCmd = &cobra.Command{
 	Use:   "org-info",
 	Short: "Get billing information for an organization",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -42,7 +42,7 @@ var userBillingCmd = &cobra.Command{
 	Use:   "user-info",
 	Short: "Get billing information for the current user",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -62,7 +62,7 @@ var orgSubscriptionCmd = &cobra.Command{
 	Use:   "org-subscription",
 	Short: "Get subscription details for an organization",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -82,7 +82,7 @@ var userSubscriptionCmd = &cobra.Command{
 	Use:   "user-subscription",
 	Short: "Get subscription details for the current user",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -102,7 +102,7 @@ var orgInvoicesCmd = &cobra.Command{
 	Use:   "org-invoices",
 	Short: "Get invoices for an organization",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -122,7 +122,7 @@ var userInvoicesCmd = &cobra.Command{
 	Use:   "user-invoices",
 	Short: "Get invoices for the current user",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -142,7 +142,7 @@ var plansCmd = &cobra.Command{
 	Use:   "plans",
 	Short: "Get available subscription plans",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -43,7 +43,7 @@ var buildListCmd = &cobra.Command{
 	Short: "List builds for a repository",
 	Long:  `List all builds for the specified repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -66,7 +66,7 @@ var buildInfoCmd = &cobra.Command{
 	Short: "Get build details",
 	Long:  `Get detailed information about a specific build.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -89,7 +89,7 @@ var buildLogsCmd = &cobra.Command{
 	Short: "Get build logs",
 	Long:  `Get the logs for a specific build.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -114,7 +114,7 @@ var buildRequestCmd = &cobra.Command{
 
 The archive should be a tar.gz file containing a Dockerfile and any necessary build context.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -150,7 +150,7 @@ var buildCancelCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -171,7 +171,7 @@ var buildStatusCmd = &cobra.Command{
 	Short: "Get build status",
 	Long:  `Get the current status of a specific build.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)

--- a/cmd/discovery.go
+++ b/cmd/discovery.go
@@ -25,7 +25,7 @@ var discoveryAPICmd = &cobra.Command{
 	Short: "Get API discovery information",
 	Long:  `Get API discovery information from Quay.io including available endpoints and versions.`,
 	Run: func(_ *cobra.Command, _ []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -46,7 +46,7 @@ var discoveryAppInfoCmd = &cobra.Command{
 	Short: "Get application information by client ID",
 	Long:  `Get detailed information about an OAuth application by its client ID.`,
 	Run: func(_ *cobra.Command, _ []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -67,7 +67,7 @@ var discoveryEntitiesCmd = &cobra.Command{
 	Short: "Search for entities by prefix",
 	Long:  `Search for users, organizations, and teams by name prefix.`,
 	Run: func(_ *cobra.Command, _ []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)

--- a/cmd/errortype.go
+++ b/cmd/errortype.go
@@ -32,7 +32,7 @@ This endpoint provides details about error types that can be returned by the Qua
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -32,7 +32,7 @@ var repoLogsCmd = &cobra.Command{
 	Short: "Get repository logs",
 	Long:  `Get action logs for a specific repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -53,7 +53,7 @@ var repoAggregatedLogsCmd = &cobra.Command{
 	Short: "Get aggregated repository logs",
 	Long:  `Get aggregated action logs for a specific repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -74,7 +74,7 @@ var orgLogsCmd = &cobra.Command{
 	Short: "Get organization logs",
 	Long:  `Get action logs for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -95,7 +95,7 @@ var orgAggregatedLogsCmd = &cobra.Command{
 	Short: "Get aggregated organization logs",
 	Long:  `Get aggregated action logs for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -116,7 +116,7 @@ var userLogsCmd = &cobra.Command{
 	Short: "Get user logs",
 	Long:  `Get action logs for the current user.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -137,7 +137,7 @@ var userAggregatedLogsCmd = &cobra.Command{
 	Short: "Get aggregated user logs",
 	Long:  `Get aggregated action logs for the current user.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -158,7 +158,7 @@ var exportOrgLogsCmd = &cobra.Command{
 	Short: "Export organization logs",
 	Long:  `Export action logs for an organization via callback URL or email.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -184,7 +184,7 @@ var exportUserLogsCmd = &cobra.Command{
 	Short: "Export user logs",
 	Long:  `Export action logs for the current user via callback URL or email.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -210,7 +210,7 @@ var exportRepoLogsCmd = &cobra.Command{
 	Short: "Export repository logs",
 	Long:  `Export action logs for a repository via callback URL or email.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)

--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -38,7 +38,7 @@ var manifestInfoCmd = &cobra.Command{
 	Short: "Get detailed manifest information",
 	Long:  `Get detailed information about a specific manifest including layers, config, and metadata.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -67,7 +67,7 @@ var manifestDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -89,7 +89,7 @@ var manifestLabelsCmd = &cobra.Command{
 	Short: "List manifest labels",
 	Long:  `List all labels associated with a specific manifest.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -112,7 +112,7 @@ var manifestLabelCmd = &cobra.Command{
 	Short: "Get a specific manifest label",
 	Long:  `Get detailed information about a specific label on a manifest.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -135,7 +135,7 @@ var manifestAddLabelCmd = &cobra.Command{
 	Short: "Add a label to a manifest",
 	Long:  `Add a new label with a key-value pair to a specific manifest.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -158,7 +158,7 @@ var manifestRemoveLabelCmd = &cobra.Command{
 	Short: "Remove a label from a manifest",
 	Long:  `Remove a specific label from a manifest by its label ID.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -24,7 +24,7 @@ var messagesListCmd = &cobra.Command{
 	Short: "Get system messages",
 	Long:  `Get system-wide messages including maintenance notifications and announcements.`,
 	Run: func(_ *cobra.Command, _ []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -45,7 +45,7 @@ var messagesCreateCmd = &cobra.Command{
 	Short: "Create a system message",
 	Long:  `Create a new system-wide message.`,
 	Run: func(_ *cobra.Command, _ []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -57,7 +57,7 @@ var notificationListCmd = &cobra.Command{
 	Short: "List notifications for a repository",
 	Long:  `List all notifications (webhooks) for the specified repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -80,7 +80,7 @@ var notificationInfoCmd = &cobra.Command{
 	Short: "Get notification details",
 	Long:  `Get detailed information about a specific notification.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -107,7 +107,7 @@ For webhook method, provide the --url flag with the webhook endpoint.
 For email method, provide the --url flag with the email address.
 For slack method, provide the --url flag with the Slack webhook URL.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -153,7 +153,7 @@ var notificationDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -175,7 +175,7 @@ var notificationTestCmd = &cobra.Command{
 	Short: "Test a notification",
 	Long:  `Send a test event to the notification endpoint.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -197,7 +197,7 @@ var notificationResetCmd = &cobra.Command{
 	Short: "Reset notification failure count",
 	Long:  `Reset the failure count for a notification that has failed.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -218,7 +218,7 @@ var notificationUpdateCmd = &cobra.Command{
 	Short: "Update a notification",
 	Long:  `Update an existing notification (webhook) configuration.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -62,7 +62,7 @@ var orgInfoCmd = &cobra.Command{
 	Short: "Get organization information",
 	Long:  `Get detailed information about an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -82,7 +82,7 @@ var orgMembersCmd = &cobra.Command{
 	Short: "Get organization members",
 	Long:  `Get list of all members in an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -102,7 +102,7 @@ var orgTeamsCmd = &cobra.Command{
 	Short: "Get organization teams",
 	Long:  `Get list of all teams in an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -122,7 +122,7 @@ var teamInfoCmd = &cobra.Command{
 	Short: "Get team information",
 	Long:  `Get detailed information about a specific team.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -142,7 +142,7 @@ var teamMembersCmd = &cobra.Command{
 	Short: "Get team members",
 	Long:  `Get list of all members in a specific team.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -162,7 +162,7 @@ var orgRobotsCmd = &cobra.Command{
 	Short: "Get organization robots",
 	Long:  `Get list of all robot accounts in an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -182,7 +182,7 @@ var orgQuotaCmd = &cobra.Command{
 	Short: "Get organization quota",
 	Long:  `Get quota information for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -202,7 +202,7 @@ var autoPruneCmd = &cobra.Command{
 	Short: "Get auto-prune policies",
 	Long:  `Get list of auto-prune policies for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -222,7 +222,7 @@ var orgApplicationsCmd = &cobra.Command{
 	Short: "Get organization applications",
 	Long:  `Get list of OAuth applications for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -242,7 +242,7 @@ var createOrgCmd = &cobra.Command{
 	Short: "Create an organization",
 	Long:  `Create a new organization with the specified name and email.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -262,7 +262,7 @@ var updateOrgCmd = &cobra.Command{
 	Short: "Update an organization",
 	Long:  `Update an organization's email.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -286,7 +286,7 @@ var deleteOrgCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to delete an organization")
 			os.Exit(1)
 		}
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -306,7 +306,7 @@ var addMemberCmd = &cobra.Command{
 	Short: "Add a member to an organization",
 	Long:  `Add a member to an organization by member name.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -330,7 +330,7 @@ var removeMemberCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to remove a member")
 			os.Exit(1)
 		}
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -350,7 +350,7 @@ var getMemberCmd = &cobra.Command{
 	Short: "Get organization member information",
 	Long:  `Get detailed information about a specific organization member.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -370,7 +370,7 @@ var collaboratorsCmd = &cobra.Command{
 	Short: "Get organization collaborators",
 	Long:  `Get list of collaborators for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -390,7 +390,7 @@ var orgRepositoriesCmd = &cobra.Command{
 	Short: "Get organization repositories",
 	Long:  `Get list of repositories for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -410,7 +410,7 @@ var defaultPermissionsCmd = &cobra.Command{
 	Short: "Get default permissions",
 	Long:  `Get default permissions for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -430,7 +430,7 @@ var createDefaultPermissionCmd = &cobra.Command{
 	Short: "Create a default permission",
 	Long:  `Create a default permission for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -454,7 +454,7 @@ var deleteDefaultPermissionCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to delete a default permission")
 			os.Exit(1)
 		}
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -474,7 +474,7 @@ var proxyCacheCmd = &cobra.Command{
 	Short: "Get proxy cache configuration",
 	Long:  `Get proxy cache configuration for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -494,7 +494,7 @@ var createProxyCacheCmd = &cobra.Command{
 	Short: "Create proxy cache configuration",
 	Long:  `Create proxy cache configuration for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -518,7 +518,7 @@ var deleteProxyCacheCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to delete proxy cache config")
 			os.Exit(1)
 		}
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -538,7 +538,7 @@ var orgRobotCmd = &cobra.Command{
 	Short: "Get robot account information",
 	Long:  `Get detailed information about a specific robot account.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -558,7 +558,7 @@ var createRobotCmd = &cobra.Command{
 	Short: "Create a robot account",
 	Long:  `Create a new robot account in an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -582,7 +582,7 @@ var deleteRobotCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to delete a robot account")
 			os.Exit(1)
 		}
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -602,7 +602,7 @@ var regenerateRobotCmd = &cobra.Command{
 	Short: "Regenerate a robot account token",
 	Long:  `Regenerate the token for a robot account.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -622,7 +622,7 @@ var orgRobotPermissionsCmd = &cobra.Command{
 	Short: "Get robot account permissions",
 	Long:  `Get permissions for a specific robot account.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -642,7 +642,7 @@ var setRobotPermissionCmd = &cobra.Command{
 	Short: "Set robot repository permission",
 	Long:  `Set a robot account's permission on a repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -666,7 +666,7 @@ var removeRobotPermissionCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to remove a robot permission")
 			os.Exit(1)
 		}
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -686,7 +686,7 @@ var applicationCmd = &cobra.Command{
 	Short: "Get application information",
 	Long:  `Get detailed information about a specific OAuth application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -706,7 +706,7 @@ var createApplicationCmd = &cobra.Command{
 	Short: "Create an OAuth application",
 	Long:  `Create a new OAuth application for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -726,7 +726,7 @@ var updateApplicationCmd = &cobra.Command{
 	Short: "Update an OAuth application",
 	Long:  `Update an existing OAuth application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -750,7 +750,7 @@ var deleteApplicationCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to delete an application")
 			os.Exit(1)
 		}
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -770,7 +770,7 @@ var resetApplicationSecretCmd = &cobra.Command{
 	Short: "Reset application client secret",
 	Long:  `Reset the client secret for an OAuth application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -790,7 +790,7 @@ var marketplaceCmd = &cobra.Command{
 	Short: "Get organization marketplace information",
 	Long:  `Get marketplace information for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -810,7 +810,7 @@ var createMarketplaceSubscriptionCmd = &cobra.Command{
 	Short: "Create a marketplace subscription",
 	Long:  `Create a marketplace subscription for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -834,7 +834,7 @@ var deleteMarketplaceSubscriptionCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to delete a marketplace subscription")
 			os.Exit(1)
 		}
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -858,7 +858,7 @@ var batchRemoveSubscriptionsCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to batch remove subscriptions")
 			os.Exit(1)
 		}
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -878,7 +878,7 @@ var createQuotaCmd = &cobra.Command{
 	Short: "Create organization quota",
 	Long:  `Create a quota for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -898,7 +898,7 @@ var updateQuotaCmd = &cobra.Command{
 	Short: "Update organization quota",
 	Long:  `Update the quota for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -922,7 +922,7 @@ var deleteQuotaCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to delete a quota")
 			os.Exit(1)
 		}
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -942,7 +942,7 @@ var autoPrunePolicyCmd = &cobra.Command{
 	Short: "Get a specific auto-prune policy",
 	Long:  `Get detailed information about a specific auto-prune policy.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -962,7 +962,7 @@ var createAutoPruneCmd = &cobra.Command{
 	Short: "Create an auto-prune policy",
 	Long:  `Create an auto-prune policy for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -982,7 +982,7 @@ var updateAutoPruneCmd = &cobra.Command{
 	Short: "Update an auto-prune policy",
 	Long:  `Update an existing auto-prune policy.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -1006,7 +1006,7 @@ var deleteAutoPruneCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to delete an auto-prune policy")
 			os.Exit(1)
 		}
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -1026,7 +1026,7 @@ var inviteMemberCmd = &cobra.Command{
 	Short: "Invite a member to a team",
 	Long:  `Invite a member to a team by email.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -1050,7 +1050,7 @@ var cancelInviteCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to cancel an invite")
 			os.Exit(1)
 		}
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)

--- a/cmd/permissions.go
+++ b/cmd/permissions.go
@@ -35,7 +35,7 @@ var permListCmd = &cobra.Command{
 	Short: "List repository permissions",
 	Long:  `List all users and robots that have permissions on this repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -58,7 +58,7 @@ var permSetCmd = &cobra.Command{
 	Short: "Set permission for a user/robot",
 	Long:  `Set permission level for a user or robot account on this repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -81,7 +81,7 @@ var permRemoveCmd = &cobra.Command{
 	Short: "Remove permission for a user/robot",
 	Long:  `Remove permission for a user or robot account from this repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -102,7 +102,7 @@ var permUserPermissionsCmd = &cobra.Command{
 	Use:   "user-permissions",
 	Short: "List user permissions on repository",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -122,7 +122,7 @@ var permUserPermissionCmd = &cobra.Command{
 	Use:   "user-permission",
 	Short: "Get specific user permission on repository",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -142,7 +142,7 @@ var permSetUserPermCmd = &cobra.Command{
 	Use:   "set-user-permission",
 	Short: "Set user permission on repository",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -170,7 +170,7 @@ var permDeleteUserPermCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -191,7 +191,7 @@ var permUserTransitiveCmd = &cobra.Command{
 	Use:   "user-transitive-permission",
 	Short: "Get user transitive permission on repository",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -211,7 +211,7 @@ var permTeamPermissionsCmd = &cobra.Command{
 	Use:   "team-permissions",
 	Short: "List team permissions on repository",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -231,7 +231,7 @@ var permTeamPermissionCmd = &cobra.Command{
 	Use:   "team-permission",
 	Short: "Get specific team permission on repository",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -251,7 +251,7 @@ var permSetTeamPermCmd = &cobra.Command{
 	Use:   "set-team-permission",
 	Short: "Set team permission on repository",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -279,7 +279,7 @@ var permDeleteTeamPermCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)

--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -45,7 +45,7 @@ var prototypeListCmd = &cobra.Command{
 	Short: "List all permission prototypes",
 	Long:  `List all permission prototypes for an organization.`,
 	Run: func(_ *cobra.Command, _ []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)
@@ -77,7 +77,7 @@ var prototypeInfoCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)
@@ -127,7 +127,7 @@ Roles:
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)
@@ -171,7 +171,7 @@ var prototypeUpdateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)
@@ -211,7 +211,7 @@ var prototypeDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -41,7 +41,7 @@ var repoInfoCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -68,7 +68,7 @@ var repoCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -96,7 +96,7 @@ var repoUpdateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -130,7 +130,7 @@ var repoDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -151,7 +151,7 @@ var repoListCmd = &cobra.Command{
 	Short: "List repositories in a namespace",
 	Long:  `List all repositories in a namespace with optional filters.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -177,7 +177,7 @@ var repoChangeVisibilityCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)

--- a/cmd/repotoken.go
+++ b/cmd/repotoken.go
@@ -46,7 +46,7 @@ var repotokenListCmd = &cobra.Command{
 	Short: "List all repository tokens",
 	Long:  `List all tokens for a repository. (DEPRECATED - use robot accounts)`,
 	Run: func(_ *cobra.Command, _ []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)
@@ -78,7 +78,7 @@ var repotokenInfoCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)
@@ -110,7 +110,7 @@ var repotokenCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)
@@ -150,7 +150,7 @@ var repotokenUpdateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)
@@ -190,7 +190,7 @@ var repotokenDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)

--- a/cmd/robot.go
+++ b/cmd/robot.go
@@ -38,7 +38,7 @@ var robotListCmd = &cobra.Command{
 	Short: "List all robot accounts",
 	Long:  `List all robot accounts associated with your user account.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -61,7 +61,7 @@ var robotInfoCmd = &cobra.Command{
 	Short: "Get robot account details",
 	Long:  `Get detailed information about a specific robot account including its token.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -84,7 +84,7 @@ var robotCreateCmd = &cobra.Command{
 	Short: "Create a new robot account",
 	Long:  `Create a new robot account with the specified name and description.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -114,7 +114,7 @@ var robotDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -136,7 +136,7 @@ var robotRegenerateCmd = &cobra.Command{
 	Short: "Regenerate robot token",
 	Long:  `Regenerate the token for a robot account. The old token will be invalidated.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -160,7 +160,7 @@ var robotPermissionsCmd = &cobra.Command{
 	Short: "Get robot repository permissions",
 	Long:  `Get the repository permissions assigned to a robot account.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,8 +3,11 @@ package cmd
 import (
 	"os"
 
+	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
 )
+
+var quayURL string
 
 var rootCmd = &cobra.Command{
 	Use:   "quay",
@@ -20,8 +23,16 @@ var getCmd = &cobra.Command{
 	Short: "Get objects from Quay.io",
 }
 
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
 func init() {
-	getCmd.PersistentFlags().StringVarP(&token, "token", "t", os.Getenv("QUAY_TOKEN"), "Quay.io API token (default: $QUAY_TOKEN)")
+	getCmd.PersistentFlags().StringVarP(&token, "token", "t", envOrDefault("QUAY_TOKEN", ""), "Quay.io API token (default: $QUAY_TOKEN)")
+	getCmd.PersistentFlags().StringVar(&quayURL, "quay-url", envOrDefault("QUAY_URL", lib.DefaultQuayURL), "Quay API base URL (default: $QUAY_URL)")
 	rootCmd.AddCommand(getCmd)
 	getCmd.AddCommand(repositoryCmd)
 	getCmd.AddCommand(billingCmd)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"testing"
+
+	"github.com/sebrandon1/go-quay/lib"
 )
 
 func TestTokenFlagExistsOnGetCmd(t *testing.T) {
@@ -37,5 +39,20 @@ func TestSetVersion(t *testing.T) {
 	SetVersion("v1.2.3")
 	if rootCmd.Version != "v1.2.3" {
 		t.Errorf("Expected version 'v1.2.3', got '%s'", rootCmd.Version)
+	}
+}
+
+func TestQuayURLFlagExists(t *testing.T) {
+	flag := getCmd.PersistentFlags().Lookup("quay-url")
+	if flag == nil {
+		t.Fatal("Expected --quay-url flag on getCmd, not found")
+	}
+	if flag.DefValue != lib.DefaultQuayURL {
+		// Default may come from QUAY_URL env var at init time
+		if flag.Annotations != nil {
+			if _, found := flag.Annotations["cobra_annotation_bash_completion_one_required_flag"]; found {
+				t.Error("quay-url flag should not be marked as required")
+			}
+		}
 	}
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -30,7 +30,7 @@ var searchReposCmd = &cobra.Command{
 	Short: "Search for repositories",
 	Long:  `Search for repositories on Quay.io by name or description.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -60,7 +60,7 @@ Results include a 'kind' field indicating the entity type:
   - team: Team within an organization
   - robot: Robot account`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)

--- a/cmd/secscan.go
+++ b/cmd/secscan.go
@@ -39,7 +39,7 @@ The scan status can be:
   - unsupported: Image type is not supported for scanning
   - failed: Scan failed`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -35,7 +35,7 @@ var tagInfoCmd = &cobra.Command{
 	Short: "Get detailed tag information",
 	Long:  `Get detailed information about a specific tag including metadata, manifest digest, and size.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -58,7 +58,7 @@ var tagUpdateCmd = &cobra.Command{
 	Short: "Update tag metadata",
 	Long:  `Update tag metadata such as expiration date.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -87,7 +87,7 @@ var tagDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -109,7 +109,7 @@ var tagHistoryCmd = &cobra.Command{
 	Short: "Get tag history",
 	Long:  `Get the history of changes for a specific tag, including previous versions and modifications.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -132,7 +132,7 @@ var tagRevertCmd = &cobra.Command{
 	Short: "Revert tag to a previous state",
 	Long:  `Revert a tag to a previous state using its manifest digest.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -154,7 +154,7 @@ var tagRestoreCmd = &cobra.Command{
 	Short: "Restore a tag from a previous state",
 	Long:  `Restore a previously deleted or modified tag using its manifest digest.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -49,7 +49,7 @@ var teamListCmd = &cobra.Command{
 	Short: "List all teams in an organization",
 	Long:  `List all teams within the specified organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -72,7 +72,7 @@ var teamCmdInfoCmd = &cobra.Command{
 	Short: "Get team details",
 	Long:  `Get detailed information about a specific team.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -100,7 +100,7 @@ Roles:
   - creator: Can create new repositories
   - admin: Full administrative access`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -123,7 +123,7 @@ var teamUpdateCmd = &cobra.Command{
 	Short: "Update team settings",
 	Long:  `Update team description and role.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -152,7 +152,7 @@ var teamDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -174,7 +174,7 @@ var teamCmdMembersCmd = &cobra.Command{
 	Short: "List team members",
 	Long:  `List all members of a specific team.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -197,7 +197,7 @@ var teamAddMemberCmd = &cobra.Command{
 	Short: "Add a member to a team",
 	Long:  `Add a user or robot account to a team.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -225,7 +225,7 @@ var teamRemoveMemberCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -247,7 +247,7 @@ var teamPermissionsCmd = &cobra.Command{
 	Short: "List team repository permissions",
 	Long:  `List all repository permissions for a team.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -275,7 +275,7 @@ Permission roles:
   - write: Pull and push images
   - admin: Full administrative access`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -305,7 +305,7 @@ var teamRemovePermissionCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)

--- a/cmd/trigger.go
+++ b/cmd/trigger.go
@@ -46,7 +46,7 @@ var triggerListCmd = &cobra.Command{
 	Short: "List all build triggers for a repository",
 	Long:  `List all build triggers configured for a repository.`,
 	Run: func(_ *cobra.Command, _ []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)
@@ -78,7 +78,7 @@ var triggerInfoCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)
@@ -110,7 +110,7 @@ var triggerDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)
@@ -137,7 +137,7 @@ var triggerEnableCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)
@@ -169,7 +169,7 @@ var triggerDisableCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)
@@ -201,7 +201,7 @@ var triggerStartCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)
@@ -240,7 +240,7 @@ var triggerActivateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)
@@ -276,7 +276,7 @@ var triggerBuildsCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Println("Error creating client:", err)
 			os.Exit(1)

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -27,7 +27,7 @@ var userInfoCmd = &cobra.Command{
 	Short: "Get current user information",
 	Long:  `Get detailed information about the currently authenticated user account.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -50,7 +50,7 @@ var userStarredCmd = &cobra.Command{
 	Short: "List starred repositories",
 	Long:  `List all repositories starred by the current user.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -73,7 +73,7 @@ var starRepoCmd = &cobra.Command{
 	Short: "Star a repository",
 	Long:  `Add a repository to your starred list for easy discovery.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -95,7 +95,7 @@ var unstarRepoCmd = &cobra.Command{
 	Short: "Unstar a repository",
 	Long:  `Remove a repository from your starred list.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -118,7 +118,7 @@ var userLookupCmd = &cobra.Command{
 	Short: "Look up a user by username",
 	Long:  `Get information about a specific user by their username.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -139,7 +139,7 @@ var userMarketplaceCmd = &cobra.Command{
 	Short: "Get user marketplace information",
 	Long:  `Get marketplace subscription information for the current user.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -160,7 +160,7 @@ var starUserRepoCmd = &cobra.Command{
 	Short: "Star a repository (user endpoint)",
 	Long:  `Add a repository to your starred list using the user star endpoint.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)
@@ -181,7 +181,7 @@ var unstarUserRepoCmd = &cobra.Command{
 	Short: "Unstar a repository (user endpoint)",
 	Long:  `Remove a repository from your starred list using the user star endpoint.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClient(token)
+		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
 			fmt.Printf("Error creating client: %v\n", err)
 			os.Exit(1)

--- a/lib/billing.go
+++ b/lib/billing.go
@@ -26,7 +26,7 @@ import (
 // GetOrganizationBilling returns billing information for an organization
 func (c *Client) GetOrganizationBilling(orgname string) (*BillingInfo, error) {
 	// Get new request
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/plan", QuayURL, orgname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/plan", c.BaseURL, orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func (c *Client) GetOrganizationBilling(orgname string) (*BillingInfo, error) {
 // GetUserBilling returns billing information for the current user
 func (c *Client) GetUserBilling() (*BillingInfo, error) {
 	// Get new request
-	req, err := newRequest("GET", QuayURL+"/user/plan", nil)
+	req, err := newRequest("GET", c.BaseURL+"/user/plan", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (c *Client) GetUserBilling() (*BillingInfo, error) {
 // GetOrganizationSubscription returns subscription details for an organization
 func (c *Client) GetOrganizationSubscription(orgname string) (*Subscription, error) {
 	// Get new request
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/plan", QuayURL, orgname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/plan", c.BaseURL, orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (c *Client) GetOrganizationSubscription(orgname string) (*Subscription, err
 // GetUserSubscription returns subscription details for the current user
 func (c *Client) GetUserSubscription() (*Subscription, error) {
 	// Get new request
-	req, err := newRequest("GET", QuayURL+"/user/plan", nil)
+	req, err := newRequest("GET", c.BaseURL+"/user/plan", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func (c *Client) GetUserSubscription() (*Subscription, error) {
 // GetOrganizationInvoices returns invoices for an organization
 func (c *Client) GetOrganizationInvoices(orgname string) ([]Invoice, error) {
 	// Get new request
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/invoices", QuayURL, orgname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/invoices", c.BaseURL, orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func (c *Client) GetUserInvoices() ([]Invoice, error) {
 // Original implementation commented out due to 404 errors:
 // func (c *Client) GetUserInvoices() ([]Invoice, error) {
 // 	// Get new request
-// 	req, err := newRequest("GET", QuayURL+"/user/invoices", nil)
+// 	req, err := newRequest("GET", c.BaseURL+"/user/invoices", nil)
 // 	if err != nil {
 // 		return nil, err
 // 	}
@@ -144,7 +144,7 @@ func (c *Client) GetUserInvoices() ([]Invoice, error) {
 // GetAvailablePlans returns available subscription plans
 func (c *Client) GetAvailablePlans() ([]Subscription, error) {
 	// Get new request
-	req, err := newRequest("GET", QuayURL+"/plans", nil)
+	req, err := newRequest("GET", c.BaseURL+"/plans", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/build.go
+++ b/lib/build.go
@@ -21,7 +21,7 @@ import (
 
 // GetBuilds retrieves a list of builds for a repository
 func (c *Client) GetBuilds(namespace, repository string, limit int) (*Builds, error) {
-	url := fmt.Sprintf("%s/repository/%s/%s/build/", QuayURL, namespace, repository)
+	url := fmt.Sprintf("%s/repository/%s/%s/build/", c.BaseURL, namespace, repository)
 	if limit > 0 {
 		url = fmt.Sprintf("%s?limit=%d", url, limit)
 	}
@@ -41,7 +41,7 @@ func (c *Client) GetBuilds(namespace, repository string, limit int) (*Builds, er
 
 // GetBuild retrieves a specific build by UUID
 func (c *Client) GetBuild(namespace, repository, buildUUID string) (*Build, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/build/%s", QuayURL, namespace, repository, buildUUID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/build/%s", c.BaseURL, namespace, repository, buildUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get build request: %w", err)
 	}
@@ -56,7 +56,7 @@ func (c *Client) GetBuild(namespace, repository, buildUUID string) (*Build, erro
 
 // GetBuildLogs retrieves the logs for a specific build
 func (c *Client) GetBuildLogs(namespace, repository, buildUUID string) (*BuildLogs, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/build/%s/logs", QuayURL, namespace, repository, buildUUID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/build/%s/logs", c.BaseURL, namespace, repository, buildUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get build logs request: %w", err)
 	}
@@ -71,7 +71,7 @@ func (c *Client) GetBuildLogs(namespace, repository, buildUUID string) (*BuildLo
 
 // RequestBuild triggers a new build for a repository
 func (c *Client) RequestBuild(namespace, repository string, buildRequest *RequestBuildRequest) (*Build, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/build/", QuayURL, namespace, repository), buildRequest)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/build/", c.BaseURL, namespace, repository), buildRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request build request: %w", err)
 	}
@@ -86,7 +86,7 @@ func (c *Client) RequestBuild(namespace, repository string, buildRequest *Reques
 
 // CancelBuild cancels an ongoing build
 func (c *Client) CancelBuild(namespace, repository, buildUUID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/build/%s", QuayURL, namespace, repository, buildUUID), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/build/%s", c.BaseURL, namespace, repository, buildUUID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create cancel build request: %w", err)
 	}
@@ -100,7 +100,7 @@ func (c *Client) CancelBuild(namespace, repository, buildUUID string) error {
 
 // GetBuildStatus gets the status of a build
 func (c *Client) GetBuildStatus(namespace, repository, buildUUID string) (*BuildStatus, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/build/%s/status", QuayURL, namespace, repository, buildUUID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/build/%s/status", c.BaseURL, namespace, repository, buildUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get build status request: %w", err)
 	}

--- a/lib/build_test.go
+++ b/lib/build_test.go
@@ -34,11 +34,7 @@ func TestGetBuilds(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -78,11 +74,7 @@ func TestGetBuild(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -124,11 +116,7 @@ func TestGetBuildLogs(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -168,11 +156,7 @@ func TestRequestBuild(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -205,11 +189,7 @@ func TestCancelBuild(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -226,11 +206,7 @@ func TestGetBuildsError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -247,11 +223,7 @@ func TestGetBuildError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/lib/client.go
+++ b/lib/client.go
@@ -4,7 +4,8 @@ Package lib provides Quay.io API client functionality.
 This file covers HTTP CLIENT and helper methods:
 
 Client Setup:
-  - NewClient(bearerToken string) (*Client, error)   - Create authenticated client
+  - NewClient(bearerToken string) (*Client, error)                - Create authenticated client (default URL)
+  - NewClientWithURL(bearerToken, baseURL string) (*Client, error) - Create authenticated client with custom URL
 
 HTTP Helper Methods:
   - get(req *http.Request, v any) error      - Execute GET requests
@@ -36,12 +37,16 @@ import (
 	"time"
 )
 
+// DefaultQuayURL is the default Quay.io API base URL.
+const DefaultQuayURL = "https://quay.io/api/v1"
+
 type Client struct {
 	BearerToken string
+	BaseURL     string
 	HTTPClient  *http.Client
 }
 
-func NewClient(bearerToken string) (*Client, error) {
+func NewClientWithURL(bearerToken, baseURL string) (*Client, error) {
 	if bearerToken == "" {
 		return nil, errors.New("bearer token is required")
 	}
@@ -55,11 +60,16 @@ func NewClient(bearerToken string) (*Client, error) {
 
 	return &Client{
 		BearerToken: bearerToken,
+		BaseURL:     baseURL,
 		HTTPClient: &http.Client{
 			Timeout:   30 * time.Second,
 			Transport: transport,
 		},
 	}, nil
+}
+
+func NewClient(bearerToken string) (*Client, error) {
+	return NewClientWithURL(bearerToken, DefaultQuayURL)
 }
 
 func (c *Client) get(req *http.Request, v any) error {

--- a/lib/discovery.go
+++ b/lib/discovery.go
@@ -16,7 +16,7 @@ import (
 
 // GetDiscovery retrieves API discovery information
 func (c *Client) GetDiscovery() (*Discovery, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/discovery", QuayURL), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/discovery", c.BaseURL), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discovery request: %w", err)
 	}
@@ -31,7 +31,7 @@ func (c *Client) GetDiscovery() (*Discovery, error) {
 
 // GetAppInfo retrieves public information about an OAuth application by client ID
 func (c *Client) GetAppInfo(clientID string) (*Application, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/app/%s", QuayURL, clientID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/app/%s", c.BaseURL, clientID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get app info request: %w", err)
 	}
@@ -46,7 +46,7 @@ func (c *Client) GetAppInfo(clientID string) (*Application, error) {
 
 // GetEntities searches for entities (users, robots, teams) matching a prefix
 func (c *Client) GetEntities(prefix string, includeOrgs, includeTeams bool) (*Entities, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/entities/%s", QuayURL, prefix), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/entities/%s", c.BaseURL, prefix), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get entities request: %w", err)
 	}

--- a/lib/discovery_test.go
+++ b/lib/discovery_test.go
@@ -33,11 +33,7 @@ func TestGetDiscovery(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -61,11 +57,7 @@ func TestGetDiscoveryError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/lib/error.go
+++ b/lib/error.go
@@ -17,7 +17,7 @@ import (
 
 // GetErrorType retrieves details about a specific error type
 func (c *Client) GetErrorType(errorType string) (*ErrorType, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/error/%s", QuayURL, errorType), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/error/%s", c.BaseURL, errorType), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create error type request: %w", err)
 	}

--- a/lib/error_test.go
+++ b/lib/error_test.go
@@ -33,11 +33,7 @@ func TestGetErrorType(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -61,11 +57,7 @@ func TestGetErrorTypeError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/lib/logs.go
+++ b/lib/logs.go
@@ -24,10 +24,6 @@ const (
 	endTimeParam   = "endtime"
 )
 
-var (
-	QuayURL = "https://quay.io/api/v1"
-)
-
 // addQueryParams adds query parameters to a request URL.
 func addQueryParams(req *http.Request, params map[string]string) {
 	q := req.URL.Query()
@@ -57,7 +53,7 @@ func addLogQueryParams(req *http.Request, nextPage, startDate, endDate string) {
 // GetAggregatedLogs returns the aggregated logs for a repository
 func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate string) (*AggregatedLogs, error) {
 	// Get new request
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/aggregatelogs", QuayURL, namespace, repository), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/aggregatelogs", c.BaseURL, namespace, repository), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +74,7 @@ func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate str
 
 // GetLogs returns the logs for a repository
 func (c *Client) GetLogs(namespace, repository, nextPage, startDate, endDate string) (*Logs, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/logs", QuayURL, namespace, repository), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/logs", c.BaseURL, namespace, repository), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +91,7 @@ func (c *Client) GetLogs(namespace, repository, nextPage, startDate, endDate str
 
 // GetOrganizationLogs returns the logs for an organization
 func (c *Client) GetOrganizationLogs(orgname, nextPage, startDate, endDate string) (*Logs, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/logs", QuayURL, orgname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/logs", c.BaseURL, orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +108,7 @@ func (c *Client) GetOrganizationLogs(orgname, nextPage, startDate, endDate strin
 
 // GetOrganizationAggregatedLogs returns the aggregated logs for an organization
 func (c *Client) GetOrganizationAggregatedLogs(orgname, startDate, endDate string) (*AggregatedLogs, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/aggregatelogs", QuayURL, orgname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/aggregatelogs", c.BaseURL, orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +128,7 @@ func (c *Client) GetOrganizationAggregatedLogs(orgname, startDate, endDate strin
 
 // ExportOrganizationLogs exports the logs for an organization
 func (c *Client) ExportOrganizationLogs(orgname string, request *ExportLogsRequest) error {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/exportlogs", QuayURL, orgname), request)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/exportlogs", c.BaseURL, orgname), request)
 	if err != nil {
 		return err
 	}
@@ -146,7 +142,7 @@ func (c *Client) ExportOrganizationLogs(orgname string, request *ExportLogsReque
 
 // GetUserLogs returns the logs for the current user
 func (c *Client) GetUserLogs(nextPage, startDate, endDate string) (*Logs, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/user/logs", QuayURL), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/user/logs", c.BaseURL), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +159,7 @@ func (c *Client) GetUserLogs(nextPage, startDate, endDate string) (*Logs, error)
 
 // GetUserAggregatedLogs returns the aggregated logs for the current user
 func (c *Client) GetUserAggregatedLogs(startDate, endDate string) (*AggregatedLogs, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/user/aggregatelogs", QuayURL), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/user/aggregatelogs", c.BaseURL), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +179,7 @@ func (c *Client) GetUserAggregatedLogs(startDate, endDate string) (*AggregatedLo
 
 // ExportUserLogs exports the logs for the current user
 func (c *Client) ExportUserLogs(request *ExportLogsRequest) error {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/user/exportlogs", QuayURL), request)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/user/exportlogs", c.BaseURL), request)
 	if err != nil {
 		return err
 	}
@@ -197,7 +193,7 @@ func (c *Client) ExportUserLogs(request *ExportLogsRequest) error {
 
 // ExportRepositoryLogs exports the logs for a repository
 func (c *Client) ExportRepositoryLogs(namespace, repository string, request *ExportLogsRequest) error {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/exportlogs", QuayURL, namespace, repository), request)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/exportlogs", c.BaseURL, namespace, repository), request)
 	if err != nil {
 		return err
 	}

--- a/lib/logs_test.go
+++ b/lib/logs_test.go
@@ -45,11 +45,7 @@ func TestGetAggregatedLogs(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -97,11 +93,7 @@ func TestGetLogs(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -137,11 +129,7 @@ func TestGetLogsWithDateRange(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -164,11 +152,7 @@ func TestGetLogsWithNextPage(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -198,11 +182,7 @@ func TestGetOrganizationLogsWithDateRange(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -232,11 +212,7 @@ func TestGetUserLogsWithDateRange(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -253,11 +229,7 @@ func TestGetAggregatedLogsError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -274,11 +246,7 @@ func TestGetLogsError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/lib/manifest.go
+++ b/lib/manifest.go
@@ -24,7 +24,7 @@ import (
 
 // GetManifest retrieves detailed information about a specific manifest
 func (c *Client) GetManifest(namespace, repository, manifestRef string) (*Manifest, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/manifest/%s", QuayURL, namespace, repository, manifestRef), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/manifest/%s", c.BaseURL, namespace, repository, manifestRef), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest request: %w", err)
 	}
@@ -39,7 +39,7 @@ func (c *Client) GetManifest(namespace, repository, manifestRef string) (*Manife
 
 // DeleteManifest deletes a specific manifest from a repository
 func (c *Client) DeleteManifest(namespace, repository, manifestRef string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/manifest/%s", QuayURL, namespace, repository, manifestRef), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/manifest/%s", c.BaseURL, namespace, repository, manifestRef), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete manifest request: %w", err)
 	}
@@ -53,7 +53,7 @@ func (c *Client) DeleteManifest(namespace, repository, manifestRef string) error
 
 // GetManifestLabels retrieves all labels for a specific manifest
 func (c *Client) GetManifestLabels(namespace, repository, manifestRef string) (*ManifestLabels, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/manifest/%s/labels", QuayURL, namespace, repository, manifestRef), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/manifest/%s/labels", c.BaseURL, namespace, repository, manifestRef), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest labels request: %w", err)
 	}
@@ -77,7 +77,7 @@ func (c *Client) AddManifestLabel(namespace, repository, manifestRef, key, value
 		addReq.MediaType = mediaType
 	}
 
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/manifest/%s/labels", QuayURL, namespace, repository, manifestRef), addReq)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/manifest/%s/labels", c.BaseURL, namespace, repository, manifestRef), addReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create add manifest label request: %w", err)
 	}
@@ -92,7 +92,7 @@ func (c *Client) AddManifestLabel(namespace, repository, manifestRef, key, value
 
 // GetManifestLabel retrieves a specific label from a manifest
 func (c *Client) GetManifestLabel(namespace, repository, manifestRef, labelID string) (*ManifestLabel, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/manifest/%s/labels/%s", QuayURL, namespace, repository, manifestRef, labelID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/manifest/%s/labels/%s", c.BaseURL, namespace, repository, manifestRef, labelID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest label request: %w", err)
 	}
@@ -107,7 +107,7 @@ func (c *Client) GetManifestLabel(namespace, repository, manifestRef, labelID st
 
 // DeleteManifestLabel deletes a specific label from a manifest
 func (c *Client) DeleteManifestLabel(namespace, repository, manifestRef, labelID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/manifest/%s/labels/%s", QuayURL, namespace, repository, manifestRef, labelID), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/manifest/%s/labels/%s", c.BaseURL, namespace, repository, manifestRef, labelID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete manifest label request: %w", err)
 	}

--- a/lib/manifest_test.go
+++ b/lib/manifest_test.go
@@ -56,11 +56,7 @@ func TestGetManifest(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -97,11 +93,7 @@ func TestDeleteManifest(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -148,11 +140,7 @@ func TestGetManifestLabels(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -211,11 +199,7 @@ func TestAddManifestLabel(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -262,11 +246,7 @@ func TestGetManifestLabel(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -298,11 +278,7 @@ func TestDeleteManifestLabel(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -321,11 +297,7 @@ func TestManifestErrorHandling(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/lib/messages.go
+++ b/lib/messages.go
@@ -17,7 +17,7 @@ import (
 
 // GetMessages retrieves system messages for the user
 func (c *Client) GetMessages() (*Messages, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/messages", QuayURL), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/messages", c.BaseURL), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create messages request: %w", err)
 	}
@@ -50,7 +50,7 @@ func (c *Client) CreateMessage(content, severity, mediaType string) (*Message, e
 		},
 	}
 
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/messages", QuayURL), body)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/messages", c.BaseURL), body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create message request: %w", err)
 	}

--- a/lib/messages_test.go
+++ b/lib/messages_test.go
@@ -39,11 +39,7 @@ func TestGetMessages(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -73,11 +69,7 @@ func TestGetMessagesEmpty(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -98,11 +90,7 @@ func TestGetMessagesError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/lib/notification.go
+++ b/lib/notification.go
@@ -38,7 +38,7 @@ import (
 
 // GetNotifications retrieves all notifications for a repository
 func (c *Client) GetNotifications(namespace, repository string) (*RepositoryNotifications, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/notification/", QuayURL, namespace, repository), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/notification/", c.BaseURL, namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get notifications request: %w", err)
 	}
@@ -53,7 +53,7 @@ func (c *Client) GetNotifications(namespace, repository string) (*RepositoryNoti
 
 // GetNotification retrieves a specific notification by UUID
 func (c *Client) GetNotification(namespace, repository, uuid string) (*RepositoryNotification, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/notification/%s", QuayURL, namespace, repository, uuid), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/notification/%s", c.BaseURL, namespace, repository, uuid), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get notification request: %w", err)
 	}
@@ -68,7 +68,7 @@ func (c *Client) GetNotification(namespace, repository, uuid string) (*Repositor
 
 // CreateNotification creates a new notification for a repository
 func (c *Client) CreateNotification(namespace, repository string, notificationReq *CreateNotificationRequest) (*RepositoryNotification, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/notification/", QuayURL, namespace, repository), notificationReq)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/notification/", c.BaseURL, namespace, repository), notificationReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create notification request: %w", err)
 	}
@@ -83,7 +83,7 @@ func (c *Client) CreateNotification(namespace, repository string, notificationRe
 
 // DeleteNotification deletes a notification from a repository
 func (c *Client) DeleteNotification(namespace, repository, uuid string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/notification/%s", QuayURL, namespace, repository, uuid), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/notification/%s", c.BaseURL, namespace, repository, uuid), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete notification request: %w", err)
 	}
@@ -97,7 +97,7 @@ func (c *Client) DeleteNotification(namespace, repository, uuid string) error {
 
 // TestNotification tests a notification by sending a test event
 func (c *Client) TestNotification(namespace, repository, uuid string) error {
-	req, err := newRequest("POST", fmt.Sprintf("%s/repository/%s/%s/notification/%s/test", QuayURL, namespace, repository, uuid), nil)
+	req, err := newRequest("POST", fmt.Sprintf("%s/repository/%s/%s/notification/%s/test", c.BaseURL, namespace, repository, uuid), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create test notification request: %w", err)
 	}
@@ -111,7 +111,7 @@ func (c *Client) TestNotification(namespace, repository, uuid string) error {
 
 // ResetNotification resets failure count for a notification
 func (c *Client) ResetNotification(namespace, repository, uuid string) error {
-	req, err := newRequest("POST", fmt.Sprintf("%s/repository/%s/%s/notification/%s/reset", QuayURL, namespace, repository, uuid), nil)
+	req, err := newRequest("POST", fmt.Sprintf("%s/repository/%s/%s/notification/%s/reset", c.BaseURL, namespace, repository, uuid), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create reset notification request: %w", err)
 	}
@@ -125,7 +125,7 @@ func (c *Client) ResetNotification(namespace, repository, uuid string) error {
 
 // UpdateNotification updates an existing notification
 func (c *Client) UpdateNotification(namespace, repository, uuid string, notificationReq *CreateNotificationRequest) (*RepositoryNotification, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/notification/%s", QuayURL, namespace, repository, uuid), notificationReq)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/notification/%s", c.BaseURL, namespace, repository, uuid), notificationReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update notification request: %w", err)
 	}

--- a/lib/notification_test.go
+++ b/lib/notification_test.go
@@ -35,11 +35,7 @@ func TestGetNotifications(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -80,11 +76,7 @@ func TestGetNotification(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -125,11 +117,7 @@ func TestCreateNotification(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -164,11 +152,7 @@ func TestDeleteNotification(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -192,11 +176,7 @@ func TestTestNotification(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -220,11 +200,7 @@ func TestResetNotification(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -241,11 +217,7 @@ func TestGetNotificationsError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -262,11 +234,7 @@ func TestGetNotificationError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/lib/organization.go
+++ b/lib/organization.go
@@ -89,7 +89,7 @@ const fieldRole = "role"
 
 // CreateOrganization creates a new organization
 func (c *Client) CreateOrganization(name, email string) (*Organization, error) {
-	req, err := newRequestWithBody("POST", QuayURL+"/organization/", CreateOrganizationRequest{
+	req, err := newRequestWithBody("POST", c.BaseURL+"/organization/", CreateOrganizationRequest{
 		Name:  name,
 		Email: email,
 	})
@@ -107,7 +107,7 @@ func (c *Client) CreateOrganization(name, email string) (*Organization, error) {
 
 // GetOrganization retrieves organization details
 func (c *Client) GetOrganization(orgname string) (*Organization, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s", QuayURL, orgname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s", c.BaseURL, orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (c *Client) GetOrganization(orgname string) (*Organization, error) {
 
 // DeleteOrganization deletes an organization
 func (c *Client) DeleteOrganization(orgname string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s", QuayURL, orgname), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s", c.BaseURL, orgname), nil)
 	if err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ func (c *Client) DeleteOrganization(orgname string) error {
 
 // UpdateOrganization updates organization settings
 func (c *Client) UpdateOrganization(orgname, email string) (*Organization, error) {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s", QuayURL, orgname), map[string]interface{}{
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s", c.BaseURL, orgname), map[string]interface{}{
 		"email": email,
 	})
 	if err != nil {
@@ -151,7 +151,7 @@ func (c *Client) UpdateOrganization(orgname, email string) (*Organization, error
 
 // GetOrganizationMembers retrieves organization members
 func (c *Client) GetOrganizationMembers(orgname string) (*OrganizationMembers, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/members", QuayURL, orgname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/members", c.BaseURL, orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ func (c *Client) GetOrganizationMembers(orgname string) (*OrganizationMembers, e
 
 // AddOrganizationMember adds a member to an organization
 func (c *Client) AddOrganizationMember(orgname, membername string) error {
-	req, err := newRequest("PUT", fmt.Sprintf("%s/organization/%s/members/%s", QuayURL, orgname, membername), nil)
+	req, err := newRequest("PUT", fmt.Sprintf("%s/organization/%s/members/%s", c.BaseURL, orgname, membername), nil)
 	if err != nil {
 		return err
 	}
@@ -176,7 +176,7 @@ func (c *Client) AddOrganizationMember(orgname, membername string) error {
 
 // RemoveOrganizationMember removes a member from an organization
 func (c *Client) RemoveOrganizationMember(orgname, membername string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/members/%s", QuayURL, orgname, membername), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/members/%s", c.BaseURL, orgname, membername), nil)
 	if err != nil {
 		return err
 	}
@@ -188,7 +188,7 @@ func (c *Client) RemoveOrganizationMember(orgname, membername string) error {
 
 // GetOrganizationRepositories retrieves repositories for an organization
 func (c *Client) GetOrganizationRepositories(orgname string) (*OrganizationRepositories, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/repositories", QuayURL, orgname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/repositories", c.BaseURL, orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +205,7 @@ func (c *Client) GetOrganizationRepositories(orgname string) (*OrganizationRepos
 
 // GetDefaultPermissions retrieves default permissions for an organization
 func (c *Client) GetDefaultPermissions(orgname string) (*DefaultPermissions, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/prototypes", QuayURL, orgname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/prototypes", c.BaseURL, orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +220,7 @@ func (c *Client) GetDefaultPermissions(orgname string) (*DefaultPermissions, err
 
 // CreateDefaultPermission creates a default permission for an organization
 func (c *Client) CreateDefaultPermission(orgname, role, delegateType, delegateName string) (*DefaultPermission, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/prototypes", QuayURL, orgname), map[string]interface{}{
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/prototypes", c.BaseURL, orgname), map[string]interface{}{
 		fieldRole: role,
 		"delegate": map[string]interface{}{
 			"kind": delegateType,
@@ -241,7 +241,7 @@ func (c *Client) CreateDefaultPermission(orgname, role, delegateType, delegateNa
 
 // DeleteDefaultPermission deletes a default permission
 func (c *Client) DeleteDefaultPermission(orgname, prototypeid string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/prototypes/%s", QuayURL, orgname, prototypeid), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/prototypes/%s", c.BaseURL, orgname, prototypeid), nil)
 	if err != nil {
 		return err
 	}
@@ -253,7 +253,7 @@ func (c *Client) DeleteDefaultPermission(orgname, prototypeid string) error {
 
 // GetProxyCacheConfig retrieves proxy cache configuration for an organization
 func (c *Client) GetProxyCacheConfig(orgname string) (*ProxyCacheConfig, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/proxycache", QuayURL, orgname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/proxycache", c.BaseURL, orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +268,7 @@ func (c *Client) GetProxyCacheConfig(orgname string) (*ProxyCacheConfig, error) 
 
 // CreateProxyCacheConfig creates proxy cache configuration for an organization
 func (c *Client) CreateProxyCacheConfig(orgname, upstreamRegistry string, insecure bool, expiration int) (*ProxyCacheConfig, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/proxycache", QuayURL, orgname), map[string]interface{}{
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/proxycache", c.BaseURL, orgname), map[string]interface{}{
 		"upstream_registry": upstreamRegistry,
 		"insecure":          insecure,
 		"expiration":        expiration,
@@ -287,7 +287,7 @@ func (c *Client) CreateProxyCacheConfig(orgname, upstreamRegistry string, insecu
 
 // DeleteProxyCacheConfig deletes proxy cache configuration for an organization
 func (c *Client) DeleteProxyCacheConfig(orgname string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/proxycache", QuayURL, orgname), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/proxycache", c.BaseURL, orgname), nil)
 	if err != nil {
 		return err
 	}
@@ -299,7 +299,7 @@ func (c *Client) DeleteProxyCacheConfig(orgname string) error {
 
 // GetTeams retrieves all teams for an organization
 func (c *Client) GetTeams(orgname string) ([]Team, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/teams", QuayURL, orgname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/teams", c.BaseURL, orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -316,7 +316,7 @@ func (c *Client) GetTeams(orgname string) ([]Team, error) {
 
 // CreateTeam creates a new team in an organization
 func (c *Client) CreateTeam(orgname, teamname, description, role string) (*Team, error) {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/team/%s", QuayURL, orgname, teamname), CreateTeamRequest{
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/team/%s", c.BaseURL, orgname, teamname), CreateTeamRequest{
 		Name:        teamname,
 		Description: description,
 		Role:        role,
@@ -335,7 +335,7 @@ func (c *Client) CreateTeam(orgname, teamname, description, role string) (*Team,
 
 // GetTeam retrieves details for a specific team
 func (c *Client) GetTeam(orgname, teamname string) (*Team, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/team/%s", QuayURL, orgname, teamname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/team/%s", c.BaseURL, orgname, teamname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +350,7 @@ func (c *Client) GetTeam(orgname, teamname string) (*Team, error) {
 
 // DeleteTeam deletes a team from an organization
 func (c *Client) DeleteTeam(orgname, teamname string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/team/%s", QuayURL, orgname, teamname), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/team/%s", c.BaseURL, orgname, teamname), nil)
 	if err != nil {
 		return err
 	}
@@ -360,7 +360,7 @@ func (c *Client) DeleteTeam(orgname, teamname string) error {
 
 // UpdateTeam updates team settings
 func (c *Client) UpdateTeam(orgname, teamname, description, role string) (*Team, error) {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/team/%s", QuayURL, orgname, teamname), map[string]interface{}{
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/team/%s", c.BaseURL, orgname, teamname), map[string]interface{}{
 		"description": description,
 		fieldRole:     role,
 	})
@@ -380,7 +380,7 @@ func (c *Client) UpdateTeam(orgname, teamname, description, role string) (*Team,
 
 // GetTeamMembers retrieves members of a team
 func (c *Client) GetTeamMembers(orgname, teamname string) (*TeamMembers, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/team/%s/members", QuayURL, orgname, teamname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/team/%s/members", c.BaseURL, orgname, teamname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -395,7 +395,7 @@ func (c *Client) GetTeamMembers(orgname, teamname string) (*TeamMembers, error) 
 
 // AddTeamMember adds a member to a team
 func (c *Client) AddTeamMember(orgname, teamname, membername string) error {
-	req, err := newRequest("PUT", fmt.Sprintf("%s/organization/%s/team/%s/members/%s", QuayURL, orgname, teamname, membername), nil)
+	req, err := newRequest("PUT", fmt.Sprintf("%s/organization/%s/team/%s/members/%s", c.BaseURL, orgname, teamname, membername), nil)
 	if err != nil {
 		return err
 	}
@@ -405,7 +405,7 @@ func (c *Client) AddTeamMember(orgname, teamname, membername string) error {
 
 // RemoveTeamMember removes a member from a team
 func (c *Client) RemoveTeamMember(orgname, teamname, membername string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/team/%s/members/%s", QuayURL, orgname, teamname, membername), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/team/%s/members/%s", c.BaseURL, orgname, teamname, membername), nil)
 	if err != nil {
 		return err
 	}
@@ -417,7 +417,7 @@ func (c *Client) RemoveTeamMember(orgname, teamname, membername string) error {
 
 // GetTeamPermissions retrieves repository permissions for a team
 func (c *Client) GetTeamPermissions(orgname, teamname string) (*TeamPermissions, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/team/%s/permissions", QuayURL, orgname, teamname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/team/%s/permissions", c.BaseURL, orgname, teamname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -432,7 +432,7 @@ func (c *Client) GetTeamPermissions(orgname, teamname string) (*TeamPermissions,
 
 // SetTeamRepositoryPermission sets repository permission for a team
 func (c *Client) SetTeamRepositoryPermission(orgname, teamname, repository, role string) error {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/team/%s/permissions/%s", QuayURL, orgname, teamname, repository), map[string]interface{}{
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/team/%s/permissions/%s", c.BaseURL, orgname, teamname, repository), map[string]interface{}{
 		fieldRole: role,
 	})
 	if err != nil {
@@ -444,7 +444,7 @@ func (c *Client) SetTeamRepositoryPermission(orgname, teamname, repository, role
 
 // RemoveTeamRepositoryPermission removes repository permission for a team
 func (c *Client) RemoveTeamRepositoryPermission(orgname, teamname, repository string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/team/%s/permissions/%s", QuayURL, orgname, teamname, repository), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/team/%s/permissions/%s", c.BaseURL, orgname, teamname, repository), nil)
 	if err != nil {
 		return err
 	}
@@ -456,7 +456,7 @@ func (c *Client) RemoveTeamRepositoryPermission(orgname, teamname, repository st
 
 // GetRobotAccounts retrieves all robot accounts for an organization
 func (c *Client) GetRobotAccounts(orgname string) (*RobotAccounts, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/robots", QuayURL, orgname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/robots", c.BaseURL, orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -471,7 +471,7 @@ func (c *Client) GetRobotAccounts(orgname string) (*RobotAccounts, error) {
 
 // CreateRobotAccount creates a new robot account in an organization
 func (c *Client) CreateRobotAccount(orgname, robotShortname, description string, unstructured map[string]interface{}) (*RobotAccount, error) {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/robots/%s", QuayURL, orgname, robotShortname), CreateRobotRequest{
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/robots/%s", c.BaseURL, orgname, robotShortname), CreateRobotRequest{
 		Description:  description,
 		Unstructured: unstructured,
 	})
@@ -489,7 +489,7 @@ func (c *Client) CreateRobotAccount(orgname, robotShortname, description string,
 
 // GetRobotAccount retrieves details for a specific robot account
 func (c *Client) GetRobotAccount(orgname, robotShortname string) (*RobotAccount, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/robots/%s", QuayURL, orgname, robotShortname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/robots/%s", c.BaseURL, orgname, robotShortname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -504,7 +504,7 @@ func (c *Client) GetRobotAccount(orgname, robotShortname string) (*RobotAccount,
 
 // DeleteRobotAccount deletes a robot account from an organization
 func (c *Client) DeleteRobotAccount(orgname, robotShortname string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/robots/%s", QuayURL, orgname, robotShortname), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/robots/%s", c.BaseURL, orgname, robotShortname), nil)
 	if err != nil {
 		return err
 	}
@@ -514,7 +514,7 @@ func (c *Client) DeleteRobotAccount(orgname, robotShortname string) error {
 
 // RegenerateRobotToken regenerates the token for a robot account
 func (c *Client) RegenerateRobotToken(orgname, robotShortname string) (*RobotAccount, error) {
-	req, err := newRequest("POST", fmt.Sprintf("%s/organization/%s/robots/%s/regenerate", QuayURL, orgname, robotShortname), nil)
+	req, err := newRequest("POST", fmt.Sprintf("%s/organization/%s/robots/%s/regenerate", c.BaseURL, orgname, robotShortname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -529,7 +529,7 @@ func (c *Client) RegenerateRobotToken(orgname, robotShortname string) (*RobotAcc
 
 // GetRobotPermissions retrieves repository permissions for a robot account
 func (c *Client) GetRobotPermissions(orgname, robotShortname string) (*RobotPermissions, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/robots/%s/permissions", QuayURL, orgname, robotShortname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/robots/%s/permissions", c.BaseURL, orgname, robotShortname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -544,7 +544,7 @@ func (c *Client) GetRobotPermissions(orgname, robotShortname string) (*RobotPerm
 
 // SetRobotRepositoryPermission sets repository permission for a robot account
 func (c *Client) SetRobotRepositoryPermission(orgname, robotShortname, repository, role string) error {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/robots/%s/permissions/%s", QuayURL, orgname, robotShortname, repository), map[string]interface{}{
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/robots/%s/permissions/%s", c.BaseURL, orgname, robotShortname, repository), map[string]interface{}{
 		fieldRole: role,
 	})
 	if err != nil {
@@ -556,7 +556,7 @@ func (c *Client) SetRobotRepositoryPermission(orgname, robotShortname, repositor
 
 // RemoveRobotRepositoryPermission removes repository permission for a robot account
 func (c *Client) RemoveRobotRepositoryPermission(orgname, robotShortname, repository string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/robots/%s/permissions/%s", QuayURL, orgname, robotShortname, repository), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/robots/%s/permissions/%s", c.BaseURL, orgname, robotShortname, repository), nil)
 	if err != nil {
 		return err
 	}
@@ -568,7 +568,7 @@ func (c *Client) RemoveRobotRepositoryPermission(orgname, robotShortname, reposi
 
 // GetQuota retrieves quota information for an organization
 func (c *Client) GetQuota(orgname string) (*Quota, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/quota", QuayURL, orgname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/quota", c.BaseURL, orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -583,7 +583,7 @@ func (c *Client) GetQuota(orgname string) (*Quota, error) {
 
 // CreateQuota creates a quota for an organization
 func (c *Client) CreateQuota(orgname string, limitBytes int64) (*Quota, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/quota", QuayURL, orgname), CreateQuotaRequest{
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/quota", c.BaseURL, orgname), CreateQuotaRequest{
 		LimitBytes: limitBytes,
 	})
 	if err != nil {
@@ -600,7 +600,7 @@ func (c *Client) CreateQuota(orgname string, limitBytes int64) (*Quota, error) {
 
 // UpdateQuota updates quota limits for an organization
 func (c *Client) UpdateQuota(orgname string, limitBytes int64) (*Quota, error) {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/quota", QuayURL, orgname), CreateQuotaRequest{
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/quota", c.BaseURL, orgname), CreateQuotaRequest{
 		LimitBytes: limitBytes,
 	})
 	if err != nil {
@@ -617,7 +617,7 @@ func (c *Client) UpdateQuota(orgname string, limitBytes int64) (*Quota, error) {
 
 // DeleteQuota deletes quota for an organization
 func (c *Client) DeleteQuota(orgname string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/quota", QuayURL, orgname), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/quota", c.BaseURL, orgname), nil)
 	if err != nil {
 		return err
 	}
@@ -629,7 +629,7 @@ func (c *Client) DeleteQuota(orgname string) error {
 
 // GetAutoPrunePolicies retrieves auto-prune policies for an organization
 func (c *Client) GetAutoPrunePolicies(orgname string) (*AutoPrunePolicies, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/autoprunepolicy", QuayURL, orgname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/autoprunepolicy", c.BaseURL, orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -644,7 +644,7 @@ func (c *Client) GetAutoPrunePolicies(orgname string) (*AutoPrunePolicies, error
 
 // CreateAutoPrunePolicy creates an auto-prune policy for an organization
 func (c *Client) CreateAutoPrunePolicy(orgname, method string, value int, tagPattern string) (*AutoPrunePolicy, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/autoprunepolicy", QuayURL, orgname), CreateAutoPruneRequest{
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/autoprunepolicy", c.BaseURL, orgname), CreateAutoPruneRequest{
 		Method:     method,
 		Value:      value,
 		TagPattern: tagPattern,
@@ -663,7 +663,7 @@ func (c *Client) CreateAutoPrunePolicy(orgname, method string, value int, tagPat
 
 // GetAutoPrunePolicy retrieves a specific auto-prune policy
 func (c *Client) GetAutoPrunePolicy(orgname, policyUUID string) (*AutoPrunePolicy, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/autoprunepolicy/%s", QuayURL, orgname, policyUUID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/autoprunepolicy/%s", c.BaseURL, orgname, policyUUID), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -678,7 +678,7 @@ func (c *Client) GetAutoPrunePolicy(orgname, policyUUID string) (*AutoPrunePolic
 
 // UpdateAutoPrunePolicy updates an auto-prune policy
 func (c *Client) UpdateAutoPrunePolicy(orgname, policyUUID, method string, value int, tagPattern string) (*AutoPrunePolicy, error) {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/autoprunepolicy/%s", QuayURL, orgname, policyUUID), CreateAutoPruneRequest{
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/autoprunepolicy/%s", c.BaseURL, orgname, policyUUID), CreateAutoPruneRequest{
 		Method:     method,
 		Value:      value,
 		TagPattern: tagPattern,
@@ -697,7 +697,7 @@ func (c *Client) UpdateAutoPrunePolicy(orgname, policyUUID, method string, value
 
 // DeleteAutoPrunePolicy deletes an auto-prune policy
 func (c *Client) DeleteAutoPrunePolicy(orgname, policyUUID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/autoprunepolicy/%s", QuayURL, orgname, policyUUID), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/autoprunepolicy/%s", c.BaseURL, orgname, policyUUID), nil)
 	if err != nil {
 		return err
 	}
@@ -709,7 +709,7 @@ func (c *Client) DeleteAutoPrunePolicy(orgname, policyUUID string) error {
 
 // GetApplications retrieves applications for an organization
 func (c *Client) GetApplications(orgname string) (*Applications, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/applications", QuayURL, orgname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/applications", c.BaseURL, orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -724,7 +724,7 @@ func (c *Client) GetApplications(orgname string) (*Applications, error) {
 
 // CreateApplication creates a new application for an organization
 func (c *Client) CreateApplication(orgname, name, description, applicationURI, redirectURI string) (*Application, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/applications", QuayURL, orgname), CreateApplicationRequest{
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/applications", c.BaseURL, orgname), CreateApplicationRequest{
 		Name:           name,
 		Description:    description,
 		ApplicationURI: applicationURI,
@@ -744,7 +744,7 @@ func (c *Client) CreateApplication(orgname, name, description, applicationURI, r
 
 // GetApplication retrieves details for a specific application
 func (c *Client) GetApplication(orgname, clientID string) (*Application, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/applications/%s", QuayURL, orgname, clientID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/applications/%s", c.BaseURL, orgname, clientID), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -759,7 +759,7 @@ func (c *Client) GetApplication(orgname, clientID string) (*Application, error) 
 
 // UpdateApplication updates an application
 func (c *Client) UpdateApplication(orgname, clientID, name, description, applicationURI, redirectURI string) (*Application, error) {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/applications/%s", QuayURL, orgname, clientID), CreateApplicationRequest{
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/applications/%s", c.BaseURL, orgname, clientID), CreateApplicationRequest{
 		Name:           name,
 		Description:    description,
 		ApplicationURI: applicationURI,
@@ -779,7 +779,7 @@ func (c *Client) UpdateApplication(orgname, clientID, name, description, applica
 
 // DeleteApplication deletes an application
 func (c *Client) DeleteApplication(orgname, clientID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/applications/%s", QuayURL, orgname, clientID), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/applications/%s", c.BaseURL, orgname, clientID), nil)
 	if err != nil {
 		return err
 	}
@@ -789,7 +789,7 @@ func (c *Client) DeleteApplication(orgname, clientID string) error {
 
 // ResetApplicationClientSecret resets the client secret for an application
 func (c *Client) ResetApplicationClientSecret(orgname, clientID string) (*Application, error) {
-	req, err := newRequest("POST", fmt.Sprintf("%s/organization/%s/applications/%s/resetclientsecret", QuayURL, orgname, clientID), nil)
+	req, err := newRequest("POST", fmt.Sprintf("%s/organization/%s/applications/%s/resetclientsecret", c.BaseURL, orgname, clientID), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -804,7 +804,7 @@ func (c *Client) ResetApplicationClientSecret(orgname, clientID string) (*Applic
 
 // GetOrganizationCollaborators gets the list of collaborators for an organization
 func (c *Client) GetOrganizationCollaborators(orgname string) (*Collaborators, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/collaborators", QuayURL, orgname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/collaborators", c.BaseURL, orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -819,7 +819,7 @@ func (c *Client) GetOrganizationCollaborators(orgname string) (*Collaborators, e
 
 // GetOrganizationMember gets information about a specific organization member
 func (c *Client) GetOrganizationMember(orgname, membername string) (*OrganizationMember, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/members/%s", QuayURL, orgname, membername), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/members/%s", c.BaseURL, orgname, membername), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -834,7 +834,7 @@ func (c *Client) GetOrganizationMember(orgname, membername string) (*Organizatio
 
 // GetOrganizationMarketplace gets marketplace information for an organization
 func (c *Client) GetOrganizationMarketplace(orgname string) (*MarketplaceInfo, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/marketplace", QuayURL, orgname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/marketplace", c.BaseURL, orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -849,7 +849,7 @@ func (c *Client) GetOrganizationMarketplace(orgname string) (*MarketplaceInfo, e
 
 // CreateOrganizationMarketplaceSubscription creates a marketplace subscription
 func (c *Client) CreateOrganizationMarketplaceSubscription(orgname string, subscription *MarketplaceSubscriptionRequest) error {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/marketplace", QuayURL, orgname), subscription)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/marketplace", c.BaseURL, orgname), subscription)
 	if err != nil {
 		return err
 	}
@@ -864,7 +864,7 @@ func (c *Client) BatchRemoveOrganizationMarketplaceSubscriptions(orgname string,
 	}{
 		SubscriptionIDs: subscriptionIDs,
 	}
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/marketplace/batchremove", QuayURL, orgname), body)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/marketplace/batchremove", c.BaseURL, orgname), body)
 	if err != nil {
 		return err
 	}
@@ -874,7 +874,7 @@ func (c *Client) BatchRemoveOrganizationMarketplaceSubscriptions(orgname string,
 
 // DeleteOrganizationMarketplaceSubscription removes a specific marketplace subscription
 func (c *Client) DeleteOrganizationMarketplaceSubscription(orgname, subscriptionID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/marketplace/%s", QuayURL, orgname, subscriptionID), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/marketplace/%s", c.BaseURL, orgname, subscriptionID), nil)
 	if err != nil {
 		return err
 	}
@@ -884,7 +884,7 @@ func (c *Client) DeleteOrganizationMarketplaceSubscription(orgname, subscription
 
 // InviteTeamMember invites a member to a team via email
 func (c *Client) InviteTeamMember(orgname, teamname, email string) error {
-	req, err := newRequest("PUT", fmt.Sprintf("%s/organization/%s/team/%s/invite/%s", QuayURL, orgname, teamname, email), nil)
+	req, err := newRequest("PUT", fmt.Sprintf("%s/organization/%s/team/%s/invite/%s", c.BaseURL, orgname, teamname, email), nil)
 	if err != nil {
 		return err
 	}
@@ -894,7 +894,7 @@ func (c *Client) InviteTeamMember(orgname, teamname, email string) error {
 
 // DeleteTeamInvite deletes a pending team invitation
 func (c *Client) DeleteTeamInvite(orgname, teamname, email string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/team/%s/invite/%s", QuayURL, orgname, teamname, email), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/team/%s/invite/%s", c.BaseURL, orgname, teamname, email), nil)
 	if err != nil {
 		return err
 	}

--- a/lib/permissions.go
+++ b/lib/permissions.go
@@ -19,7 +19,7 @@ import (
 
 // GetRepositoryPermissions retrieves permissions for a repository
 func (c *Client) GetRepositoryPermissions(namespace, repository string) (*RepositoryPermissions, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/permissions", QuayURL, namespace, repository), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/permissions", c.BaseURL, namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repository permissions request: %w", err)
 	}
@@ -35,7 +35,7 @@ func (c *Client) GetRepositoryPermissions(namespace, repository string) (*Reposi
 // SetRepositoryPermission sets permission for a user/robot on a repository
 // role should be one of: "read", "write", "admin"
 func (c *Client) SetRepositoryPermission(namespace, repository, username, role string) error {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/permissions/%s", QuayURL, namespace, repository, username), SetRepositoryPermissionRequest{
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/permissions/%s", c.BaseURL, namespace, repository, username), SetRepositoryPermissionRequest{
 		Role: role,
 	})
 	if err != nil {
@@ -51,7 +51,7 @@ func (c *Client) SetRepositoryPermission(namespace, repository, username, role s
 
 // RemoveRepositoryPermission removes permission for a user/robot from a repository
 func (c *Client) RemoveRepositoryPermission(namespace, repository, username string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/permissions/%s", QuayURL, namespace, repository, username), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/permissions/%s", c.BaseURL, namespace, repository, username), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create remove repository permission request: %w", err)
 	}
@@ -67,7 +67,7 @@ func (c *Client) RemoveRepositoryPermission(namespace, repository, username stri
 
 // ListUserPermissions lists all user permissions for a repository
 func (c *Client) ListUserPermissions(namespace, repository string) (*RepositoryPermissions, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/permissions/user/", QuayURL, namespace, repository), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/permissions/user/", c.BaseURL, namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list user permissions request: %w", err)
 	}
@@ -82,7 +82,7 @@ func (c *Client) ListUserPermissions(namespace, repository string) (*RepositoryP
 
 // GetUserPermission gets permission for a specific user on a repository
 func (c *Client) GetUserPermission(namespace, repository, username string) (*RepositoryPermission, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/permissions/user/%s", QuayURL, namespace, repository, username), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/permissions/user/%s", c.BaseURL, namespace, repository, username), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user permission request: %w", err)
 	}
@@ -98,7 +98,7 @@ func (c *Client) GetUserPermission(namespace, repository, username string) (*Rep
 // SetUserPermission sets permission for a user on a repository
 // role should be one of: "read", "write", "admin"
 func (c *Client) SetUserPermission(namespace, repository, username, role string) error {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/permissions/user/%s", QuayURL, namespace, repository, username), SetRepositoryPermissionRequest{
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/permissions/user/%s", c.BaseURL, namespace, repository, username), SetRepositoryPermissionRequest{
 		Role: role,
 	})
 	if err != nil {
@@ -114,7 +114,7 @@ func (c *Client) SetUserPermission(namespace, repository, username, role string)
 
 // DeleteUserPermission removes permission for a user from a repository
 func (c *Client) DeleteUserPermission(namespace, repository, username string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/permissions/user/%s", QuayURL, namespace, repository, username), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/permissions/user/%s", c.BaseURL, namespace, repository, username), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete user permission request: %w", err)
 	}
@@ -128,7 +128,7 @@ func (c *Client) DeleteUserPermission(namespace, repository, username string) er
 
 // GetUserTransitivePermission gets the transitive permission for a user on a repository
 func (c *Client) GetUserTransitivePermission(namespace, repository, username string) (*RepositoryPermission, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/permissions/user/%s/transitive", QuayURL, namespace, repository, username), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/permissions/user/%s/transitive", c.BaseURL, namespace, repository, username), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user transitive permission request: %w", err)
 	}
@@ -145,7 +145,7 @@ func (c *Client) GetUserTransitivePermission(namespace, repository, username str
 
 // ListTeamPermissions lists all team permissions for a repository
 func (c *Client) ListTeamPermissions(namespace, repository string) (*RepositoryPermissions, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/permissions/team/", QuayURL, namespace, repository), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/permissions/team/", c.BaseURL, namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list team permissions request: %w", err)
 	}
@@ -160,7 +160,7 @@ func (c *Client) ListTeamPermissions(namespace, repository string) (*RepositoryP
 
 // GetTeamPermission gets permission for a specific team on a repository
 func (c *Client) GetTeamPermission(namespace, repository, teamname string) (*RepositoryPermission, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/permissions/team/%s", QuayURL, namespace, repository, teamname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/permissions/team/%s", c.BaseURL, namespace, repository, teamname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get team permission request: %w", err)
 	}
@@ -176,7 +176,7 @@ func (c *Client) GetTeamPermission(namespace, repository, teamname string) (*Rep
 // SetTeamPermission sets permission for a team on a repository
 // role should be one of: "read", "write", "admin"
 func (c *Client) SetTeamPermission(namespace, repository, teamname, role string) error {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/permissions/team/%s", QuayURL, namespace, repository, teamname), SetRepositoryPermissionRequest{
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/permissions/team/%s", c.BaseURL, namespace, repository, teamname), SetRepositoryPermissionRequest{
 		Role: role,
 	})
 	if err != nil {
@@ -192,7 +192,7 @@ func (c *Client) SetTeamPermission(namespace, repository, teamname, role string)
 
 // DeleteTeamPermission removes permission for a team from a repository
 func (c *Client) DeleteTeamPermission(namespace, repository, teamname string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/permissions/team/%s", QuayURL, namespace, repository, teamname), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/permissions/team/%s", c.BaseURL, namespace, repository, teamname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete team permission request: %w", err)
 	}

--- a/lib/permissions_test.go
+++ b/lib/permissions_test.go
@@ -51,11 +51,7 @@ func TestGetRepositoryPermissions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -117,11 +113,7 @@ func TestSetRepositoryPermission(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -139,11 +131,7 @@ func TestSetRepositoryPermissionInvalidRole(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -171,11 +159,7 @@ func TestRemoveRepositoryPermission(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -194,11 +178,7 @@ func TestPermissionsErrorHandling(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/lib/prototype.go
+++ b/lib/prototype.go
@@ -27,7 +27,7 @@ import (
 
 // GetPrototypes retrieves all permission prototypes for an organization
 func (c *Client) GetPrototypes(orgname string) (*Prototypes, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/prototypes", QuayURL, orgname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/prototypes", c.BaseURL, orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get prototypes request: %w", err)
 	}
@@ -42,7 +42,7 @@ func (c *Client) GetPrototypes(orgname string) (*Prototypes, error) {
 
 // CreatePrototype creates a new permission prototype for an organization
 func (c *Client) CreatePrototype(orgname string, createReq *CreatePrototypeRequest) (*Prototype, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/prototypes", QuayURL, orgname), createReq)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/prototypes", c.BaseURL, orgname), createReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create prototype request: %w", err)
 	}
@@ -57,7 +57,7 @@ func (c *Client) CreatePrototype(orgname string, createReq *CreatePrototypeReque
 
 // GetPrototype retrieves a specific prototype by UUID
 func (c *Client) GetPrototype(orgname, prototypeUUID string) (*Prototype, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/prototypes/%s", QuayURL, orgname, prototypeUUID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/prototypes/%s", c.BaseURL, orgname, prototypeUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get prototype request: %w", err)
 	}
@@ -72,7 +72,7 @@ func (c *Client) GetPrototype(orgname, prototypeUUID string) (*Prototype, error)
 
 // UpdatePrototype updates an existing prototype
 func (c *Client) UpdatePrototype(orgname, prototypeUUID string, updateReq *UpdatePrototypeRequest) (*Prototype, error) {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/prototypes/%s", QuayURL, orgname, prototypeUUID), updateReq)
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/prototypes/%s", c.BaseURL, orgname, prototypeUUID), updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update prototype request: %w", err)
 	}
@@ -87,7 +87,7 @@ func (c *Client) UpdatePrototype(orgname, prototypeUUID string, updateReq *Updat
 
 // DeletePrototype deletes a prototype
 func (c *Client) DeletePrototype(orgname, prototypeUUID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/prototypes/%s", QuayURL, orgname, prototypeUUID), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/prototypes/%s", c.BaseURL, orgname, prototypeUUID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete prototype request: %w", err)
 	}

--- a/lib/prototype_test.go
+++ b/lib/prototype_test.go
@@ -39,11 +39,7 @@ func TestGetPrototypes(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -82,11 +78,7 @@ func TestCreatePrototype(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -133,11 +125,7 @@ func TestGetPrototype(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -168,11 +156,7 @@ func TestUpdatePrototype(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -204,11 +188,7 @@ func TestDeletePrototype(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -225,11 +205,7 @@ func TestGetPrototypesError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/lib/repository.go
+++ b/lib/repository.go
@@ -58,7 +58,7 @@ type RepositoryWithTags struct {
 // GetRepository returns a repository with tags information baked in
 func (c *Client) GetRepository(namespace, repository string) (RepositoryWithTags, error) {
 	// Fetch repository details
-	repoURL := fmt.Sprintf("%s/repository/%s/%s", QuayURL, namespace, repository)
+	repoURL := fmt.Sprintf("%s/repository/%s/%s", c.BaseURL, namespace, repository)
 	req, err := newRequest("GET", repoURL, nil)
 	if err != nil {
 		return RepositoryWithTags{}, fmt.Errorf("failed to create request for repository: %w", err)
@@ -70,7 +70,7 @@ func (c *Client) GetRepository(namespace, repository string) (RepositoryWithTags
 	}
 
 	// Fetch repository tags
-	tagsURL := fmt.Sprintf("%s/repository/%s/%s/tag", QuayURL, namespace, repository)
+	tagsURL := fmt.Sprintf("%s/repository/%s/%s/tag", c.BaseURL, namespace, repository)
 	req, err = newRequest("GET", tagsURL, nil)
 	if err != nil {
 		return RepositoryWithTags{}, fmt.Errorf("failed to create request for tags: %w", err)
@@ -89,7 +89,7 @@ func (c *Client) GetRepository(namespace, repository string) (RepositoryWithTags
 
 // CreateRepository creates a new repository
 func (c *Client) CreateRepository(namespace, repository, visibility, description string) (*Repository, error) {
-	req, err := newRequestWithBody("POST", QuayURL+"/repository", CreateRepositoryRequest{
+	req, err := newRequestWithBody("POST", c.BaseURL+"/repository", CreateRepositoryRequest{
 		Repository:  repository,
 		Namespace:   namespace,
 		Visibility:  visibility,
@@ -119,7 +119,7 @@ func (c *Client) UpdateRepository(namespace, repository, description, visibility
 		updateReq.Visibility = visibility
 	}
 
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s", QuayURL, namespace, repository), updateReq)
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s", c.BaseURL, namespace, repository), updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update repository request: %w", err)
 	}
@@ -134,7 +134,7 @@ func (c *Client) UpdateRepository(namespace, repository, description, visibility
 
 // DeleteRepository deletes a repository
 func (c *Client) DeleteRepository(namespace, repository string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s", QuayURL, namespace, repository), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s", c.BaseURL, namespace, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete repository request: %w", err)
 	}
@@ -148,7 +148,7 @@ func (c *Client) DeleteRepository(namespace, repository string) error {
 
 // ListRepositories lists all repositories visible to the user
 func (c *Client) ListRepositories(namespace string, public, starred bool, page, limit int) (*RepositoryList, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository", QuayURL), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository", c.BaseURL), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list repositories request: %w", err)
 	}
@@ -186,7 +186,7 @@ func (c *Client) ChangeRepositoryVisibility(namespace, repository, visibility st
 	}{
 		Visibility: visibility,
 	}
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/changevisibility", QuayURL, namespace, repository), body)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/changevisibility", c.BaseURL, namespace, repository), body)
 	if err != nil {
 		return fmt.Errorf("failed to create change visibility request: %w", err)
 	}

--- a/lib/repository_test.go
+++ b/lib/repository_test.go
@@ -58,13 +58,8 @@ func TestCreateRepository(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Override QuayURL for testing
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
 	// Create client and test
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -119,11 +114,7 @@ func TestUpdateRepository(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -151,11 +142,7 @@ func TestDeleteRepository(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -218,11 +205,8 @@ func TestGetRepository(t *testing.T) {
 	defer server.Close()
 
 	// Override base URL since GetRepository uses hardcoded URL
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
 
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/lib/repotoken.go
+++ b/lib/repotoken.go
@@ -23,7 +23,7 @@ import (
 //
 // Deprecated: Use robot accounts instead.
 func (c *Client) GetRepoTokens(namespace, repository string) (*RepoTokens, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/tokens", QuayURL, namespace, repository), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/tokens", c.BaseURL, namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repo tokens request: %w", err)
 	}
@@ -40,7 +40,7 @@ func (c *Client) GetRepoTokens(namespace, repository string) (*RepoTokens, error
 //
 // Deprecated: Use robot accounts instead.
 func (c *Client) CreateRepoToken(namespace, repository string, createReq *CreateRepoTokenRequest) (*RepoToken, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/tokens", QuayURL, namespace, repository), createReq)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/tokens", c.BaseURL, namespace, repository), createReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create repo token request: %w", err)
 	}
@@ -57,7 +57,7 @@ func (c *Client) CreateRepoToken(namespace, repository string, createReq *Create
 //
 // Deprecated: Use robot accounts instead.
 func (c *Client) GetRepoToken(namespace, repository, code string) (*RepoToken, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/tokens/%s", QuayURL, namespace, repository, code), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/tokens/%s", c.BaseURL, namespace, repository, code), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repo token request: %w", err)
 	}
@@ -74,7 +74,7 @@ func (c *Client) GetRepoToken(namespace, repository, code string) (*RepoToken, e
 //
 // Deprecated: Use robot accounts instead.
 func (c *Client) UpdateRepoToken(namespace, repository, code string, updateReq *UpdateRepoTokenRequest) (*RepoToken, error) {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/tokens/%s", QuayURL, namespace, repository, code), updateReq)
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/tokens/%s", c.BaseURL, namespace, repository, code), updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update repo token request: %w", err)
 	}
@@ -91,7 +91,7 @@ func (c *Client) UpdateRepoToken(namespace, repository, code string, updateReq *
 //
 // Deprecated: Use robot accounts instead.
 func (c *Client) DeleteRepoToken(namespace, repository, code string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/tokens/%s", QuayURL, namespace, repository, code), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/tokens/%s", c.BaseURL, namespace, repository, code), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete repo token request: %w", err)
 	}

--- a/lib/repotoken_test.go
+++ b/lib/repotoken_test.go
@@ -33,11 +33,7 @@ func TestGetRepoTokens(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -73,11 +69,7 @@ func TestCreateRepoToken(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -117,11 +109,7 @@ func TestGetRepoToken(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -153,11 +141,7 @@ func TestUpdateRepoToken(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -189,11 +173,7 @@ func TestDeleteRepoToken(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -210,11 +190,7 @@ func TestGetRepoTokensError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/lib/robot.go
+++ b/lib/robot.go
@@ -22,7 +22,7 @@ import (
 
 // GetUserRobotAccounts retrieves all robot accounts for the authenticated user
 func (c *Client) GetUserRobotAccounts() (*RobotAccounts, error) {
-	req, err := newRequest("GET", QuayURL+"/user/robots", nil)
+	req, err := newRequest("GET", c.BaseURL+"/user/robots", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user robots request: %w", err)
 	}
@@ -37,7 +37,7 @@ func (c *Client) GetUserRobotAccounts() (*RobotAccounts, error) {
 
 // GetUserRobotAccount retrieves a specific robot account for the authenticated user
 func (c *Client) GetUserRobotAccount(robotShortname string) (*RobotAccount, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/user/robots/%s", QuayURL, robotShortname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/user/robots/%s", c.BaseURL, robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user robot request: %w", err)
 	}
@@ -57,7 +57,7 @@ func (c *Client) CreateUserRobotAccount(robotShortname, description string, unst
 		Unstructured: unstructured,
 	}
 
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/user/robots/%s", QuayURL, robotShortname), createReq)
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/user/robots/%s", c.BaseURL, robotShortname), createReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user robot request: %w", err)
 	}
@@ -72,7 +72,7 @@ func (c *Client) CreateUserRobotAccount(robotShortname, description string, unst
 
 // DeleteUserRobotAccount deletes a robot account for the authenticated user
 func (c *Client) DeleteUserRobotAccount(robotShortname string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/user/robots/%s", QuayURL, robotShortname), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/user/robots/%s", c.BaseURL, robotShortname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete user robot request: %w", err)
 	}
@@ -86,7 +86,7 @@ func (c *Client) DeleteUserRobotAccount(robotShortname string) error {
 
 // RegenerateUserRobotToken regenerates the token for a user's robot account
 func (c *Client) RegenerateUserRobotToken(robotShortname string) (*RobotAccount, error) {
-	req, err := newRequest("POST", fmt.Sprintf("%s/user/robots/%s/regenerate", QuayURL, robotShortname), nil)
+	req, err := newRequest("POST", fmt.Sprintf("%s/user/robots/%s/regenerate", c.BaseURL, robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create regenerate user robot token request: %w", err)
 	}
@@ -101,7 +101,7 @@ func (c *Client) RegenerateUserRobotToken(robotShortname string) (*RobotAccount,
 
 // GetUserRobotPermissions retrieves the repository permissions for a user's robot account
 func (c *Client) GetUserRobotPermissions(robotShortname string) (*RobotPermissions, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/user/robots/%s/permissions", QuayURL, robotShortname), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/user/robots/%s/permissions", c.BaseURL, robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user robot permissions request: %w", err)
 	}

--- a/lib/robot_test.go
+++ b/lib/robot_test.go
@@ -43,11 +43,7 @@ func TestGetUserRobotAccounts(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -90,11 +86,7 @@ func TestGetUserRobotAccount(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -145,11 +137,7 @@ func TestCreateUserRobotAccount(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -181,11 +169,7 @@ func TestDeleteUserRobotAccount(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -221,11 +205,7 @@ func TestRegenerateUserRobotToken(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -271,11 +251,7 @@ func TestGetUserRobotPermissions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -300,11 +276,7 @@ func TestUserRobotErrorHandling(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/lib/search.go
+++ b/lib/search.go
@@ -25,7 +25,7 @@ func (c *Client) SearchRepositories(query string, page int) (*SearchRepositoryRe
 		params.Add("page", fmt.Sprintf("%d", page))
 	}
 
-	req, err := newRequest("GET", fmt.Sprintf("%s/find/repositories?%s", QuayURL, params.Encode()), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/find/repositories?%s", c.BaseURL, params.Encode()), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create search repositories request: %w", err)
 	}
@@ -43,7 +43,7 @@ func (c *Client) SearchAll(query string) (*SearchAllResult, error) {
 	params := url.Values{}
 	params.Add("query", query)
 
-	req, err := newRequest("GET", fmt.Sprintf("%s/find/all?%s", QuayURL, params.Encode()), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/find/all?%s", c.BaseURL, params.Encode()), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create search all request: %w", err)
 	}

--- a/lib/search_test.go
+++ b/lib/search_test.go
@@ -53,11 +53,7 @@ func TestSearchRepositories(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -102,11 +98,7 @@ func TestSearchRepositoriesWithPage(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -170,11 +162,7 @@ func TestSearchAll(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -211,11 +199,7 @@ func TestSearchErrorHandling(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -250,11 +234,7 @@ func TestSearchEmptyResults(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/lib/secscan.go
+++ b/lib/secscan.go
@@ -17,7 +17,7 @@ import (
 
 // GetManifestSecurity retrieves security scan information for a specific manifest
 func (c *Client) GetManifestSecurity(namespace, repository, manifestRef string, vulnerabilities bool) (*SecurityScan, error) {
-	url := fmt.Sprintf("%s/repository/%s/%s/manifest/%s/security", QuayURL, namespace, repository, manifestRef)
+	url := fmt.Sprintf("%s/repository/%s/%s/manifest/%s/security", c.BaseURL, namespace, repository, manifestRef)
 
 	// Add query parameter to include vulnerabilities
 	if vulnerabilities {

--- a/lib/secscan_test.go
+++ b/lib/secscan_test.go
@@ -71,11 +71,7 @@ func TestGetManifestSecurity(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -143,11 +139,7 @@ func TestGetManifestSecurityWithoutVulnerabilities(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -177,11 +169,7 @@ func TestGetManifestSecurityQueued(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -207,11 +195,7 @@ func TestGetManifestSecurityErrorHandling(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -237,11 +221,7 @@ func TestGetManifestSecurityUnsupported(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/lib/tag.go
+++ b/lib/tag.go
@@ -20,7 +20,7 @@ import (
 
 // GetTag retrieves detailed information about a specific tag
 func (c *Client) GetTag(namespace, repository, tag string) (*Tag, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/tag/%s", QuayURL, namespace, repository, tag), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/tag/%s", c.BaseURL, namespace, repository, tag), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get tag request: %w", err)
 	}
@@ -41,7 +41,7 @@ func (c *Client) UpdateTag(namespace, repository, tag, expiration string) (*Tag,
 		updateReq.Expiration = expiration
 	}
 
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/tag/%s", QuayURL, namespace, repository, tag), updateReq)
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/tag/%s", c.BaseURL, namespace, repository, tag), updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update tag request: %w", err)
 	}
@@ -56,7 +56,7 @@ func (c *Client) UpdateTag(namespace, repository, tag, expiration string) (*Tag,
 
 // DeleteTag deletes a specific tag from a repository
 func (c *Client) DeleteTag(namespace, repository, tag string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/tag/%s", QuayURL, namespace, repository, tag), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/tag/%s", c.BaseURL, namespace, repository, tag), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete tag request: %w", err)
 	}
@@ -70,7 +70,7 @@ func (c *Client) DeleteTag(namespace, repository, tag string) error {
 
 // GetTagHistory retrieves the history of changes for a specific tag
 func (c *Client) GetTagHistory(namespace, repository, tag string) (*TagHistory, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/tag/%s/history", QuayURL, namespace, repository, tag), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/tag/%s/history", c.BaseURL, namespace, repository, tag), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get tag history request: %w", err)
 	}
@@ -85,7 +85,7 @@ func (c *Client) GetTagHistory(namespace, repository, tag string) (*TagHistory, 
 
 // RevertTag reverts a tag to a previous state by manifest digest
 func (c *Client) RevertTag(namespace, repository, tag, manifestDigest string) (*Tag, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/tag/%s/revert", QuayURL, namespace, repository, tag), map[string]interface{}{
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/tag/%s/revert", c.BaseURL, namespace, repository, tag), map[string]interface{}{
 		"manifest_digest": manifestDigest,
 	})
 	if err != nil {
@@ -107,7 +107,7 @@ func (c *Client) RestoreTag(namespace, repository, tag, manifestDigest string) e
 	}{
 		ManifestDigest: manifestDigest,
 	}
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/tag/%s/restore", QuayURL, namespace, repository, tag), body)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/tag/%s/restore", c.BaseURL, namespace, repository, tag), body)
 	if err != nil {
 		return fmt.Errorf("failed to create restore tag request: %w", err)
 	}

--- a/lib/tag_test.go
+++ b/lib/tag_test.go
@@ -42,11 +42,7 @@ func TestGetTag(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -103,11 +99,7 @@ func TestUpdateTag(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -135,11 +127,7 @@ func TestDeleteTag(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -184,11 +172,7 @@ func TestGetTagHistory(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -246,11 +230,7 @@ func TestRevertTag(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -273,11 +253,7 @@ func TestTagErrorHandling(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/lib/team_test.go
+++ b/lib/team_test.go
@@ -39,11 +39,7 @@ func TestGetTeams(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -87,11 +83,7 @@ func TestGetTeam(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -133,11 +125,7 @@ func TestCreateTeam(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -176,11 +164,7 @@ func TestUpdateTeam(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -214,11 +198,7 @@ func TestDeleteTeam(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -251,11 +231,7 @@ func TestGetTeamMembers(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -292,11 +268,7 @@ func TestAddTeamMember(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -320,11 +292,7 @@ func TestRemoveTeamMember(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -357,11 +325,7 @@ func TestGetTeamPermissions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -395,11 +359,7 @@ func TestSetTeamRepositoryPermission(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -423,11 +383,7 @@ func TestRemoveTeamRepositoryPermission(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -444,11 +400,7 @@ func TestGetTeamsError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -465,11 +417,7 @@ func TestGetTeamError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/lib/trigger.go
+++ b/lib/trigger.go
@@ -28,7 +28,7 @@ import (
 
 // GetTriggers retrieves all build triggers for a repository
 func (c *Client) GetTriggers(namespace, repository string) (*BuildTriggers, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/trigger/", QuayURL, namespace, repository), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/trigger/", c.BaseURL, namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get triggers request: %w", err)
 	}
@@ -43,7 +43,7 @@ func (c *Client) GetTriggers(namespace, repository string) (*BuildTriggers, erro
 
 // GetTrigger retrieves a specific build trigger by UUID
 func (c *Client) GetTrigger(namespace, repository, triggerUUID string) (*BuildTrigger, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/trigger/%s", QuayURL, namespace, repository, triggerUUID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/trigger/%s", c.BaseURL, namespace, repository, triggerUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get trigger request: %w", err)
 	}
@@ -58,7 +58,7 @@ func (c *Client) GetTrigger(namespace, repository, triggerUUID string) (*BuildTr
 
 // DeleteTrigger deletes a build trigger
 func (c *Client) DeleteTrigger(namespace, repository, triggerUUID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/trigger/%s", QuayURL, namespace, repository, triggerUUID), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/trigger/%s", c.BaseURL, namespace, repository, triggerUUID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete trigger request: %w", err)
 	}
@@ -76,7 +76,7 @@ func (c *Client) UpdateTrigger(namespace, repository, triggerUUID string, enable
 		"enabled": enabled,
 	}
 
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/trigger/%s", QuayURL, namespace, repository, triggerUUID), body)
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/trigger/%s", c.BaseURL, namespace, repository, triggerUUID), body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update trigger request: %w", err)
 	}
@@ -96,7 +96,7 @@ func (c *Client) StartTriggerBuild(namespace, repository, triggerUUID string, tr
 		body = triggerReq
 	}
 
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/trigger/%s/start", QuayURL, namespace, repository, triggerUUID), body)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/trigger/%s/start", c.BaseURL, namespace, repository, triggerUUID), body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create start trigger build request: %w", err)
 	}
@@ -111,7 +111,7 @@ func (c *Client) StartTriggerBuild(namespace, repository, triggerUUID string, tr
 
 // ActivateTrigger activates a build trigger with configuration
 func (c *Client) ActivateTrigger(namespace, repository, triggerUUID string, activateReq *ActivateTriggerRequest) (*BuildTrigger, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/trigger/%s/activate", QuayURL, namespace, repository, triggerUUID), activateReq)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/trigger/%s/activate", c.BaseURL, namespace, repository, triggerUUID), activateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create activate trigger request: %w", err)
 	}
@@ -126,7 +126,7 @@ func (c *Client) ActivateTrigger(namespace, repository, triggerUUID string, acti
 
 // GetTriggerBuilds gets the builds started by a specific trigger
 func (c *Client) GetTriggerBuilds(namespace, repository, triggerUUID string, limit int) (*Builds, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/trigger/%s/builds", QuayURL, namespace, repository, triggerUUID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/trigger/%s/builds", c.BaseURL, namespace, repository, triggerUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get trigger builds request: %w", err)
 	}

--- a/lib/trigger_test.go
+++ b/lib/trigger_test.go
@@ -34,11 +34,7 @@ func TestGetTriggers(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -84,11 +80,7 @@ func TestGetTrigger(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -122,11 +114,7 @@ func TestDeleteTrigger(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -159,11 +147,7 @@ func TestUpdateTrigger(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -199,11 +183,7 @@ func TestStartTriggerBuild(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -244,11 +224,7 @@ func TestActivateTrigger(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -279,11 +255,7 @@ func TestGetTriggersError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -300,11 +272,7 @@ func TestGetTriggerError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/lib/user.go
+++ b/lib/user.go
@@ -22,7 +22,7 @@ import (
 
 // GetUser retrieves information about the current authenticated user
 func (c *Client) GetUser() (*UserDetails, error) {
-	req, err := newRequest("GET", QuayURL+"/user", nil)
+	req, err := newRequest("GET", c.BaseURL+"/user", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user request: %w", err)
 	}
@@ -37,7 +37,7 @@ func (c *Client) GetUser() (*UserDetails, error) {
 
 // GetStarredRepositories retrieves repositories starred by the current user
 func (c *Client) GetStarredRepositories() (*StarredRepositories, error) {
-	req, err := newRequest("GET", QuayURL+"/user/starred", nil)
+	req, err := newRequest("GET", c.BaseURL+"/user/starred", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get starred repositories request: %w", err)
 	}
@@ -52,7 +52,7 @@ func (c *Client) GetStarredRepositories() (*StarredRepositories, error) {
 
 // StarRepository adds a repository to the user's starred list
 func (c *Client) StarRepository(namespace, repository string) error {
-	req, err := newRequest("PUT", fmt.Sprintf("%s/repository/%s/%s/star", QuayURL, namespace, repository), nil)
+	req, err := newRequest("PUT", fmt.Sprintf("%s/repository/%s/%s/star", c.BaseURL, namespace, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create star repository request: %w", err)
 	}
@@ -66,7 +66,7 @@ func (c *Client) StarRepository(namespace, repository string) error {
 
 // UnstarRepository removes a repository from the user's starred list
 func (c *Client) UnstarRepository(namespace, repository string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/star", QuayURL, namespace, repository), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/star", c.BaseURL, namespace, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create unstar repository request: %w", err)
 	}
@@ -85,7 +85,7 @@ func (c *Client) StarUserRepository(namespace, repository string) error {
 	}{
 		Repository: namespace + "/" + repository,
 	}
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/user/starred", QuayURL), body)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/user/starred", c.BaseURL), body)
 	if err != nil {
 		return fmt.Errorf("failed to create star user repository request: %w", err)
 	}
@@ -100,7 +100,7 @@ func (c *Client) StarUserRepository(namespace, repository string) error {
 // UnstarUserRepository unstars a repository using the /user/starred endpoint
 func (c *Client) UnstarUserRepository(namespace, repository string) error {
 	// The spec uses {repository} as namespace/repo
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/user/starred/%s/%s", QuayURL, namespace, repository), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/user/starred/%s/%s", c.BaseURL, namespace, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create unstar user repository request: %w", err)
 	}
@@ -114,7 +114,7 @@ func (c *Client) UnstarUserRepository(namespace, repository string) error {
 
 // GetUserByUsername retrieves information about a specific user
 func (c *Client) GetUserByUsername(username string) (*UserDetails, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/users/%s", QuayURL, username), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/users/%s", c.BaseURL, username), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user by username request: %w", err)
 	}
@@ -129,7 +129,7 @@ func (c *Client) GetUserByUsername(username string) (*UserDetails, error) {
 
 // GetUserMarketplace retrieves marketplace information for the current user
 func (c *Client) GetUserMarketplace() (*MarketplaceInfo, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/user/marketplace", QuayURL), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/user/marketplace", c.BaseURL), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user marketplace request: %w", err)
 	}

--- a/lib/user_test.go
+++ b/lib/user_test.go
@@ -51,11 +51,7 @@ func TestGetUser(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -128,11 +124,7 @@ func TestGetStarredRepositories(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -181,11 +173,7 @@ func TestStarRepository(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -209,11 +197,7 @@ func TestUnstarRepository(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -231,10 +215,6 @@ func TestUserErrorHandling(t *testing.T) {
 		w.Write([]byte(`{"error": "Invalid token"}`))
 	}))
 	defer server.Close()
-
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
 
 	client, err := NewClient("invalid-token")
 	if err != nil {
@@ -274,11 +254,7 @@ func TestUserStarRepositoryNotFound(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalURL := QuayURL
-	QuayURL = server.URL + "/api/v1"
-	defer func() { QuayURL = originalURL }()
-
-	client, err := NewClient("test-token")
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/scripts/check-swagger-alignment.go
+++ b/scripts/check-swagger-alignment.go
@@ -54,7 +54,7 @@ type ImplementedEndpoint struct {
 func main() {
 	swaggerURL := flag.String("swagger-url", "https://quay.io/api/v1/discovery", "URL to fetch Swagger spec")
 	libPath := flag.String("lib-path", "./lib", "Path to lib directory")
-	baseURLVar := flag.String("base-url-var", "QuayURL", "Variable name for base URL in source")
+	baseURLVar := flag.String("base-url-var", "BaseURL", "Variable name for base URL in source")
 	outputFormat := flag.String("output", "text", "Output format: text, json, markdown")
 	flag.Parse()
 
@@ -147,7 +147,7 @@ func scanSourceEndpoints(libPath, baseURLVar string) ([]ImplementedEndpoint, err
 	var endpoints []ImplementedEndpoint
 
 	// Patterns to match endpoint definitions
-	// Matches: QuayURL + "/path" or fmt.Sprintf("%s/path", QuayURL)
+	// Matches: c.BaseURL + "/path" or fmt.Sprintf("%s/path", c.BaseURL)
 	urlConcatPattern := regexp.MustCompile(baseURLVar + `\s*\+\s*"(/[^"]+)"`)
 	sprintfPattern := regexp.MustCompile(`fmt\.Sprintf\s*\(\s*"%s(/[^"]+)"`)
 	// Match HTTP method from http.NewRequest or newRequest calls


### PR DESCRIPTION
## Summary

- Move `QuayURL` from a mutable global `var` to a `BaseURL` field on the `Client` struct
- Add `NewClientWithURL(token, baseURL)` constructor for custom Quay instances
- `NewClient(token)` still works unchanged (defaults to `https://quay.io/api/v1`)
- Add `--quay-url` CLI flag with `QUAY_URL` env var default for private registry support
- Update all 18 test files to use per-client URLs instead of global override — eliminates save/restore boilerplate
- **Net: -398 lines** (61 files changed)

### Why this matters
- Eliminates global mutable state — tests are now safe for parallel execution
- Enables enterprise users to target self-hosted Quay instances
- Cleaner test patterns — no more `originalURL := QuayURL` / `defer` restore

### Usage
```bash
# Default (quay.io)
go-quay get user info

# Private registry
go-quay get user info --quay-url https://my-quay.example.com/api/v1

# Via env var
export QUAY_URL=https://my-quay.example.com/api/v1
go-quay get user info
```

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./...` all tests pass
- [x] `make lint` passes (0 issues)
- [x] `grep -rn "QuayURL" lib/ cmd/` confirms no remaining global references
- [x] `./go-quay get --help` shows `--quay-url` flag
