### PR TITLE
docs: fix ListRepositories signature in library guide

### DIFF
--- a/docs/library-guide.md
+++ b/docs/library-guide.md
@@ -64,7 +64,7 @@ err := client.DeleteUserRobot("name")
 
 ```go
 // List repositories
-repos, err := client.ListRepositories(namespace, public, starred, page, limit)
+repos, err := client.ListRepositories(namespace, public, starred, popularity, page, limit)
 
 // CRUD operations
 repo, err := client.CreateRepository(namespace, name, visibility, description)


### PR DESCRIPTION
Fixes incorrect function signature in library-guide.md that was missing the `popularity` parameter.

**Problem:** Documentation showed 5 parameters but actual function has 6.
**Fix:** Added missing `popularity bool` parameter to match implementation.

Actual signature: `ListRepositories(namespace, public, starred, popularity, page, limit)`

Prevents copy-paste errors for users following the library guide.