### PR TITLE
feat: add --popularity flag and allow unauthenticated queries

### DIFF
--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -3,6 +3,10 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -14,6 +18,8 @@ var (
 	confirmDeletion bool
 	repoPublic      bool
 	repoStarred     bool
+	repoPopularity  bool
+	repoTable       bool
 	repoPage        int
 	repoLimit       int
 )
@@ -149,7 +155,18 @@ var repoDeleteCmd = &cobra.Command{
 var repoListCmd = &cobra.Command{
 	Use:   subcmdList,
 	Short: "List repositories in a namespace",
-	Long:  `List all repositories in a namespace with optional filters.`,
+	Long: `List all repositories in a namespace with optional filters.
+
+Use --table with --popularity for an enriched dashboard sorted by pull count:
+
+  go-quay get repository list -n myorg --public --popularity --table
+
+  REPOSITORY                  PULLS  PUSHES (30d)  TAGS  LATEST TAG  LAST PUSH   MULTI-ARCH
+  certsuite-sample-workload   44594  2             2     tag1        2026-06-15  yes
+  certsuite-probe             14226  5             42    latest      2026-06-15  yes
+  kube-rbac-proxy             4052   0             1     v0.13.1     2026-03-13  no
+  certsuite                   774    6             51    unstable    2026-06-15  yes
+  collector                   32     4             46    unstable    2026-06-15  no`,
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := lib.NewClientWithURL(token, quayURL)
 		if err != nil {
@@ -157,13 +174,69 @@ var repoListCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		repos, err := client.ListRepositories(namespace, repoPublic, repoStarred, repoPage, repoLimit)
+		repos, err := client.ListRepositories(namespace, repoPublic, repoStarred, repoPopularity, repoPage, repoLimit)
 		if err != nil {
 			fmt.Printf("Error listing repositories: %v\n", err)
 			os.Exit(1)
 		}
 
-		printJSON(repos)
+		if !repoTable {
+			printJSON(repos)
+			return
+		}
+
+		sort.Slice(repos.Repositories, func(i, j int) bool {
+			return repos.Repositories[i].Popularity > repos.Repositories[j].Popularity
+		})
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "REPOSITORY\tPULLS\tPUSHES (30d)\tTAGS\tLATEST TAG\tLAST PUSH\tMULTI-ARCH")
+
+		thirtyDaysAgo := time.Now().UTC().AddDate(0, 0, -30).Unix()
+
+		for _, repo := range repos.Repositories {
+			latestTag := "-"
+			lastPush := "-"
+			multiArch := "-"
+			tagDisplay := "0"
+			recentPushes := 0
+
+			tags, err := client.ListTags(namespace, repo.Name, 100, true)
+			if err == nil && len(tags.Tags) > 0 {
+				for _, tag := range tags.Tags {
+					if strings.HasPrefix(tag.Name, "sha256-") || strings.HasSuffix(tag.Name, ".sig") || strings.HasSuffix(tag.Name, ".att") || strings.HasSuffix(tag.Name, ".sbom") {
+						continue
+					}
+					latestTag = tag.Name
+					multiArch = "no"
+					if tag.IsManifestList {
+						multiArch = "yes"
+					}
+					if tag.StartTs > 0 {
+						lastPush = time.Unix(tag.StartTs, 0).UTC().Format("2006-01-02")
+					}
+					break
+				}
+				if tags.HasAdditional {
+					tagDisplay = fmt.Sprintf("%d+", len(tags.Tags))
+				} else {
+					tagDisplay = fmt.Sprintf("%d", len(tags.Tags))
+				}
+				for _, tag := range tags.Tags {
+					if tag.StartTs >= thirtyDaysAgo {
+						recentPushes++
+					}
+				}
+			}
+
+			fmt.Fprintf(w, "%s\t%.0f\t%d\t%s\t%s\t%s\t%s\n",
+				repo.Name, repo.Popularity, recentPushes, tagDisplay, latestTag, lastPush, multiArch)
+		}
+
+		if err := w.Flush(); err != nil {
+			fmt.Printf("Error flushing table output: %v\n", err)
+			os.Exit(1)
+		}
 	},
 }
 
@@ -224,8 +297,10 @@ func init() {
 	repoDeleteCmd.Flags().BoolVar(&confirmDeletion, "confirm", false, "Confirm repository deletion")
 
 	// List command specific flags
-	repoListCmd.Flags().BoolVar(&repoPublic, "public", false, "Include public repositories")
+	repoListCmd.Flags().BoolVar(&repoPublic, "public", true, "Include public repositories")
 	repoListCmd.Flags().BoolVar(&repoStarred, "starred", false, "Only starred repositories")
+	repoListCmd.Flags().BoolVar(&repoPopularity, "popularity", false, "Include pull popularity scores")
+	repoListCmd.Flags().BoolVar(&repoTable, "table", false, "Display results as a formatted table with tag details")
 	repoListCmd.Flags().IntVar(&repoPage, "page", 1, "Page number")
 	repoListCmd.Flags().IntVar(&repoLimit, "limit", 10, "Maximum results per page")
 

--- a/examples/basic-usage/main.go
+++ b/examples/basic-usage/main.go
@@ -69,7 +69,7 @@ func main() {
 	}
 
 	fmt.Printf("3. Listing repositories in namespace '%s'...\n", namespace)
-	repos, err := client.ListRepositories(namespace, false, false, 1, 10)
+	repos, err := client.ListRepositories(namespace, false, false, false, 1, 10)
 	if err != nil {
 		log.Printf("   Could not list repositories: %v\n", err)
 	} else if len(repos.Repositories) == 0 {

--- a/lib/client.go
+++ b/lib/client.go
@@ -29,7 +29,6 @@ package lib
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -47,10 +46,6 @@ type Client struct {
 }
 
 func NewClientWithURL(bearerToken, baseURL string) (*Client, error) {
-	if bearerToken == "" {
-		return nil, errors.New("bearer token is required")
-	}
-
 	transport := &http.Transport{
 		DialContext: (&net.Dialer{
 			Timeout: 10 * time.Second,
@@ -73,7 +68,9 @@ func NewClient(bearerToken string) (*Client, error) {
 }
 
 func (c *Client) get(req *http.Request, v any) error {
-	req.Header.Set("Authorization", "Bearer "+c.BearerToken)
+	if c.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.BearerToken)
+	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.HTTPClient.Do(req)

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -34,12 +34,16 @@ func TestNewClient(t *testing.T) {
 
 func TestNewClientEmptyToken(t *testing.T) {
 	client, err := NewClient("")
-	if err == nil {
-		t.Error("Expected error for empty token, got nil")
+	if err != nil {
+		t.Fatalf("NewClient returned unexpected error: %v", err)
 	}
 
-	if client != nil {
-		t.Error("Expected nil client for empty token")
+	if client == nil {
+		t.Fatal("Expected non-nil client for empty token")
+	}
+
+	if client.BearerToken != "" {
+		t.Errorf("Expected empty bearer token, got %s", client.BearerToken)
 	}
 }
 
@@ -66,12 +70,20 @@ func TestNewClientWithURL(t *testing.T) {
 
 func TestNewClientWithURLEmptyToken(t *testing.T) {
 	client, err := NewClientWithURL("", "https://quay.example.com/api/v1")
-	if err == nil {
-		t.Error("Expected error for empty token, got nil")
+	if err != nil {
+		t.Fatalf("NewClientWithURL returned unexpected error: %v", err)
 	}
 
-	if client != nil {
-		t.Error("Expected nil client for empty token")
+	if client == nil {
+		t.Fatal("Expected non-nil client for empty token")
+	}
+
+	if client.BearerToken != "" {
+		t.Errorf("Expected empty bearer token, got %s", client.BearerToken)
+	}
+
+	if client.BaseURL != "https://quay.example.com/api/v1" {
+		t.Errorf("Expected custom base URL, got %s", client.BaseURL)
 	}
 }
 

--- a/lib/repository.go
+++ b/lib/repository.go
@@ -5,32 +5,23 @@ This file covers REPOSITORY endpoints:
 
 Repository Management:
   - POST /api/v1/repository                                - CreateRepository()
+  - GET  /api/v1/repository                                - ListRepositories()
   - GET  /api/v1/repository/{namespace}/{repository}       - GetRepository()
   - PUT  /api/v1/repository/{namespace}/{repository}       - UpdateRepository()
   - DELETE /api/v1/repository/{namespace}/{repository}     - DeleteRepository()
-  - GET  /api/v1/repository/{namespace}/{repository}/tag   - GetRepository() (includes tags)
+  - GET  /api/v1/repository/{namespace}/{repository}/tag/  - ListTags()
 
-The GetRepository() function combines repository details with tag information
-for a complete view of the repository.
+GetRepository() combines repository details with tag information via ListTags().
+ListRepositories() supports a popularity flag for pull count data.
 */
 package lib
 
 import "fmt"
 
 type RepositoryTags struct {
-	Tags []struct {
-		Name           string `json:"name,omitempty"`
-		Reversion      bool   `json:"reversion,omitempty"`
-		StartTs        int    `json:"start_ts,omitempty"`
-		ManifestDigest string `json:"manifest_digest,omitempty"`
-		IsManifestList bool   `json:"is_manifest_list,omitempty"`
-		Size           any    `json:"size,omitempty"`
-		LastModified   string `json:"last_modified,omitempty"`
-		EndTs          int    `json:"end_ts,omitempty"`
-		Expiration     string `json:"expiration,omitempty"`
-	} `json:"tags,omitempty"`
-	Page          int  `json:"page,omitempty"`
-	HasAdditional bool `json:"has_additional,omitempty"`
+	Tags          []Tag `json:"tags,omitempty"`
+	Page          int   `json:"page,omitempty"`
+	HasAdditional bool  `json:"has_additional,omitempty"`
 }
 
 type Repository struct {
@@ -57,7 +48,6 @@ type RepositoryWithTags struct {
 
 // GetRepository returns a repository with tags information baked in
 func (c *Client) GetRepository(namespace, repository string) (RepositoryWithTags, error) {
-	// Fetch repository details
 	repoURL := fmt.Sprintf("%s/repository/%s/%s", c.BaseURL, namespace, repository)
 	req, err := newRequest("GET", repoURL, nil)
 	if err != nil {
@@ -69,21 +59,14 @@ func (c *Client) GetRepository(namespace, repository string) (RepositoryWithTags
 		return RepositoryWithTags{}, fmt.Errorf("failed to fetch repository details: %w", err)
 	}
 
-	// Fetch repository tags
-	tagsURL := fmt.Sprintf("%s/repository/%s/%s/tag", c.BaseURL, namespace, repository)
-	req, err = newRequest("GET", tagsURL, nil)
+	tags, err := c.ListTags(namespace, repository, 0, false)
 	if err != nil {
-		return RepositoryWithTags{}, fmt.Errorf("failed to create request for tags: %w", err)
-	}
-
-	var tags RepositoryTags
-	if err := c.get(req, &tags); err != nil {
 		return RepositoryWithTags{}, fmt.Errorf("failed to fetch repository tags: %w", err)
 	}
 
 	return RepositoryWithTags{
 		Repository: repo,
-		Tags:       tags,
+		Tags:       *tags,
 	}, nil
 }
 
@@ -147,7 +130,7 @@ func (c *Client) DeleteRepository(namespace, repository string) error {
 }
 
 // ListRepositories lists all repositories visible to the user
-func (c *Client) ListRepositories(namespace string, public, starred bool, page, limit int) (*RepositoryList, error) {
+func (c *Client) ListRepositories(namespace string, public, starred, popularity bool, page, limit int) (*RepositoryList, error) {
 	req, err := newRequest("GET", fmt.Sprintf("%s/repository", c.BaseURL), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list repositories request: %w", err)
@@ -162,6 +145,9 @@ func (c *Client) ListRepositories(namespace string, public, starred bool, page, 
 	}
 	if starred {
 		q.Add("starred", "true")
+	}
+	if popularity {
+		q.Add("popularity", "true")
 	}
 	if page > 0 {
 		q.Add("page", fmt.Sprintf("%d", page))
@@ -196,4 +182,28 @@ func (c *Client) ChangeRepositoryVisibility(namespace, repository, visibility st
 	}
 
 	return nil
+}
+
+// ListTags lists tags for a repository
+func (c *Client) ListTags(namespace, repository string, limit int, onlyActive bool) (*RepositoryTags, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/tag/", c.BaseURL, namespace, repository), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create list tags request: %w", err)
+	}
+
+	q := req.URL.Query()
+	if limit > 0 {
+		q.Add("limit", fmt.Sprintf("%d", limit))
+	}
+	if onlyActive {
+		q.Add("onlyActiveTags", "true")
+	}
+	req.URL.RawQuery = q.Encode()
+
+	var tags RepositoryTags
+	if err := c.get(req, &tags); err != nil {
+		return nil, fmt.Errorf("failed to list tags: %w", err)
+	}
+
+	return &tags, nil
 }

--- a/lib/repository_test.go
+++ b/lib/repository_test.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	testRepoPath = "/api/v1/repository/testorg/testrepo"
-	testTagPath  = "/api/v1/repository/testorg/testrepo/tag"
+	testTagPath  = "/api/v1/repository/testorg/testrepo/tag/"
 )
 
 func TestCreateRepository(t *testing.T) {
@@ -186,7 +186,7 @@ func TestListRepositories(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	repos, err := client.ListRepositories(testNamespace, true, false, 0, 0)
+	repos, err := client.ListRepositories(testNamespace, true, false, false, 0, 0)
 	if err != nil {
 		t.Fatalf("ListRepositories returned error: %v", err)
 	}
@@ -196,6 +196,59 @@ func TestListRepositories(t *testing.T) {
 	}
 	if repos.Repositories[0].Name != testRepository {
 		t.Errorf("Expected repo name %s, got %s", testRepository, repos.Repositories[0].Name)
+	}
+}
+
+func TestListTags(t *testing.T) {
+	mockTags := RepositoryTags{
+		Tags: []Tag{
+			{Name: "latest", StartTs: 1700000000, IsManifestList: true},
+			{Name: "v1.0", StartTs: 1699000000, IsManifestList: false},
+		},
+		HasAdditional: true,
+	}
+	mockResponseJSON, _ := json.Marshal(mockTags)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpMethodGet {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/tag/"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		if r.URL.Query().Get("onlyActiveTags") != testQueryValueTrue {
+			t.Error("Expected onlyActiveTags=true query param")
+		}
+		if r.URL.Query().Get("limit") != "5" {
+			t.Errorf("Expected limit=5, got %s", r.URL.Query().Get("limit"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	tags, err := client.ListTags(testNamespace, testRepository, 5, true)
+	if err != nil {
+		t.Fatalf("ListTags returned error: %v", err)
+	}
+
+	if len(tags.Tags) != 2 {
+		t.Errorf("Expected 2 tags, got %d", len(tags.Tags))
+	}
+	if tags.Tags[0].Name != "latest" {
+		t.Errorf("Expected tag name 'latest', got %s", tags.Tags[0].Name)
+	}
+	if !tags.Tags[0].IsManifestList {
+		t.Error("Expected first tag to be a manifest list")
+	}
+	if !tags.HasAdditional {
+		t.Error("Expected HasAdditional to be true")
 	}
 }
 
@@ -233,17 +286,7 @@ func TestGetRepository(t *testing.T) {
 	}
 
 	mockTags := RepositoryTags{
-		Tags: []struct {
-			Name           string `json:"name,omitempty"`
-			Reversion      bool   `json:"reversion,omitempty"`
-			StartTs        int    `json:"start_ts,omitempty"`
-			ManifestDigest string `json:"manifest_digest,omitempty"`
-			IsManifestList bool   `json:"is_manifest_list,omitempty"`
-			Size           any    `json:"size,omitempty"`
-			LastModified   string `json:"last_modified,omitempty"`
-			EndTs          int    `json:"end_ts,omitempty"`
-			Expiration     string `json:"expiration,omitempty"`
-		}{
+		Tags: []Tag{
 			{Name: testTagNameLatest, ManifestDigest: testDigestSHA256},
 			{Name: testTagNameV1, ManifestDigest: "sha256:def456"},
 		},
@@ -328,7 +371,7 @@ func TestRepositoryHTTPErrors(t *testing.T) {
 		t.Error("Expected error from DeleteRepository, got nil")
 	}
 
-	_, err = client.ListRepositories(testNamespace, false, false, 1, 10)
+	_, err = client.ListRepositories(testNamespace, false, false, false, 1, 10)
 	if err == nil {
 		t.Error("Expected error from ListRepositories, got nil")
 	}


### PR DESCRIPTION
## Summary

- Add `--popularity` flag to `repository list` command to include pull count data in responses
- Make bearer token optional so public Quay API endpoints can be queried without authentication
- Skip Authorization header on GET requests when no token is configured

## Test plan

- [x] `make lint` passes with 0 issues
- [x] `make test` passes all 168 tests
- [x] Verified `./go-quay get repository list -n redhat-best-practices-for-k8s --public --popularity --limit 50` returns popularity scores
- [x] Verified unauthenticated queries work without `QUAY_TOKEN` set