### PR TITLE
test: add HTTP error path tests, lib coverage 77.2% → 85.5%

### DIFF
--- a/lib/billing_test.go
+++ b/lib/billing_test.go
@@ -419,3 +419,30 @@ func TestGetAvailablePlansError(t *testing.T) {
 		t.Error("Expected nil plans on error")
 	}
 }
+
+func TestBillingHTTPErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL(testTokenValue, server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetOrganizationSubscription(testNamespace)
+	if err == nil {
+		t.Error("Expected error from GetOrganizationSubscription, got nil")
+	}
+
+	_, err = client.GetUserSubscription()
+	if err == nil {
+		t.Error("Expected error from GetUserSubscription, got nil")
+	}
+
+	_, err = client.GetOrganizationInvoices(testNamespace)
+	if err == nil {
+		t.Error("Expected error from GetOrganizationInvoices, got nil")
+	}
+}

--- a/lib/build_test.go
+++ b/lib/build_test.go
@@ -277,3 +277,35 @@ func TestGetBuildError(t *testing.T) {
 		t.Error("Expected error, got nil")
 	}
 }
+
+func TestBuildHTTPErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetBuildLogs(testNamespace, testRepository, testBuildUUID)
+	if err == nil {
+		t.Error("Expected error from GetBuildLogs, got nil")
+	}
+
+	_, err = client.GetBuildStatus(testNamespace, testRepository, testBuildUUID)
+	if err == nil {
+		t.Error("Expected error from GetBuildStatus, got nil")
+	}
+
+	_, err = client.RequestBuild(testNamespace, testRepository, &RequestBuildRequest{ArchiveURL: "https://example.com/archive.tar.gz"})
+	if err == nil {
+		t.Error("Expected error from RequestBuild, got nil")
+	}
+
+	err = client.CancelBuild(testNamespace, testRepository, testBuildUUID)
+	if err == nil {
+		t.Error("Expected error from CancelBuild, got nil")
+	}
+}

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -314,7 +314,7 @@ func TestPutRequestNoContent(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	req, err := newRequestWithBody(httpMethodPut, server.URL+"/api/v1/test", map[string]string{testFieldName: "test"})
+	req, err := newRequestWithBody(httpMethodPut, server.URL+"/api/v1/test", map[string]string{testFieldName: testPlaceholder})
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}

--- a/lib/discovery_test.go
+++ b/lib/discovery_test.go
@@ -196,3 +196,30 @@ func TestGetDiscoveryError(t *testing.T) {
 		t.Error("Expected error, got nil")
 	}
 }
+
+func TestDiscoveryHTTPErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetRegistryCapabilities()
+	if err == nil {
+		t.Error("Expected error from GetRegistryCapabilities, got nil")
+	}
+
+	_, err = client.GetAppInfo(testClientID)
+	if err == nil {
+		t.Error("Expected error from GetAppInfo, got nil")
+	}
+
+	_, err = client.GetEntities("test", true, true)
+	if err == nil {
+		t.Error("Expected error from GetEntities, got nil")
+	}
+}

--- a/lib/logs_test.go
+++ b/lib/logs_test.go
@@ -437,6 +437,53 @@ func TestGetLogsError(t *testing.T) {
 	}
 }
 
+func TestLogsHTTPErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetOrganizationLogs(testNamespace, "", "", "")
+	if err == nil {
+		t.Error("Expected error from GetOrganizationLogs, got nil")
+	}
+
+	_, err = client.GetOrganizationAggregatedLogs(testNamespace, testStartDate, testEndDateMay)
+	if err == nil {
+		t.Error("Expected error from GetOrganizationAggregatedLogs, got nil")
+	}
+
+	err = client.ExportOrganizationLogs(testNamespace, &ExportLogsRequest{StartTime: testStartDate, EndTime: testEndDateMay})
+	if err == nil {
+		t.Error("Expected error from ExportOrganizationLogs, got nil")
+	}
+
+	_, err = client.GetUserLogs("", testStartDate, testEndDateMay)
+	if err == nil {
+		t.Error("Expected error from GetUserLogs, got nil")
+	}
+
+	_, err = client.GetUserAggregatedLogs(testStartDate, testEndDateMay)
+	if err == nil {
+		t.Error("Expected error from GetUserAggregatedLogs, got nil")
+	}
+
+	err = client.ExportUserLogs(&ExportLogsRequest{StartTime: testStartDate, EndTime: testEndDateMay})
+	if err == nil {
+		t.Error("Expected error from ExportUserLogs, got nil")
+	}
+
+	err = client.ExportRepositoryLogs(testNamespace, testRepository, &ExportLogsRequest{StartTime: testStartDate, EndTime: testEndDateMay})
+	if err == nil {
+		t.Error("Expected error from ExportRepositoryLogs, got nil")
+	}
+}
+
 func TestOrganizationRepositoryPopularityZero(t *testing.T) {
 	repo := OrganizationRepository{
 		Name:       testRepository,

--- a/lib/messages_test.go
+++ b/lib/messages_test.go
@@ -141,3 +141,20 @@ func TestGetMessagesError(t *testing.T) {
 		t.Error("Expected error, got nil")
 	}
 }
+
+func TestMessagesHTTPErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.CreateMessage("test content", "info", testMediaTypePlain)
+	if err == nil {
+		t.Error("Expected error from CreateMessage, got nil")
+	}
+}

--- a/lib/notification_test.go
+++ b/lib/notification_test.go
@@ -296,3 +296,48 @@ func TestGetNotificationError(t *testing.T) {
 		t.Error("Expected error, got nil")
 	}
 }
+
+func TestNotificationHTTPErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.CreateNotification(testNamespace, testRepository, &CreateNotificationRequest{
+		Event:  testNotificationEvent,
+		Method: testNotificationMethod,
+		Title:  "Test",
+	})
+	if err == nil {
+		t.Error("Expected error from CreateNotification, got nil")
+	}
+
+	err = client.DeleteNotification(testNamespace, testRepository, testNotificationUUID)
+	if err == nil {
+		t.Error("Expected error from DeleteNotification, got nil")
+	}
+
+	err = client.TestNotification(testNamespace, testRepository, testNotificationUUID)
+	if err == nil {
+		t.Error("Expected error from TestNotification, got nil")
+	}
+
+	err = client.ResetNotification(testNamespace, testRepository, testNotificationUUID)
+	if err == nil {
+		t.Error("Expected error from ResetNotification, got nil")
+	}
+
+	_, err = client.UpdateNotification(testNamespace, testRepository, testNotificationUUID, &CreateNotificationRequest{
+		Event:  testNotificationEvent,
+		Method: testNotificationMethod,
+		Title:  "Updated",
+	})
+	if err == nil {
+		t.Error("Expected error from UpdateNotification, got nil")
+	}
+}

--- a/lib/organization_test.go
+++ b/lib/organization_test.go
@@ -1917,3 +1917,324 @@ func TestGetOrganizationMarketplace(t *testing.T) {
 		t.Errorf("Expected subscription ID %s, got %s", testSubscriptionID, marketplace.Subscriptions[0].ID)
 	}
 }
+
+func newOrgErrorClient(t *testing.T) *Client {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	return client
+}
+
+func TestOrganizationCRUDHTTPErrors(t *testing.T) {
+	client := newOrgErrorClient(t)
+
+	_, err := client.CreateOrganization("testorg", testEmailAddress)
+	if err == nil {
+		t.Error("Expected error from CreateOrganization, got nil")
+	}
+
+	_, err = client.UpdateOrganization(testOrgName, testEmailAddress)
+	if err == nil {
+		t.Error("Expected error from UpdateOrganization, got nil")
+	}
+
+	err = client.DeleteOrganization(testOrgName)
+	if err == nil {
+		t.Error("Expected error from DeleteOrganization, got nil")
+	}
+
+	err = client.AddOrganizationMember(testOrgName, testMemberName)
+	if err == nil {
+		t.Error("Expected error from AddOrganizationMember, got nil")
+	}
+
+	err = client.RemoveOrganizationMember(testOrgName, testMemberName)
+	if err == nil {
+		t.Error("Expected error from RemoveOrganizationMember, got nil")
+	}
+
+	_, err = client.GetOrganizationMember(testOrgName, testMemberName)
+	if err == nil {
+		t.Error("Expected error from GetOrganizationMember, got nil")
+	}
+
+	_, err = client.GetOrganizationRepositories(testOrgName)
+	if err == nil {
+		t.Error("Expected error from GetOrganizationRepositories, got nil")
+	}
+
+	_, err = client.GetOrganizationCollaborators(testOrgName)
+	if err == nil {
+		t.Error("Expected error from GetOrganizationCollaborators, got nil")
+	}
+
+	_, err = client.GetDefaultPermissions(testOrgName)
+	if err == nil {
+		t.Error("Expected error from GetDefaultPermissions, got nil")
+	}
+
+	_, err = client.CreateDefaultPermission(testOrgName, testRoleRead, "user", testMemberName)
+	if err == nil {
+		t.Error("Expected error from CreateDefaultPermission, got nil")
+	}
+
+	err = client.DeleteDefaultPermission(testOrgName, testPrototypeID)
+	if err == nil {
+		t.Error("Expected error from DeleteDefaultPermission, got nil")
+	}
+
+	_, err = client.GetProxyCacheConfig(testOrgName)
+	if err == nil {
+		t.Error("Expected error from GetProxyCacheConfig, got nil")
+	}
+
+	_, err = client.CreateProxyCacheConfig(testOrgName, testUpstreamReg, false, 86400)
+	if err == nil {
+		t.Error("Expected error from CreateProxyCacheConfig, got nil")
+	}
+
+	err = client.DeleteProxyCacheConfig(testOrgName)
+	if err == nil {
+		t.Error("Expected error from DeleteProxyCacheConfig, got nil")
+	}
+}
+
+func TestOrganizationTeamHTTPErrors(t *testing.T) {
+	client := newOrgErrorClient(t)
+
+	_, err := client.GetTeams(testOrgName)
+	if err == nil {
+		t.Error("Expected error from GetTeams, got nil")
+	}
+
+	_, err = client.CreateTeam(testOrgName, testTeamName, testTeamDescDev, roleMember)
+	if err == nil {
+		t.Error("Expected error from CreateTeam, got nil")
+	}
+
+	_, err = client.GetTeam(testOrgName, testTeamName)
+	if err == nil {
+		t.Error("Expected error from GetTeam, got nil")
+	}
+
+	err = client.DeleteTeam(testOrgName, testTeamName)
+	if err == nil {
+		t.Error("Expected error from DeleteTeam, got nil")
+	}
+
+	_, err = client.UpdateTeam(testOrgName, testTeamName, testTeamDescDev, roleMember)
+	if err == nil {
+		t.Error("Expected error from UpdateTeam, got nil")
+	}
+
+	_, err = client.GetTeamMembers(testOrgName, testTeamName)
+	if err == nil {
+		t.Error("Expected error from GetTeamMembers, got nil")
+	}
+
+	err = client.AddTeamMember(testOrgName, testTeamName, testMemberName)
+	if err == nil {
+		t.Error("Expected error from AddTeamMember, got nil")
+	}
+
+	err = client.RemoveTeamMember(testOrgName, testTeamName, testMemberName)
+	if err == nil {
+		t.Error("Expected error from RemoveTeamMember, got nil")
+	}
+
+	_, err = client.GetTeamPermissions(testOrgName, testTeamName)
+	if err == nil {
+		t.Error("Expected error from GetTeamPermissions, got nil")
+	}
+
+	err = client.SetTeamRepositoryPermission(testOrgName, testTeamName, testRepository, testRoleRead)
+	if err == nil {
+		t.Error("Expected error from SetTeamRepositoryPermission, got nil")
+	}
+
+	err = client.RemoveTeamRepositoryPermission(testOrgName, testTeamName, testRepository)
+	if err == nil {
+		t.Error("Expected error from RemoveTeamRepositoryPermission, got nil")
+	}
+
+	err = client.InviteTeamMember(testOrgName, testTeamName, testEmailAddress)
+	if err == nil {
+		t.Error("Expected error from InviteTeamMember, got nil")
+	}
+
+	err = client.DeleteTeamInvite(testOrgName, testTeamName, testEmailAddress)
+	if err == nil {
+		t.Error("Expected error from DeleteTeamInvite, got nil")
+	}
+}
+
+func TestOrganizationRobotHTTPErrors(t *testing.T) {
+	client := newOrgErrorClient(t)
+
+	_, err := client.GetRobotAccounts(testOrgName)
+	if err == nil {
+		t.Error("Expected error from GetRobotAccounts, got nil")
+	}
+
+	_, err = client.CreateRobotAccount(testOrgName, "testbot", testRobotDescValue, nil)
+	if err == nil {
+		t.Error("Expected error from CreateRobotAccount, got nil")
+	}
+
+	_, err = client.GetRobotAccount(testOrgName, "testbot")
+	if err == nil {
+		t.Error("Expected error from GetRobotAccount, got nil")
+	}
+
+	err = client.DeleteRobotAccount(testOrgName, "testbot")
+	if err == nil {
+		t.Error("Expected error from DeleteRobotAccount, got nil")
+	}
+
+	_, err = client.RegenerateRobotToken(testOrgName, "testbot")
+	if err == nil {
+		t.Error("Expected error from RegenerateRobotToken, got nil")
+	}
+
+	_, err = client.GetRobotPermissions(testOrgName, "testbot")
+	if err == nil {
+		t.Error("Expected error from GetRobotPermissions, got nil")
+	}
+
+	err = client.SetRobotRepositoryPermission(testOrgName, "testbot", testRepository, testRoleRead)
+	if err == nil {
+		t.Error("Expected error from SetRobotRepositoryPermission, got nil")
+	}
+
+	err = client.RemoveRobotRepositoryPermission(testOrgName, "testbot", testRepository)
+	if err == nil {
+		t.Error("Expected error from RemoveRobotRepositoryPermission, got nil")
+	}
+
+	_, err = client.GetRobotFederation(testOrgName, "testbot")
+	if err == nil {
+		t.Error("Expected error from GetRobotFederation, got nil")
+	}
+
+	err = client.CreateRobotFederation(testOrgName, "testbot", []RobotFederationConfig{{Issuer: "https://example.com", Subject: testPlaceholder}})
+	if err == nil {
+		t.Error("Expected error from CreateRobotFederation, got nil")
+	}
+
+	err = client.DeleteRobotFederation(testOrgName, "testbot")
+	if err == nil {
+		t.Error("Expected error from DeleteRobotFederation, got nil")
+	}
+}
+
+func TestOrganizationQuotaPolicyHTTPErrors(t *testing.T) {
+	client := newOrgErrorClient(t)
+
+	_, err := client.GetQuota(testOrgName)
+	if err == nil {
+		t.Error("Expected error from GetQuota, got nil")
+	}
+
+	_, err = client.CreateQuota(testOrgName, 1073741824)
+	if err == nil {
+		t.Error("Expected error from CreateQuota, got nil")
+	}
+
+	_, err = client.UpdateQuota(testOrgName, 2147483648)
+	if err == nil {
+		t.Error("Expected error from UpdateQuota, got nil")
+	}
+
+	err = client.DeleteQuota(testOrgName)
+	if err == nil {
+		t.Error("Expected error from DeleteQuota, got nil")
+	}
+
+	_, err = client.GetAutoPrunePolicies(testOrgName)
+	if err == nil {
+		t.Error("Expected error from GetAutoPrunePolicies, got nil")
+	}
+
+	_, err = client.CreateAutoPrunePolicy(testOrgName, testAutoPruneMethodNumberOfTags, 10, "")
+	if err == nil {
+		t.Error("Expected error from CreateAutoPrunePolicy, got nil")
+	}
+
+	_, err = client.GetAutoPrunePolicy(testOrgName, testPolicyUUID)
+	if err == nil {
+		t.Error("Expected error from GetAutoPrunePolicy, got nil")
+	}
+
+	_, err = client.UpdateAutoPrunePolicy(testOrgName, testPolicyUUID, testAutoPruneMethodNumberOfTags, 20, "")
+	if err == nil {
+		t.Error("Expected error from UpdateAutoPrunePolicy, got nil")
+	}
+
+	err = client.DeleteAutoPrunePolicy(testOrgName, testPolicyUUID)
+	if err == nil {
+		t.Error("Expected error from DeleteAutoPrunePolicy, got nil")
+	}
+}
+
+func TestOrganizationAppMarketplaceHTTPErrors(t *testing.T) {
+	client := newOrgErrorClient(t)
+
+	_, err := client.GetApplications(testOrgName)
+	if err == nil {
+		t.Error("Expected error from GetApplications, got nil")
+	}
+
+	_, err = client.CreateApplication(testOrgName, testAppName, "desc", testAppURI, testRedirectURI)
+	if err == nil {
+		t.Error("Expected error from CreateApplication, got nil")
+	}
+
+	_, err = client.GetApplication(testOrgName, testClientID)
+	if err == nil {
+		t.Error("Expected error from GetApplication, got nil")
+	}
+
+	_, err = client.UpdateApplication(testOrgName, testClientID, testAppName, "desc", testAppURI, testRedirectURI)
+	if err == nil {
+		t.Error("Expected error from UpdateApplication, got nil")
+	}
+
+	err = client.DeleteApplication(testOrgName, testClientID)
+	if err == nil {
+		t.Error("Expected error from DeleteApplication, got nil")
+	}
+
+	_, err = client.ResetApplicationClientSecret(testOrgName, testClientID)
+	if err == nil {
+		t.Error("Expected error from ResetApplicationClientSecret, got nil")
+	}
+
+	_, err = client.GetOrganizationMarketplace(testOrgName)
+	if err == nil {
+		t.Error("Expected error from GetOrganizationMarketplace, got nil")
+	}
+
+	err = client.CreateOrganizationMarketplaceSubscription(testOrgName, &MarketplaceSubscriptionRequest{SKU: testPlaceholder})
+	if err == nil {
+		t.Error("Expected error from CreateOrganizationMarketplaceSubscription, got nil")
+	}
+
+	err = client.BatchRemoveOrganizationMarketplaceSubscriptions(testOrgName, []string{testSubscriptionID})
+	if err == nil {
+		t.Error("Expected error from BatchRemoveOrganizationMarketplaceSubscriptions, got nil")
+	}
+
+	err = client.DeleteOrganizationMarketplaceSubscription(testOrgName, testSubscriptionID)
+	if err == nil {
+		t.Error("Expected error from DeleteOrganizationMarketplaceSubscription, got nil")
+	}
+}

--- a/lib/permissions_test.go
+++ b/lib/permissions_test.go
@@ -482,4 +482,58 @@ func TestPermissionsErrorHandling(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for non-existent repository, got nil")
 	}
+
+	// Test ListUserPermissions error
+	_, err = client.ListUserPermissions(testNamespace, "nonexistent")
+	if err == nil {
+		t.Error("Expected error from ListUserPermissions, got nil")
+	}
+
+	// Test GetUserPermission error
+	_, err = client.GetUserPermission(testNamespace, "nonexistent", testPermUserName)
+	if err == nil {
+		t.Error("Expected error from GetUserPermission, got nil")
+	}
+
+	// Test SetUserPermission error
+	err = client.SetUserPermission(testNamespace, "nonexistent", testPermUserName, testRoleRead)
+	if err == nil {
+		t.Error("Expected error from SetUserPermission, got nil")
+	}
+
+	// Test DeleteUserPermission error
+	err = client.DeleteUserPermission(testNamespace, "nonexistent", testPermUserName)
+	if err == nil {
+		t.Error("Expected error from DeleteUserPermission, got nil")
+	}
+
+	// Test GetUserTransitivePermission error
+	_, err = client.GetUserTransitivePermission(testNamespace, "nonexistent", testPermUserName)
+	if err == nil {
+		t.Error("Expected error from GetUserTransitivePermission, got nil")
+	}
+
+	// Test ListTeamPermissions error
+	_, err = client.ListTeamPermissions(testNamespace, "nonexistent")
+	if err == nil {
+		t.Error("Expected error from ListTeamPermissions, got nil")
+	}
+
+	// Test GetTeamPermission error
+	_, err = client.GetTeamPermission(testNamespace, "nonexistent", testTeamName)
+	if err == nil {
+		t.Error("Expected error from GetTeamPermission, got nil")
+	}
+
+	// Test SetTeamPermission error
+	err = client.SetTeamPermission(testNamespace, "nonexistent", testTeamName, testRoleRead)
+	if err == nil {
+		t.Error("Expected error from SetTeamPermission, got nil")
+	}
+
+	// Test DeleteTeamPermission error
+	err = client.DeleteTeamPermission(testNamespace, "nonexistent", testTeamName)
+	if err == nil {
+		t.Error("Expected error from DeleteTeamPermission, got nil")
+	}
 }

--- a/lib/prototype_test.go
+++ b/lib/prototype_test.go
@@ -215,3 +215,41 @@ func TestGetPrototypesError(t *testing.T) {
 		t.Error("Expected error, got nil")
 	}
 }
+
+func TestPrototypeHTTPErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.CreatePrototype(testNamespace, &CreatePrototypeRequest{
+		Role: testRoleRead,
+		Delegate: PrototypeDelegateRequest{
+			Name: testPrototypeTeamName,
+			Kind: testKindTeam,
+		},
+	})
+	if err == nil {
+		t.Error("Expected error from CreatePrototype, got nil")
+	}
+
+	_, err = client.GetPrototype(testNamespace, testPrototypeUUID)
+	if err == nil {
+		t.Error("Expected error from GetPrototype, got nil")
+	}
+
+	_, err = client.UpdatePrototype(testNamespace, testPrototypeUUID, &UpdatePrototypeRequest{Role: testRoleWrite})
+	if err == nil {
+		t.Error("Expected error from UpdatePrototype, got nil")
+	}
+
+	err = client.DeletePrototype(testNamespace, testPrototypeUUID)
+	if err == nil {
+		t.Error("Expected error from DeletePrototype, got nil")
+	}
+}

--- a/lib/repository_test.go
+++ b/lib/repository_test.go
@@ -296,3 +296,45 @@ func TestGetRepository(t *testing.T) {
 		t.Errorf("Expected 2 tags, got %d", len(repoWithTags.Tags.Tags))
 	}
 }
+
+func TestRepositoryHTTPErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetRepository(testNamespace, testRepository)
+	if err == nil {
+		t.Error("Expected error from GetRepository, got nil")
+	}
+
+	_, err = client.CreateRepository(testNamespace, testRepository, "public", testRepoDescription)
+	if err == nil {
+		t.Error("Expected error from CreateRepository, got nil")
+	}
+
+	_, err = client.UpdateRepository(testNamespace, testRepository, updatedDescription, "private")
+	if err == nil {
+		t.Error("Expected error from UpdateRepository, got nil")
+	}
+
+	err = client.DeleteRepository(testNamespace, testRepository)
+	if err == nil {
+		t.Error("Expected error from DeleteRepository, got nil")
+	}
+
+	_, err = client.ListRepositories(testNamespace, false, false, 1, 10)
+	if err == nil {
+		t.Error("Expected error from ListRepositories, got nil")
+	}
+
+	err = client.ChangeRepositoryVisibility(testNamespace, testRepository, "public")
+	if err == nil {
+		t.Error("Expected error from ChangeRepositoryVisibility, got nil")
+	}
+}

--- a/lib/repotoken_test.go
+++ b/lib/repotoken_test.go
@@ -200,3 +200,35 @@ func TestGetRepoTokensError(t *testing.T) {
 		t.Error("Expected error, got nil")
 	}
 }
+
+func TestRepoTokenHTTPErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.CreateRepoToken(testNamespace, testRepository, &CreateRepoTokenRequest{FriendlyName: testPlaceholder})
+	if err == nil {
+		t.Error("Expected error from CreateRepoToken, got nil")
+	}
+
+	_, err = client.GetRepoToken(testNamespace, testRepository, testTokenCode)
+	if err == nil {
+		t.Error("Expected error from GetRepoToken, got nil")
+	}
+
+	_, err = client.UpdateRepoToken(testNamespace, testRepository, testTokenCode, &UpdateRepoTokenRequest{Role: testRoleWrite})
+	if err == nil {
+		t.Error("Expected error from UpdateRepoToken, got nil")
+	}
+
+	err = client.DeleteRepoToken(testNamespace, testRepository, testTokenCode)
+	if err == nil {
+		t.Error("Expected error from DeleteRepoToken, got nil")
+	}
+}

--- a/lib/robot_test.go
+++ b/lib/robot_test.go
@@ -410,3 +410,32 @@ func TestDeleteUserRobotFederation(t *testing.T) {
 		t.Fatalf("DeleteUserRobotFederation returned error: %v", err)
 	}
 }
+
+func TestRobotHTTPErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetUserRobotFederation(testRobotShortname)
+	if err == nil {
+		t.Error("Expected error from GetUserRobotFederation, got nil")
+	}
+
+	err = client.CreateUserRobotFederation(testRobotShortname, []RobotFederationConfig{
+		{Issuer: testFederationIssuer, Subject: testFederationSubject},
+	})
+	if err == nil {
+		t.Error("Expected error from CreateUserRobotFederation, got nil")
+	}
+
+	err = client.DeleteUserRobotFederation(testRobotShortname)
+	if err == nil {
+		t.Error("Expected error from DeleteUserRobotFederation, got nil")
+	}
+}

--- a/lib/search_test.go
+++ b/lib/search_test.go
@@ -123,7 +123,7 @@ func TestSearchAll(t *testing.T) {
 				Score:       0.95,
 				Avatar: Avatar{
 					Name:  "quay",
-					Hash:  "abc123",
+					Hash:  testHashABC123,
 					Kind:  "org",
 					Color: "#ff0000",
 				},

--- a/lib/tag_test.go
+++ b/lib/tag_test.go
@@ -18,7 +18,7 @@ func TestGetTag(t *testing.T) {
 		Size:           1024000,
 		LastModified:   testTimestamp,
 		IsManifestList: false,
-		DockerImageID:  "abc123",
+		DockerImageID:  testHashABC123,
 		ImageID:        "def456",
 		V1Metadata: map[string]string{
 			"architecture": testArchAmd64,
@@ -320,5 +320,11 @@ func TestTagErrorHandling(t *testing.T) {
 	_, err = client.RevertTag(testNamespace, testRepository, "nonexistent", testDigestSHA256)
 	if err == nil {
 		t.Error("Expected error for non-existent tag, got nil")
+	}
+
+	// Test RestoreTag error
+	err = client.RestoreTag(testNamespace, testRepository, "nonexistent", testDigestSHA256)
+	if err == nil {
+		t.Error("Expected error from RestoreTag, got nil")
 	}
 }

--- a/lib/test_constants_test.go
+++ b/lib/test_constants_test.go
@@ -94,6 +94,10 @@ const (
 	// Query parameter values
 	testQueryValueTrue = "true"
 
+	// Generic test placeholders
+	testPlaceholder = "test"
+	testHashABC123  = "abc123"
+
 	// Shared API path constants
 	testAPIPathRepository = "/api/v1/repository"
 

--- a/lib/trigger_test.go
+++ b/lib/trigger_test.go
@@ -322,3 +322,40 @@ func TestGetTriggerError(t *testing.T) {
 		t.Error("Expected error, got nil")
 	}
 }
+
+func TestTriggerHTTPErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.DeleteTrigger(testNamespace, testRepository, testTriggerUUID)
+	if err == nil {
+		t.Error("Expected error from DeleteTrigger, got nil")
+	}
+
+	_, err = client.UpdateTrigger(testNamespace, testRepository, testTriggerUUID, true)
+	if err == nil {
+		t.Error("Expected error from UpdateTrigger, got nil")
+	}
+
+	_, err = client.StartTriggerBuild(testNamespace, testRepository, testTriggerUUID, &ManualTriggerRequest{CommitSHA: testHashABC123})
+	if err == nil {
+		t.Error("Expected error from StartTriggerBuild, got nil")
+	}
+
+	_, err = client.ActivateTrigger(testNamespace, testRepository, testTriggerUUID, &ActivateTriggerRequest{})
+	if err == nil {
+		t.Error("Expected error from ActivateTrigger, got nil")
+	}
+
+	_, err = client.GetTriggerBuilds(testNamespace, testRepository, testTriggerUUID, 10)
+	if err == nil {
+		t.Error("Expected error from GetTriggerBuilds, got nil")
+	}
+}

--- a/lib/user_test.go
+++ b/lib/user_test.go
@@ -411,3 +411,35 @@ func TestUserStarRepositoryNotFound(t *testing.T) {
 		t.Error("Expected error for non-existent repository, got nil")
 	}
 }
+
+func TestUserHTTPErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.StarUserRepository(testNamespace, testRepository)
+	if err == nil {
+		t.Error("Expected error from StarUserRepository, got nil")
+	}
+
+	err = client.UnstarUserRepository(testNamespace, testRepository)
+	if err == nil {
+		t.Error("Expected error from UnstarUserRepository, got nil")
+	}
+
+	_, err = client.GetUserByUsername(testUserName)
+	if err == nil {
+		t.Error("Expected error from GetUserByUsername, got nil")
+	}
+
+	_, err = client.GetUserMarketplace()
+	if err == nil {
+		t.Error("Expected error from GetUserMarketplace, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Add HTTP error response tests for every lib function that was missing them. Tests verify that all functions properly return errors on 500 responses.

- Coverage: **77.2% → 85.5%**
- Total tests: **217 → 234**
- 15 test files updated with error path coverage

Relates to #104

## Test plan

- [x] `go test ./lib/ -count=1` — 234 tests pass
- [x] Coverage: 85.5%
- [x] `make lint` — 0 issues
