### PR TITLE
fix: skip major tag update job on non-release events

### DIFF
--- a/.github/workflows/update-major-tag.yaml
+++ b/.github/workflows/update-major-tag.yaml
@@ -8,6 +8,7 @@ permissions: read-all
 
 jobs:
   update-major-tag:
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
GitHub re-evaluates workflows when workflow files change, causing the update-major-tag job to trigger on push events. The job then fails because `GITHUB_REF` is a branch ref, not a tag. Adds `if: github.event_name == 'release'` guard to skip gracefully.