### PR TITLE
feat: add robot federation endpoints for user and organization robots

### DIFF
--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -680,6 +680,73 @@ var removeRobotPermissionCmd = &cobra.Command{
 	},
 }
 
+// Org Robot Federation Get
+var orgRobotFederationGetCmd = &cobra.Command{
+	Use:   "robot-federation-get",
+	Short: "Get organization robot federation configuration",
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClientWithURL(token, quayURL)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		federation, err := client.GetRobotFederation(orgName, robotShortname)
+		if err != nil {
+			fmt.Printf("Error getting robot federation: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(federation)
+	},
+}
+
+// Org Robot Federation Create
+var orgRobotFederationCreateCmd = &cobra.Command{
+	Use:   "robot-federation-create",
+	Short: "Create or update organization robot federation configuration",
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClientWithURL(token, quayURL)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		configs := []lib.RobotFederationConfig{
+			{Issuer: federationIssuer, Subject: federationSubject},
+		}
+
+		err = client.CreateRobotFederation(orgName, robotShortname, configs)
+		if err != nil {
+			fmt.Printf("Error creating robot federation: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully configured federation for robot %s in org %s\n", robotShortname, orgName)
+	},
+}
+
+// Org Robot Federation Delete
+var orgRobotFederationDeleteCmd = &cobra.Command{
+	Use:   "robot-federation-delete",
+	Short: "Delete organization robot federation configuration",
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClientWithURL(token, quayURL)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.DeleteRobotFederation(orgName, robotShortname)
+		if err != nil {
+			fmt.Printf("Error deleting robot federation: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully deleted federation for robot %s in org %s\n", robotShortname, orgName)
+	},
+}
+
 // Get Application
 var applicationCmd = &cobra.Command{
 	Use:   "application",
@@ -1096,6 +1163,9 @@ func init() {
 	organizationCmd.AddCommand(orgRobotPermissionsCmd)
 	organizationCmd.AddCommand(setRobotPermissionCmd)
 	organizationCmd.AddCommand(removeRobotPermissionCmd)
+	organizationCmd.AddCommand(orgRobotFederationGetCmd)
+	organizationCmd.AddCommand(orgRobotFederationCreateCmd)
+	organizationCmd.AddCommand(orgRobotFederationDeleteCmd)
 	organizationCmd.AddCommand(applicationCmd)
 	organizationCmd.AddCommand(createApplicationCmd)
 	organizationCmd.AddCommand(updateApplicationCmd)
@@ -1300,6 +1370,22 @@ func initOrgRobotFlags() {
 		os.Exit(1)
 	}
 	removeRobotPermissionCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm removal")
+
+	// robot-federation-get flags
+	orgRobotFederationGetCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
+	markFlagRequired(orgRobotFederationGetCmd.MarkFlagRequired("robot"))
+
+	// robot-federation-create flags
+	orgRobotFederationCreateCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
+	orgRobotFederationCreateCmd.Flags().StringVar(&federationIssuer, "issuer", "", "Federation token issuer")
+	orgRobotFederationCreateCmd.Flags().StringVar(&federationSubject, "subject", "", "Federation token subject")
+	markFlagRequired(orgRobotFederationCreateCmd.MarkFlagRequired("robot"))
+	markFlagRequired(orgRobotFederationCreateCmd.MarkFlagRequired("issuer"))
+	markFlagRequired(orgRobotFederationCreateCmd.MarkFlagRequired("subject"))
+
+	// robot-federation-delete flags
+	orgRobotFederationDeleteCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
+	markFlagRequired(orgRobotFederationDeleteCmd.MarkFlagRequired("robot"))
 }
 
 func initOrgApplicationFlags() {

--- a/cmd/robot.go
+++ b/cmd/robot.go
@@ -12,6 +12,8 @@ var (
 	robotShortname     string
 	robotDescription   string
 	confirmRobotDelete bool
+	federationIssuer   string
+	federationSubject  string
 )
 
 // robotCmd represents the robot command group
@@ -177,6 +179,73 @@ var robotPermissionsCmd = &cobra.Command{
 	},
 }
 
+// Robot Federation Get
+var robotFederationGetCmd = &cobra.Command{
+	Use:   "federation-get",
+	Short: "Get robot federation configuration",
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClientWithURL(token, quayURL)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		federation, err := client.GetUserRobotFederation(robotShortname)
+		if err != nil {
+			fmt.Printf("Error getting robot federation: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(federation)
+	},
+}
+
+// Robot Federation Create
+var robotFederationCreateCmd = &cobra.Command{
+	Use:   "federation-create",
+	Short: "Create or update robot federation configuration",
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClientWithURL(token, quayURL)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		configs := []lib.RobotFederationConfig{
+			{Issuer: federationIssuer, Subject: federationSubject},
+		}
+
+		err = client.CreateUserRobotFederation(robotShortname, configs)
+		if err != nil {
+			fmt.Printf("Error creating robot federation: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully configured federation for robot: %s\n", robotShortname)
+	},
+}
+
+// Robot Federation Delete
+var robotFederationDeleteCmd = &cobra.Command{
+	Use:   "federation-delete",
+	Short: "Delete robot federation configuration",
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := lib.NewClientWithURL(token, quayURL)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = client.DeleteUserRobotFederation(robotShortname)
+		if err != nil {
+			fmt.Printf("Error deleting robot federation: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Successfully deleted federation for robot: %s\n", robotShortname)
+	},
+}
+
 func init() {
 	// Add subcommands to robot command
 	robotCmd.AddCommand(robotListCmd)
@@ -185,6 +254,9 @@ func init() {
 	robotCmd.AddCommand(robotDeleteCmd)
 	robotCmd.AddCommand(robotRegenerateCmd)
 	robotCmd.AddCommand(robotPermissionsCmd)
+	robotCmd.AddCommand(robotFederationGetCmd)
+	robotCmd.AddCommand(robotFederationCreateCmd)
+	robotCmd.AddCommand(robotFederationDeleteCmd)
 
 	// Info command flags
 	robotInfoCmd.Flags().StringVarP(&robotShortname, "name", "n", "", "Robot short name (without username prefix)")
@@ -222,4 +294,20 @@ func init() {
 		fmt.Printf("Error marking name flag as required: %v\n", err)
 		os.Exit(1)
 	}
+
+	// Federation get command flags
+	robotFederationGetCmd.Flags().StringVarP(&robotShortname, "name", "n", "", "Robot short name")
+	markFlagRequired(robotFederationGetCmd.MarkFlagRequired("name"))
+
+	// Federation create command flags
+	robotFederationCreateCmd.Flags().StringVarP(&robotShortname, "name", "n", "", "Robot short name")
+	robotFederationCreateCmd.Flags().StringVar(&federationIssuer, "issuer", "", "Federation token issuer")
+	robotFederationCreateCmd.Flags().StringVar(&federationSubject, "subject", "", "Federation token subject")
+	markFlagRequired(robotFederationCreateCmd.MarkFlagRequired("name"))
+	markFlagRequired(robotFederationCreateCmd.MarkFlagRequired("issuer"))
+	markFlagRequired(robotFederationCreateCmd.MarkFlagRequired("subject"))
+
+	// Federation delete command flags
+	robotFederationDeleteCmd.Flags().StringVarP(&robotShortname, "name", "n", "", "Robot short name")
+	markFlagRequired(robotFederationDeleteCmd.MarkFlagRequired("name"))
 }

--- a/lib/organization.go
+++ b/lib/organization.go
@@ -46,6 +46,11 @@ Robot Permissions:
   - PUT    /api/v1/organization/{orgname}/robots/{robot_shortname}/permissions/{repository} - SetRobotRepositoryPermission()
   - DELETE /api/v1/organization/{orgname}/robots/{robot_shortname}/permissions/{repository} - RemoveRobotRepositoryPermission()
 
+Robot Federation:
+  - GET    /api/v1/organization/{orgname}/robots/{robot_shortname}/federation  - GetRobotFederation()
+  - POST   /api/v1/organization/{orgname}/robots/{robot_shortname}/federation  - CreateRobotFederation()
+  - DELETE /api/v1/organization/{orgname}/robots/{robot_shortname}/federation  - DeleteRobotFederation()
+
 Quota Management:
   - GET    /api/v1/organization/{orgname}/quota                     - GetQuota()
   - POST   /api/v1/organization/{orgname}/quota                     - CreateQuota()
@@ -562,6 +567,51 @@ func (c *Client) RemoveRobotRepositoryPermission(orgname, robotShortname, reposi
 	}
 
 	return c.delete(req)
+}
+
+// Robot Federation
+
+// GetRobotFederation retrieves the federation configuration for an organization's robot account
+func (c *Client) GetRobotFederation(orgname, robotShortname string) (*RobotFederation, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/robots/%s/federation", c.BaseURL, orgname, robotShortname), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get robot federation request: %w", err)
+	}
+
+	var federation RobotFederation
+	if err := c.get(req, &federation); err != nil {
+		return nil, fmt.Errorf("failed to get robot federation: %w", err)
+	}
+
+	return &federation, nil
+}
+
+// CreateRobotFederation creates or updates the federation configuration for an organization's robot account
+func (c *Client) CreateRobotFederation(orgname, robotShortname string, configs []RobotFederationConfig) error {
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/robots/%s/federation", c.BaseURL, orgname, robotShortname), configs)
+	if err != nil {
+		return fmt.Errorf("failed to create robot federation request: %w", err)
+	}
+
+	if err := c.post(req, nil); err != nil {
+		return fmt.Errorf("failed to create robot federation: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteRobotFederation deletes the federation configuration for an organization's robot account
+func (c *Client) DeleteRobotFederation(orgname, robotShortname string) error {
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/robots/%s/federation", c.BaseURL, orgname, robotShortname), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete robot federation request: %w", err)
+	}
+
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to delete robot federation: %w", err)
+	}
+
+	return nil
 }
 
 // Quota Management

--- a/lib/robot.go
+++ b/lib/robot.go
@@ -4,15 +4,15 @@ Package lib provides Quay.io API client functionality.
 This file covers USER ROBOT ACCOUNT operations:
 
 Robot Account Management:
-  - GET    /api/v1/user/robots                                  - GetUserRobotAccounts()
-  - GET    /api/v1/user/robots/{robot_shortname}                - GetUserRobotAccount()
-  - PUT    /api/v1/user/robots/{robot_shortname}                - CreateUserRobotAccount()
-  - DELETE /api/v1/user/robots/{robot_shortname}                - DeleteUserRobotAccount()
-  - POST   /api/v1/user/robots/{robot_shortname}/regenerate     - RegenerateUserRobotToken()
-  - GET    /api/v1/user/robots/{robot_shortname}/permissions    - GetUserRobotPermissions()
-
-User robot accounts provide automated access credentials for CI/CD pipelines
-and other automated workflows tied to a user account rather than an organization.
+  - GET    /api/v1/user/robots                                      - GetUserRobotAccounts()
+  - GET    /api/v1/user/robots/{robot_shortname}                    - GetUserRobotAccount()
+  - PUT    /api/v1/user/robots/{robot_shortname}                    - CreateUserRobotAccount()
+  - DELETE /api/v1/user/robots/{robot_shortname}                    - DeleteUserRobotAccount()
+  - POST   /api/v1/user/robots/{robot_shortname}/regenerate         - RegenerateUserRobotToken()
+  - GET    /api/v1/user/robots/{robot_shortname}/permissions        - GetUserRobotPermissions()
+  - GET    /api/v1/user/robots/{robot_shortname}/federation         - GetUserRobotFederation()
+  - POST   /api/v1/user/robots/{robot_shortname}/federation         - CreateUserRobotFederation()
+  - DELETE /api/v1/user/robots/{robot_shortname}/federation         - DeleteUserRobotFederation()
 */
 package lib
 
@@ -112,4 +112,47 @@ func (c *Client) GetUserRobotPermissions(robotShortname string) (*RobotPermissio
 	}
 
 	return &permissions, nil
+}
+
+// GetUserRobotFederation retrieves the federation configuration for a user's robot account
+func (c *Client) GetUserRobotFederation(robotShortname string) (*RobotFederation, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/user/robots/%s/federation", c.BaseURL, robotShortname), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get user robot federation request: %w", err)
+	}
+
+	var federation RobotFederation
+	if err := c.get(req, &federation); err != nil {
+		return nil, fmt.Errorf("failed to get user robot federation: %w", err)
+	}
+
+	return &federation, nil
+}
+
+// CreateUserRobotFederation creates or updates the federation configuration for a user's robot account
+func (c *Client) CreateUserRobotFederation(robotShortname string, configs []RobotFederationConfig) error {
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/user/robots/%s/federation", c.BaseURL, robotShortname), configs)
+	if err != nil {
+		return fmt.Errorf("failed to create user robot federation request: %w", err)
+	}
+
+	if err := c.post(req, nil); err != nil {
+		return fmt.Errorf("failed to create user robot federation: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteUserRobotFederation deletes the federation configuration for a user's robot account
+func (c *Client) DeleteUserRobotFederation(robotShortname string) error {
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/user/robots/%s/federation", c.BaseURL, robotShortname), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete user robot federation request: %w", err)
+	}
+
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to delete user robot federation: %w", err)
+	}
+
+	return nil
 }

--- a/lib/robot_test.go
+++ b/lib/robot_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 const (
-	testRobotShortname = "deploybot"
+	testRobotShortname    = "deploybot"
+	testFederationIssuer  = "https://accounts.google.com"
+	testFederationSubject = "robot@project.iam.gserviceaccount.com"
 )
 
 func TestGetUserRobotAccounts(t *testing.T) {
@@ -315,5 +317,96 @@ func TestUserRobotErrorHandling(t *testing.T) {
 	_, err = client.GetUserRobotPermissions("nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent robot, got nil")
+	}
+}
+
+func TestGetUserRobotFederation(t *testing.T) {
+	mockFederation := RobotFederation{
+		Federation: []RobotFederationConfig{
+			{Issuer: testFederationIssuer, Subject: testFederationSubject},
+		},
+	}
+	mockResponseJSON, _ := json.Marshal(mockFederation)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected GET, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/user/robots/" + testRobotShortname + "/federation"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	federation, err := client.GetUserRobotFederation(testRobotShortname)
+	if err != nil {
+		t.Fatalf("GetUserRobotFederation returned error: %v", err)
+	}
+
+	if len(federation.Federation) != 1 {
+		t.Fatalf("Expected 1 federation config, got %d", len(federation.Federation))
+	}
+	if federation.Federation[0].Issuer != testFederationIssuer {
+		t.Errorf("Expected issuer 'https://accounts.google.com', got '%s'", federation.Federation[0].Issuer)
+	}
+}
+
+func TestCreateUserRobotFederation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Expected POST, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/user/robots/" + testRobotShortname + "/federation"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	configs := []RobotFederationConfig{
+		{Issuer: testFederationIssuer, Subject: testFederationSubject},
+	}
+
+	err = client.CreateUserRobotFederation(testRobotShortname, configs)
+	if err != nil {
+		t.Fatalf("CreateUserRobotFederation returned error: %v", err)
+	}
+}
+
+func TestDeleteUserRobotFederation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("Expected DELETE, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/user/robots/" + testRobotShortname + "/federation"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.DeleteUserRobotFederation(testRobotShortname)
+	if err != nil {
+		t.Fatalf("DeleteUserRobotFederation returned error: %v", err)
 	}
 }

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -294,6 +294,17 @@ type TeamPermissions struct {
 	Permissions []TeamPermission `json:"permissions,omitempty"`
 }
 
+// RobotFederationConfig represents a federation configuration entry for a robot account
+type RobotFederationConfig struct {
+	Issuer  string `json:"issuer"`
+	Subject string `json:"subject"`
+}
+
+// RobotFederation represents the federation configuration for a robot account
+type RobotFederation struct {
+	Federation []RobotFederationConfig `json:"federation,omitempty"`
+}
+
 // RobotAccount represents a robot account
 type RobotAccount struct {
 	Name         string         `json:"name,omitempty"`


### PR DESCRIPTION
## Summary

- Add robot federation endpoints (GET/POST/DELETE) for both user and organization robots
- Federation enables cross-instance robot account authentication via OIDC token issuer/subject pairs
- New CLI commands: `federation-get`, `federation-create`, `federation-delete` under `robot` group
- New lib functions: `GetUserRobotFederation`, `CreateUserRobotFederation`, `DeleteUserRobotFederation`, `GetRobotFederation`, `CreateRobotFederation`, `DeleteRobotFederation`
- New structs: `RobotFederationConfig`, `RobotFederation`
- Robot API coverage: 66.7% → 94.4%

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./...` passes (3 new federation tests)
- [x] `make lint` passes (0 issues)
- [x] `make check-swagger-alignment` shows robot at 94.4%
