### PR TITLE
fix: add workflows permission to major tag update job

### DIFF
--- a/.github/workflows/update-major-tag.yaml
+++ b/.github/workflows/update-major-tag.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      workflows: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
The `update-major-tag` workflow failed on v1.0.4 because the GITHUB_TOKEN lacked `workflows: write` permission, which is required when force-pushing a tag that includes workflow file changes.