### PR TITLE
feat: add registry capabilities endpoint

### DIFF
--- a/cmd/discovery.go
+++ b/cmd/discovery.go
@@ -41,6 +41,27 @@ var discoveryAPICmd = &cobra.Command{
 	},
 }
 
+var discoveryCapabilitiesCmd = &cobra.Command{
+	Use:   "capabilities",
+	Short: "Get registry capabilities",
+	Long:  `Get registry capabilities including sparse manifest support and available mirror architectures.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		client, err := lib.NewClientWithURL(token, quayURL)
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		capabilities, err := client.GetRegistryCapabilities()
+		if err != nil {
+			fmt.Printf("Error getting registry capabilities: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(capabilities)
+	},
+}
+
 var discoveryAppInfoCmd = &cobra.Command{
 	Use:   "app-info",
 	Short: "Get application information by client ID",
@@ -85,6 +106,7 @@ var discoveryEntitiesCmd = &cobra.Command{
 
 func init() {
 	discoveryCmd.AddCommand(discoveryAPICmd)
+	discoveryCmd.AddCommand(discoveryCapabilitiesCmd)
 	discoveryCmd.AddCommand(discoveryAppInfoCmd)
 	discoveryCmd.AddCommand(discoveryEntitiesCmd)
 

--- a/lib/discovery.go
+++ b/lib/discovery.go
@@ -1,12 +1,13 @@
 /*
 Package lib provides Quay.io API client functionality.
 
-This file covers DISCOVERY operations:
+This file covers DISCOVERY and CAPABILITIES operations:
 
 API Discovery:
-  - GET /api/v1/discovery - GetDiscovery()
+  - GET /api/v1/discovery              - GetDiscovery()
 
-The Discovery API provides information about available API endpoints and versions.
+Registry Capabilities:
+  - GET /api/v1/registry/capabilities  - GetRegistryCapabilities()
 */
 package lib
 
@@ -27,6 +28,21 @@ func (c *Client) GetDiscovery() (*Discovery, error) {
 	}
 
 	return &discovery, nil
+}
+
+// GetRegistryCapabilities retrieves the registry capabilities including sparse manifest support and mirror architectures
+func (c *Client) GetRegistryCapabilities() (*RegistryCapabilities, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/registry/capabilities", c.BaseURL), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create registry capabilities request: %w", err)
+	}
+
+	var capabilities RegistryCapabilities
+	if err := c.get(req, &capabilities); err != nil {
+		return nil, fmt.Errorf("failed to get registry capabilities: %w", err)
+	}
+
+	return &capabilities, nil
 }
 
 // GetAppInfo retrieves public information about an OAuth application by client ID

--- a/lib/discovery_test.go
+++ b/lib/discovery_test.go
@@ -51,6 +51,48 @@ func TestGetDiscovery(t *testing.T) {
 	}
 }
 
+func TestGetRegistryCapabilities(t *testing.T) {
+	mockResponse := RegistryCapabilities{
+		SparseManifests: SparseManifests{
+			Supported:                    false,
+			RequiredArchitectures:        []string{},
+			OptionalArchitecturesAllowed: false,
+		},
+		MirrorArchitectures: []string{testArchAmd64, "arm64", "ppc64le", "s390x"},
+	}
+	mockResponseJSON, _ := json.Marshal(mockResponse)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpMethodGet {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/registry/capabilities"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	capabilities, err := client.GetRegistryCapabilities()
+	if err != nil {
+		t.Fatalf("GetRegistryCapabilities returned error: %v", err)
+	}
+
+	if len(capabilities.MirrorArchitectures) != 4 {
+		t.Errorf("Expected 4 mirror architectures, got %d", len(capabilities.MirrorArchitectures))
+	}
+	if capabilities.SparseManifests.Supported {
+		t.Error("Expected sparse manifests to be unsupported")
+	}
+}
+
 func TestGetDiscoveryError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -858,6 +858,21 @@ type QuayError struct {
 	ErrorDetail map[string]any `json:"error_detail,omitempty"`
 }
 
+// Registry Capabilities Structures
+
+// SparseManifests represents sparse manifest support configuration
+type SparseManifests struct {
+	Supported                    bool     `json:"supported"`
+	RequiredArchitectures        []string `json:"required_architectures"`
+	OptionalArchitecturesAllowed bool     `json:"optional_architectures_allowed"`
+}
+
+// RegistryCapabilities represents the registry capabilities response
+type RegistryCapabilities struct {
+	SparseManifests     SparseManifests `json:"sparse_manifests"`
+	MirrorArchitectures []string        `json:"mirror_architectures"`
+}
+
 // Discovery Structures
 
 // Discovery represents API discovery information

--- a/lib/tag_test.go
+++ b/lib/tag_test.go
@@ -21,7 +21,7 @@ func TestGetTag(t *testing.T) {
 		DockerImageID:  "abc123",
 		ImageID:        "def456",
 		V1Metadata: map[string]string{
-			"architecture": "amd64",
+			"architecture": testArchAmd64,
 			"os":           "linux",
 		},
 	}
@@ -61,8 +61,8 @@ func TestGetTag(t *testing.T) {
 	if tag.Size != 1024000 {
 		t.Errorf("Expected size 1024000, got %d", tag.Size)
 	}
-	if tag.V1Metadata["architecture"] != "amd64" {
-		t.Errorf("Expected architecture 'amd64', got '%s'", tag.V1Metadata["architecture"])
+	if tag.V1Metadata["architecture"] != testArchAmd64 {
+		t.Errorf("Expected architecture '%s', got '%s'", testArchAmd64, tag.V1Metadata["architecture"])
 	}
 }
 

--- a/lib/test_constants_test.go
+++ b/lib/test_constants_test.go
@@ -68,4 +68,7 @@ const (
 	// Security scan test values
 	testSecScanStatus    = "scanned"
 	testSecScanImageName = "centos:8"
+
+	// Architecture test values
+	testArchAmd64 = "amd64"
 )


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/registry/capabilities` endpoint
- New CLI command: `go-quay get discovery capabilities`
- Returns sparse manifest support config and available mirror architectures (amd64, arm64, ppc64le, s390x)
- New structs: `RegistryCapabilities`, `SparseManifests`

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./...` passes (1 new test)
- [x] `make lint` passes (0 issues)
- [x] `QUAY_TOKEN=dummy ./go-quay get discovery capabilities` returns live data
