### PR TITLE
feat: add helpful error message when token is missing

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
@@ -21,6 +22,16 @@ func SetVersion(v string) {
 var getCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Get objects from Quay.io",
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Validate token is provided
+		if token == "" {
+			return fmt.Errorf(`authentication token required
+
+Set QUAY_TOKEN environment variable or use --token/-t flag.
+Get your token at https://quay.io/organization/<org>?tab=applications`)
+		}
+		return nil
+	},
 }
 
 func envOrDefault(key, fallback string) string {


### PR DESCRIPTION
Adds validation that checks if authentication token is provided and shows a clear, actionable error message if missing.

## Problem
Users seeing generic "Error creating client" message don't know that QUAY_TOKEN is required or how to get one.

## Changes
- ✅ Added PersistentPreRunE to getCmd that validates token presence
- ✅ Shows helpful error with instructions on where to get token

## Before
```
Error creating client: ...
```

## After
```
Error: authentication token required

Set QUAY_TOKEN environment variable or use --token/-t flag.
Get your token at https://quay.io/organization/<org>?tab=applications
```

Improves first-time user experience.