### PR TITLE
refactor: extract client creation into mustGetClient helper

### DIFF
--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
 )
 
@@ -22,11 +21,7 @@ var orgBillingCmd = &cobra.Command{
 	Use:   "org-info",
 	Short: "Get billing information for an organization",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		billing, err := client.GetOrganizationBilling(billingOrgName)
 		if err != nil {
@@ -42,11 +37,7 @@ var userBillingCmd = &cobra.Command{
 	Use:   "user-info",
 	Short: "Get billing information for the current user",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		billing, err := client.GetUserBilling()
 		if err != nil {
@@ -62,11 +53,7 @@ var orgSubscriptionCmd = &cobra.Command{
 	Use:   "org-subscription",
 	Short: "Get subscription details for an organization",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		subscription, err := client.GetOrganizationSubscription(billingOrgName)
 		if err != nil {
@@ -82,11 +69,7 @@ var userSubscriptionCmd = &cobra.Command{
 	Use:   "user-subscription",
 	Short: "Get subscription details for the current user",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		subscription, err := client.GetUserSubscription()
 		if err != nil {
@@ -102,11 +85,7 @@ var orgInvoicesCmd = &cobra.Command{
 	Use:   "org-invoices",
 	Short: "Get invoices for an organization",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		invoices, err := client.GetOrganizationInvoices(billingOrgName)
 		if err != nil {
@@ -122,11 +101,7 @@ var userInvoicesCmd = &cobra.Command{
 	Use:   "user-invoices",
 	Short: "Get invoices for the current user",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		invoices, err := client.GetUserInvoices()
 		if err != nil {
@@ -142,11 +117,7 @@ var plansCmd = &cobra.Command{
 	Use:   "plans",
 	Short: "Get available subscription plans",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		plans, err := client.GetAvailablePlans()
 		if err != nil {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -43,11 +43,7 @@ var buildListCmd = &cobra.Command{
 	Short: "List builds for a repository",
 	Long:  `List all builds for the specified repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		builds, err := client.GetBuilds(buildNamespace, buildRepository, buildLimit)
 		if err != nil {
@@ -66,11 +62,7 @@ var buildInfoCmd = &cobra.Command{
 	Short: "Get build details",
 	Long:  `Get detailed information about a specific build.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		build, err := client.GetBuild(buildNamespace, buildRepository, buildUUID)
 		if err != nil {
@@ -89,11 +81,7 @@ var buildLogsCmd = &cobra.Command{
 	Short: "Get build logs",
 	Long:  `Get the logs for a specific build.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		logs, err := client.GetBuildLogs(buildNamespace, buildRepository, buildUUID)
 		if err != nil {
@@ -114,11 +102,7 @@ var buildRequestCmd = &cobra.Command{
 
 The archive should be a tar.gz file containing a Dockerfile and any necessary build context.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		buildReq := &lib.RequestBuildRequest{
 			ArchiveURL:     buildArchiveURL,
@@ -150,13 +134,9 @@ var buildCancelCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.CancelBuild(buildNamespace, buildRepository, buildUUID)
+		err := client.CancelBuild(buildNamespace, buildRepository, buildUUID)
 		if err != nil {
 			fmt.Printf("Error canceling build: %v\n", err)
 			os.Exit(1)
@@ -171,11 +151,7 @@ var buildStatusCmd = &cobra.Command{
 	Short: "Get build status",
 	Long:  `Get the current status of a specific build.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		status, err := client.GetBuildStatus(buildNamespace, buildRepository, buildUUID)
 		if err != nil {

--- a/cmd/discovery.go
+++ b/cmd/discovery.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
 )
 
@@ -25,11 +24,7 @@ var discoveryAPICmd = &cobra.Command{
 	Short: "Get API discovery information",
 	Long:  `Get API discovery information from Quay.io including available endpoints and versions.`,
 	Run: func(_ *cobra.Command, _ []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		discovery, err := client.GetDiscovery()
 		if err != nil {
@@ -46,11 +41,7 @@ var discoveryCapabilitiesCmd = &cobra.Command{
 	Short: "Get registry capabilities",
 	Long:  `Get registry capabilities including sparse manifest support and available mirror architectures.`,
 	Run: func(_ *cobra.Command, _ []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		capabilities, err := client.GetRegistryCapabilities()
 		if err != nil {
@@ -67,11 +58,7 @@ var discoveryAppInfoCmd = &cobra.Command{
 	Short: "Get application information by client ID",
 	Long:  `Get detailed information about an OAuth application by its client ID.`,
 	Run: func(_ *cobra.Command, _ []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		app, err := client.GetAppInfo(discoveryClientID)
 		if err != nil {
@@ -88,11 +75,7 @@ var discoveryEntitiesCmd = &cobra.Command{
 	Short: "Search for entities by prefix",
 	Long:  `Search for users, organizations, and teams by name prefix.`,
 	Run: func(_ *cobra.Command, _ []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		entities, err := client.GetEntities(entityPrefix, includeOrgs, includeTeams)
 		if err != nil {

--- a/cmd/errortype.go
+++ b/cmd/errortype.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
 )
 
@@ -32,11 +31,7 @@ This endpoint provides details about error types that can be returned by the Qua
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		errType, err := client.GetErrorType(errorTypeName)
 		if err != nil {

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 	"os"
+
+	"github.com/sebrandon1/go-quay/lib"
 )
 
 func markFlagRequired(err error) {
@@ -10,4 +12,15 @@ func markFlagRequired(err error) {
 		fmt.Printf("Error marking flag as required: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// mustGetClient creates a Quay client with the configured token and URL.
+// Exits with error message if client creation fails.
+func mustGetClient() *lib.Client {
+	client, err := lib.NewClientWithURL(token, quayURL)
+	if err != nil {
+		fmt.Printf("Error creating client: %v\n", err)
+		os.Exit(1)
+	}
+	return client
 }

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -32,11 +32,7 @@ var repoLogsCmd = &cobra.Command{
 	Short: "Get repository logs",
 	Long:  `Get action logs for a specific repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		logs, err := client.GetLogs(namespace, repository, nextPage, startdate, enddate)
 		if err != nil {
@@ -53,11 +49,7 @@ var repoAggregatedLogsCmd = &cobra.Command{
 	Short: "Get aggregated repository logs",
 	Long:  `Get aggregated action logs for a specific repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		logs, err := client.GetAggregatedLogs(namespace, repository, startdate, enddate)
 		if err != nil {
@@ -74,11 +66,7 @@ var orgLogsCmd = &cobra.Command{
 	Short: "Get organization logs",
 	Long:  `Get action logs for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		logs, err := client.GetOrganizationLogs(orgName, nextPage, startdate, enddate)
 		if err != nil {
@@ -95,11 +83,7 @@ var orgAggregatedLogsCmd = &cobra.Command{
 	Short: "Get aggregated organization logs",
 	Long:  `Get aggregated action logs for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		logs, err := client.GetOrganizationAggregatedLogs(orgName, startdate, enddate)
 		if err != nil {
@@ -116,11 +100,7 @@ var userLogsCmd = &cobra.Command{
 	Short: "Get user logs",
 	Long:  `Get action logs for the current user.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		logs, err := client.GetUserLogs(nextPage, startdate, enddate)
 		if err != nil {
@@ -137,11 +117,7 @@ var userAggregatedLogsCmd = &cobra.Command{
 	Short: "Get aggregated user logs",
 	Long:  `Get aggregated action logs for the current user.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		logs, err := client.GetUserAggregatedLogs(startdate, enddate)
 		if err != nil {
@@ -158,13 +134,9 @@ var exportOrgLogsCmd = &cobra.Command{
 	Short: "Export organization logs",
 	Long:  `Export action logs for an organization via callback URL or email.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.ExportOrganizationLogs(orgName, &lib.ExportLogsRequest{
+		err := client.ExportOrganizationLogs(orgName, &lib.ExportLogsRequest{
 			StartTime:   starttime,
 			EndTime:     endtime,
 			CallbackURL: callbackURL,
@@ -184,13 +156,9 @@ var exportUserLogsCmd = &cobra.Command{
 	Short: "Export user logs",
 	Long:  `Export action logs for the current user via callback URL or email.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.ExportUserLogs(&lib.ExportLogsRequest{
+		err := client.ExportUserLogs(&lib.ExportLogsRequest{
 			StartTime:   starttime,
 			EndTime:     endtime,
 			CallbackURL: callbackURL,
@@ -210,13 +178,9 @@ var exportRepoLogsCmd = &cobra.Command{
 	Short: "Export repository logs",
 	Long:  `Export action logs for a repository via callback URL or email.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.ExportRepositoryLogs(namespace, repository, &lib.ExportLogsRequest{
+		err := client.ExportRepositoryLogs(namespace, repository, &lib.ExportLogsRequest{
 			StartTime:   starttime,
 			EndTime:     endtime,
 			CallbackURL: callbackURL,

--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
 )
 
@@ -38,11 +37,7 @@ var manifestInfoCmd = &cobra.Command{
 	Short: "Get detailed manifest information",
 	Long:  `Get detailed information about a specific manifest including layers, config, and metadata.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		manifest, err := client.GetManifest(namespace, repository, manifestRef)
 		if err != nil {
@@ -67,13 +62,9 @@ var manifestDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.DeleteManifest(namespace, repository, manifestRef)
+		err := client.DeleteManifest(namespace, repository, manifestRef)
 		if err != nil {
 			fmt.Printf("Error deleting manifest: %v\n", err)
 			os.Exit(1)
@@ -89,11 +80,7 @@ var manifestLabelsCmd = &cobra.Command{
 	Short: "List manifest labels",
 	Long:  `List all labels associated with a specific manifest.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		labels, err := client.GetManifestLabels(namespace, repository, manifestRef)
 		if err != nil {
@@ -112,11 +99,7 @@ var manifestLabelCmd = &cobra.Command{
 	Short: "Get a specific manifest label",
 	Long:  `Get detailed information about a specific label on a manifest.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		label, err := client.GetManifestLabel(namespace, repository, manifestRef, labelID)
 		if err != nil {
@@ -135,11 +118,7 @@ var manifestAddLabelCmd = &cobra.Command{
 	Short: "Add a label to a manifest",
 	Long:  `Add a new label with a key-value pair to a specific manifest.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		label, err := client.AddManifestLabel(namespace, repository, manifestRef, labelKey, labelValue, labelMediaType)
 		if err != nil {
@@ -158,13 +137,9 @@ var manifestRemoveLabelCmd = &cobra.Command{
 	Short: "Remove a label from a manifest",
 	Long:  `Remove a specific label from a manifest by its label ID.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.DeleteManifestLabel(namespace, repository, manifestRef, labelID)
+		err := client.DeleteManifestLabel(namespace, repository, manifestRef, labelID)
 		if err != nil {
 			fmt.Printf("Error removing manifest label: %v\n", err)
 			os.Exit(1)

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
 )
 
@@ -24,11 +23,7 @@ var messagesListCmd = &cobra.Command{
 	Short: "Get system messages",
 	Long:  `Get system-wide messages including maintenance notifications and announcements.`,
 	Run: func(_ *cobra.Command, _ []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		messages, err := client.GetMessages()
 		if err != nil {
@@ -45,11 +40,7 @@ var messagesCreateCmd = &cobra.Command{
 	Short: "Create a system message",
 	Long:  `Create a new system-wide message.`,
 	Run: func(_ *cobra.Command, _ []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		message, err := client.CreateMessage(messageContent, messageSeverity, messageMediaType)
 		if err != nil {

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -57,11 +57,7 @@ var notificationListCmd = &cobra.Command{
 	Short: "List notifications for a repository",
 	Long:  `List all notifications (webhooks) for the specified repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		notifications, err := client.GetNotifications(notificationNamespace, notificationRepository)
 		if err != nil {
@@ -80,11 +76,7 @@ var notificationInfoCmd = &cobra.Command{
 	Short: "Get notification details",
 	Long:  `Get detailed information about a specific notification.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		notification, err := client.GetNotification(notificationNamespace, notificationRepository, notificationUUID)
 		if err != nil {
@@ -107,11 +99,7 @@ For webhook method, provide the --url flag with the webhook endpoint.
 For email method, provide the --url flag with the email address.
 For slack method, provide the --url flag with the Slack webhook URL.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		config := map[string]interface{}{}
 		switch notificationMethod {
@@ -153,13 +141,9 @@ var notificationDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.DeleteNotification(notificationNamespace, notificationRepository, notificationUUID)
+		err := client.DeleteNotification(notificationNamespace, notificationRepository, notificationUUID)
 		if err != nil {
 			fmt.Printf("Error deleting notification: %v\n", err)
 			os.Exit(1)
@@ -175,13 +159,9 @@ var notificationTestCmd = &cobra.Command{
 	Short: "Test a notification",
 	Long:  `Send a test event to the notification endpoint.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.TestNotification(notificationNamespace, notificationRepository, notificationUUID)
+		err := client.TestNotification(notificationNamespace, notificationRepository, notificationUUID)
 		if err != nil {
 			fmt.Printf("Error testing notification: %v\n", err)
 			os.Exit(1)
@@ -197,13 +177,9 @@ var notificationResetCmd = &cobra.Command{
 	Short: "Reset notification failure count",
 	Long:  `Reset the failure count for a notification that has failed.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.ResetNotification(notificationNamespace, notificationRepository, notificationUUID)
+		err := client.ResetNotification(notificationNamespace, notificationRepository, notificationUUID)
 		if err != nil {
 			fmt.Printf("Error resetting notification: %v\n", err)
 			os.Exit(1)
@@ -218,11 +194,7 @@ var notificationUpdateCmd = &cobra.Command{
 	Short: "Update a notification",
 	Long:  `Update an existing notification (webhook) configuration.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		config := map[string]interface{}{}
 		switch notificationMethod {

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -62,11 +62,7 @@ var orgInfoCmd = &cobra.Command{
 	Short: "Get organization information",
 	Long:  `Get detailed information about an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		org, err := client.GetOrganization(orgName)
 		if err != nil {
 			fmt.Printf("Error getting organization: %v\n", err)
@@ -82,11 +78,7 @@ var orgMembersCmd = &cobra.Command{
 	Short: "Get organization members",
 	Long:  `Get list of all members in an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		members, err := client.GetOrganizationMembers(orgName)
 		if err != nil {
 			fmt.Printf("Error getting organization members: %v\n", err)
@@ -102,11 +94,7 @@ var orgTeamsCmd = &cobra.Command{
 	Short: "Get organization teams",
 	Long:  `Get list of all teams in an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		teams, err := client.GetTeams(orgName)
 		if err != nil {
 			fmt.Printf("Error getting organization teams: %v\n", err)
@@ -122,11 +110,7 @@ var teamInfoCmd = &cobra.Command{
 	Short: "Get team information",
 	Long:  `Get detailed information about a specific team.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		team, err := client.GetTeam(orgName, teamName)
 		if err != nil {
 			fmt.Printf("Error getting team: %v\n", err)
@@ -142,11 +126,7 @@ var teamMembersCmd = &cobra.Command{
 	Short: "Get team members",
 	Long:  `Get list of all members in a specific team.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		members, err := client.GetTeamMembers(orgName, teamName)
 		if err != nil {
 			fmt.Printf("Error getting team members: %v\n", err)
@@ -162,11 +142,7 @@ var orgRobotsCmd = &cobra.Command{
 	Short: "Get organization robots",
 	Long:  `Get list of all robot accounts in an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		robots, err := client.GetRobotAccounts(orgName)
 		if err != nil {
 			fmt.Printf("Error getting organization robots: %v\n", err)
@@ -182,11 +158,7 @@ var orgQuotaCmd = &cobra.Command{
 	Short: "Get organization quota",
 	Long:  `Get quota information for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		quota, err := client.GetQuota(orgName)
 		if err != nil {
 			fmt.Printf("Error getting organization quota: %v\n", err)
@@ -202,11 +174,7 @@ var autoPruneCmd = &cobra.Command{
 	Short: "Get auto-prune policies",
 	Long:  `Get list of auto-prune policies for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		policies, err := client.GetAutoPrunePolicies(orgName)
 		if err != nil {
 			fmt.Printf("Error getting auto-prune policies: %v\n", err)
@@ -222,11 +190,7 @@ var orgApplicationsCmd = &cobra.Command{
 	Short: "Get organization applications",
 	Long:  `Get list of OAuth applications for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		applications, err := client.GetApplications(orgName)
 		if err != nil {
 			fmt.Printf("Error getting organization applications: %v\n", err)
@@ -242,11 +206,7 @@ var createOrgCmd = &cobra.Command{
 	Short: "Create an organization",
 	Long:  `Create a new organization with the specified name and email.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		org, err := client.CreateOrganization(orgName, email)
 		if err != nil {
 			fmt.Printf("Error creating organization: %v\n", err)
@@ -262,11 +222,7 @@ var updateOrgCmd = &cobra.Command{
 	Short: "Update an organization",
 	Long:  `Update an organization's email.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		org, err := client.UpdateOrganization(orgName, email)
 		if err != nil {
 			fmt.Printf("Error updating organization: %v\n", err)
@@ -286,12 +242,8 @@ var deleteOrgCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to delete an organization")
 			os.Exit(1)
 		}
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
-		err = client.DeleteOrganization(orgName)
+		client := mustGetClient()
+		err := client.DeleteOrganization(orgName)
 		if err != nil {
 			fmt.Printf("Error deleting organization: %v\n", err)
 			os.Exit(1)
@@ -306,12 +258,8 @@ var addMemberCmd = &cobra.Command{
 	Short: "Add a member to an organization",
 	Long:  `Add a member to an organization by member name.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
-		err = client.AddOrganizationMember(orgName, memberName)
+		client := mustGetClient()
+		err := client.AddOrganizationMember(orgName, memberName)
 		if err != nil {
 			fmt.Printf("Error adding organization member: %v\n", err)
 			os.Exit(1)
@@ -330,12 +278,8 @@ var removeMemberCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to remove a member")
 			os.Exit(1)
 		}
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
-		err = client.RemoveOrganizationMember(orgName, memberName)
+		client := mustGetClient()
+		err := client.RemoveOrganizationMember(orgName, memberName)
 		if err != nil {
 			fmt.Printf("Error removing organization member: %v\n", err)
 			os.Exit(1)
@@ -350,11 +294,7 @@ var getMemberCmd = &cobra.Command{
 	Short: "Get organization member information",
 	Long:  `Get detailed information about a specific organization member.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		member, err := client.GetOrganizationMember(orgName, memberName)
 		if err != nil {
 			fmt.Printf("Error getting organization member: %v\n", err)
@@ -370,11 +310,7 @@ var collaboratorsCmd = &cobra.Command{
 	Short: "Get organization collaborators",
 	Long:  `Get list of collaborators for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		collaborators, err := client.GetOrganizationCollaborators(orgName)
 		if err != nil {
 			fmt.Printf("Error getting organization collaborators: %v\n", err)
@@ -390,11 +326,7 @@ var orgRepositoriesCmd = &cobra.Command{
 	Short: "Get organization repositories",
 	Long:  `Get list of repositories for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		repos, err := client.GetOrganizationRepositories(orgName)
 		if err != nil {
 			fmt.Printf("Error getting organization repositories: %v\n", err)
@@ -410,11 +342,7 @@ var defaultPermissionsCmd = &cobra.Command{
 	Short: "Get default permissions",
 	Long:  `Get default permissions for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		perms, err := client.GetDefaultPermissions(orgName)
 		if err != nil {
 			fmt.Printf("Error getting default permissions: %v\n", err)
@@ -430,11 +358,7 @@ var createDefaultPermissionCmd = &cobra.Command{
 	Short: "Create a default permission",
 	Long:  `Create a default permission for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		perm, err := client.CreateDefaultPermission(orgName, role, delegateType, delegateName)
 		if err != nil {
 			fmt.Printf("Error creating default permission: %v\n", err)
@@ -454,12 +378,8 @@ var deleteDefaultPermissionCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to delete a default permission")
 			os.Exit(1)
 		}
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
-		err = client.DeleteDefaultPermission(orgName, prototypeID)
+		client := mustGetClient()
+		err := client.DeleteDefaultPermission(orgName, prototypeID)
 		if err != nil {
 			fmt.Printf("Error deleting default permission: %v\n", err)
 			os.Exit(1)
@@ -474,11 +394,7 @@ var proxyCacheCmd = &cobra.Command{
 	Short: "Get proxy cache configuration",
 	Long:  `Get proxy cache configuration for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		config, err := client.GetProxyCacheConfig(orgName)
 		if err != nil {
 			fmt.Printf("Error getting proxy cache config: %v\n", err)
@@ -494,11 +410,7 @@ var createProxyCacheCmd = &cobra.Command{
 	Short: "Create proxy cache configuration",
 	Long:  `Create proxy cache configuration for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		config, err := client.CreateProxyCacheConfig(orgName, upstreamRegistry, insecure, expiration)
 		if err != nil {
 			fmt.Printf("Error creating proxy cache config: %v\n", err)
@@ -518,12 +430,8 @@ var deleteProxyCacheCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to delete proxy cache config")
 			os.Exit(1)
 		}
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
-		err = client.DeleteProxyCacheConfig(orgName)
+		client := mustGetClient()
+		err := client.DeleteProxyCacheConfig(orgName)
 		if err != nil {
 			fmt.Printf("Error deleting proxy cache config: %v\n", err)
 			os.Exit(1)
@@ -538,11 +446,7 @@ var orgRobotCmd = &cobra.Command{
 	Short: "Get robot account information",
 	Long:  `Get detailed information about a specific robot account.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		robot, err := client.GetRobotAccount(orgName, robotShortname)
 		if err != nil {
 			fmt.Printf("Error getting robot account: %v\n", err)
@@ -558,11 +462,7 @@ var createRobotCmd = &cobra.Command{
 	Short: "Create a robot account",
 	Long:  `Create a new robot account in an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		robot, err := client.CreateRobotAccount(orgName, robotShortname, description, nil)
 		if err != nil {
 			fmt.Printf("Error creating robot account: %v\n", err)
@@ -582,12 +482,8 @@ var deleteRobotCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to delete a robot account")
 			os.Exit(1)
 		}
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
-		err = client.DeleteRobotAccount(orgName, robotShortname)
+		client := mustGetClient()
+		err := client.DeleteRobotAccount(orgName, robotShortname)
 		if err != nil {
 			fmt.Printf("Error deleting robot account: %v\n", err)
 			os.Exit(1)
@@ -602,11 +498,7 @@ var regenerateRobotCmd = &cobra.Command{
 	Short: "Regenerate a robot account token",
 	Long:  `Regenerate the token for a robot account.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		robot, err := client.RegenerateRobotToken(orgName, robotShortname)
 		if err != nil {
 			fmt.Printf("Error regenerating robot token: %v\n", err)
@@ -622,11 +514,7 @@ var orgRobotPermissionsCmd = &cobra.Command{
 	Short: "Get robot account permissions",
 	Long:  `Get permissions for a specific robot account.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		perms, err := client.GetRobotPermissions(orgName, robotShortname)
 		if err != nil {
 			fmt.Printf("Error getting robot permissions: %v\n", err)
@@ -642,12 +530,8 @@ var setRobotPermissionCmd = &cobra.Command{
 	Short: "Set robot repository permission",
 	Long:  `Set a robot account's permission on a repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
-		err = client.SetRobotRepositoryPermission(orgName, robotShortname, repository, role)
+		client := mustGetClient()
+		err := client.SetRobotRepositoryPermission(orgName, robotShortname, repository, role)
 		if err != nil {
 			fmt.Printf("Error setting robot permission: %v\n", err)
 			os.Exit(1)
@@ -666,12 +550,8 @@ var removeRobotPermissionCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to remove a robot permission")
 			os.Exit(1)
 		}
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
-		err = client.RemoveRobotRepositoryPermission(orgName, robotShortname, repository)
+		client := mustGetClient()
+		err := client.RemoveRobotRepositoryPermission(orgName, robotShortname, repository)
 		if err != nil {
 			fmt.Printf("Error removing robot permission: %v\n", err)
 			os.Exit(1)
@@ -685,11 +565,7 @@ var orgRobotFederationGetCmd = &cobra.Command{
 	Use:   "robot-federation-get",
 	Short: "Get organization robot federation configuration",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		federation, err := client.GetRobotFederation(orgName, robotShortname)
 		if err != nil {
@@ -706,17 +582,13 @@ var orgRobotFederationCreateCmd = &cobra.Command{
 	Use:   "robot-federation-create",
 	Short: "Create or update organization robot federation configuration",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		configs := []lib.RobotFederationConfig{
 			{Issuer: federationIssuer, Subject: federationSubject},
 		}
 
-		err = client.CreateRobotFederation(orgName, robotShortname, configs)
+		err := client.CreateRobotFederation(orgName, robotShortname, configs)
 		if err != nil {
 			fmt.Printf("Error creating robot federation: %v\n", err)
 			os.Exit(1)
@@ -731,13 +603,9 @@ var orgRobotFederationDeleteCmd = &cobra.Command{
 	Use:   "robot-federation-delete",
 	Short: "Delete organization robot federation configuration",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.DeleteRobotFederation(orgName, robotShortname)
+		err := client.DeleteRobotFederation(orgName, robotShortname)
 		if err != nil {
 			fmt.Printf("Error deleting robot federation: %v\n", err)
 			os.Exit(1)
@@ -753,11 +621,7 @@ var applicationCmd = &cobra.Command{
 	Short: "Get application information",
 	Long:  `Get detailed information about a specific OAuth application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		app, err := client.GetApplication(orgName, clientID)
 		if err != nil {
 			fmt.Printf("Error getting application: %v\n", err)
@@ -773,11 +637,7 @@ var createApplicationCmd = &cobra.Command{
 	Short: "Create an OAuth application",
 	Long:  `Create a new OAuth application for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		app, err := client.CreateApplication(orgName, appName, description, applicationURI, redirectURI)
 		if err != nil {
 			fmt.Printf("Error creating application: %v\n", err)
@@ -793,11 +653,7 @@ var updateApplicationCmd = &cobra.Command{
 	Short: "Update an OAuth application",
 	Long:  `Update an existing OAuth application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		app, err := client.UpdateApplication(orgName, clientID, appName, description, applicationURI, redirectURI)
 		if err != nil {
 			fmt.Printf("Error updating application: %v\n", err)
@@ -817,12 +673,8 @@ var deleteApplicationCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to delete an application")
 			os.Exit(1)
 		}
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
-		err = client.DeleteApplication(orgName, clientID)
+		client := mustGetClient()
+		err := client.DeleteApplication(orgName, clientID)
 		if err != nil {
 			fmt.Printf("Error deleting application: %v\n", err)
 			os.Exit(1)
@@ -837,11 +689,7 @@ var resetApplicationSecretCmd = &cobra.Command{
 	Short: "Reset application client secret",
 	Long:  `Reset the client secret for an OAuth application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		app, err := client.ResetApplicationClientSecret(orgName, clientID)
 		if err != nil {
 			fmt.Printf("Error resetting application secret: %v\n", err)
@@ -857,11 +705,7 @@ var marketplaceCmd = &cobra.Command{
 	Short: "Get organization marketplace information",
 	Long:  `Get marketplace information for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		marketplace, err := client.GetOrganizationMarketplace(orgName)
 		if err != nil {
 			fmt.Printf("Error getting marketplace info: %v\n", err)
@@ -877,12 +721,8 @@ var createMarketplaceSubscriptionCmd = &cobra.Command{
 	Short: "Create a marketplace subscription",
 	Long:  `Create a marketplace subscription for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
-		err = client.CreateOrganizationMarketplaceSubscription(orgName, &lib.MarketplaceSubscriptionRequest{SKU: sku, Quantity: quantity})
+		client := mustGetClient()
+		err := client.CreateOrganizationMarketplaceSubscription(orgName, &lib.MarketplaceSubscriptionRequest{SKU: sku, Quantity: quantity})
 		if err != nil {
 			fmt.Printf("Error creating marketplace subscription: %v\n", err)
 			os.Exit(1)
@@ -901,12 +741,8 @@ var deleteMarketplaceSubscriptionCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to delete a marketplace subscription")
 			os.Exit(1)
 		}
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
-		err = client.DeleteOrganizationMarketplaceSubscription(orgName, subscriptionID)
+		client := mustGetClient()
+		err := client.DeleteOrganizationMarketplaceSubscription(orgName, subscriptionID)
 		if err != nil {
 			fmt.Printf("Error deleting marketplace subscription: %v\n", err)
 			os.Exit(1)
@@ -925,12 +761,8 @@ var batchRemoveSubscriptionsCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to batch remove subscriptions")
 			os.Exit(1)
 		}
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
-		err = client.BatchRemoveOrganizationMarketplaceSubscriptions(orgName, subscriptionIDs)
+		client := mustGetClient()
+		err := client.BatchRemoveOrganizationMarketplaceSubscriptions(orgName, subscriptionIDs)
 		if err != nil {
 			fmt.Printf("Error batch removing subscriptions: %v\n", err)
 			os.Exit(1)
@@ -945,11 +777,7 @@ var createQuotaCmd = &cobra.Command{
 	Short: "Create organization quota",
 	Long:  `Create a quota for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		quota, err := client.CreateQuota(orgName, limitBytes)
 		if err != nil {
 			fmt.Printf("Error creating quota: %v\n", err)
@@ -965,11 +793,7 @@ var updateQuotaCmd = &cobra.Command{
 	Short: "Update organization quota",
 	Long:  `Update the quota for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		quota, err := client.UpdateQuota(orgName, limitBytes)
 		if err != nil {
 			fmt.Printf("Error updating quota: %v\n", err)
@@ -989,12 +813,8 @@ var deleteQuotaCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to delete a quota")
 			os.Exit(1)
 		}
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
-		err = client.DeleteQuota(orgName)
+		client := mustGetClient()
+		err := client.DeleteQuota(orgName)
 		if err != nil {
 			fmt.Printf("Error deleting quota: %v\n", err)
 			os.Exit(1)
@@ -1009,11 +829,7 @@ var autoPrunePolicyCmd = &cobra.Command{
 	Short: "Get a specific auto-prune policy",
 	Long:  `Get detailed information about a specific auto-prune policy.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		policy, err := client.GetAutoPrunePolicy(orgName, policyUUID)
 		if err != nil {
 			fmt.Printf("Error getting auto-prune policy: %v\n", err)
@@ -1029,11 +845,7 @@ var createAutoPruneCmd = &cobra.Command{
 	Short: "Create an auto-prune policy",
 	Long:  `Create an auto-prune policy for an organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		policy, err := client.CreateAutoPrunePolicy(orgName, method, pruneValue, tagPattern)
 		if err != nil {
 			fmt.Printf("Error creating auto-prune policy: %v\n", err)
@@ -1049,11 +861,7 @@ var updateAutoPruneCmd = &cobra.Command{
 	Short: "Update an auto-prune policy",
 	Long:  `Update an existing auto-prune policy.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 		policy, err := client.UpdateAutoPrunePolicy(orgName, policyUUID, method, pruneValue, tagPattern)
 		if err != nil {
 			fmt.Printf("Error updating auto-prune policy: %v\n", err)
@@ -1073,12 +881,8 @@ var deleteAutoPruneCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to delete an auto-prune policy")
 			os.Exit(1)
 		}
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
-		err = client.DeleteAutoPrunePolicy(orgName, policyUUID)
+		client := mustGetClient()
+		err := client.DeleteAutoPrunePolicy(orgName, policyUUID)
 		if err != nil {
 			fmt.Printf("Error deleting auto-prune policy: %v\n", err)
 			os.Exit(1)
@@ -1093,12 +897,8 @@ var inviteMemberCmd = &cobra.Command{
 	Short: "Invite a member to a team",
 	Long:  `Invite a member to a team by email.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
-		err = client.InviteTeamMember(orgName, teamName, email)
+		client := mustGetClient()
+		err := client.InviteTeamMember(orgName, teamName, email)
 		if err != nil {
 			fmt.Printf("Error inviting team member: %v\n", err)
 			os.Exit(1)
@@ -1117,12 +917,8 @@ var cancelInviteCmd = &cobra.Command{
 			fmt.Println("Error: must pass --confirm to cancel an invite")
 			os.Exit(1)
 		}
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
-		err = client.DeleteTeamInvite(orgName, teamName, email)
+		client := mustGetClient()
+		err := client.DeleteTeamInvite(orgName, teamName, email)
 		if err != nil {
 			fmt.Printf("Error canceling team invite: %v\n", err)
 			os.Exit(1)

--- a/cmd/permissions.go
+++ b/cmd/permissions.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
 )
 
@@ -35,11 +34,7 @@ var permListCmd = &cobra.Command{
 	Short: "List repository permissions",
 	Long:  `List all users and robots that have permissions on this repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		permissions, err := client.GetRepositoryPermissions(namespace, repository)
 		if err != nil {
@@ -58,13 +53,9 @@ var permSetCmd = &cobra.Command{
 	Short: "Set permission for a user/robot",
 	Long:  `Set permission level for a user or robot account on this repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.SetRepositoryPermission(namespace, repository, permissionUser, permissionRole)
+		err := client.SetRepositoryPermission(namespace, repository, permissionUser, permissionRole)
 		if err != nil {
 			fmt.Printf("Error setting repository permission: %v\n", err)
 			os.Exit(1)
@@ -81,13 +72,9 @@ var permRemoveCmd = &cobra.Command{
 	Short: "Remove permission for a user/robot",
 	Long:  `Remove permission for a user or robot account from this repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.RemoveRepositoryPermission(namespace, repository, permissionUser)
+		err := client.RemoveRepositoryPermission(namespace, repository, permissionUser)
 		if err != nil {
 			fmt.Printf("Error removing repository permission: %v\n", err)
 			os.Exit(1)
@@ -102,11 +89,7 @@ var permUserPermissionsCmd = &cobra.Command{
 	Use:   "user-permissions",
 	Short: "List user permissions on repository",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		permissions, err := client.ListUserPermissions(namespace, repository)
 		if err != nil {
@@ -122,11 +105,7 @@ var permUserPermissionCmd = &cobra.Command{
 	Use:   "user-permission",
 	Short: "Get specific user permission on repository",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		permission, err := client.GetUserPermission(namespace, repository, permissionUser)
 		if err != nil {
@@ -142,13 +121,9 @@ var permSetUserPermCmd = &cobra.Command{
 	Use:   "set-user-permission",
 	Short: "Set user permission on repository",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.SetUserPermission(namespace, repository, permissionUser, permissionRole)
+		err := client.SetUserPermission(namespace, repository, permissionUser, permissionRole)
 		if err != nil {
 			fmt.Printf("Error setting user permission: %v\n", err)
 			os.Exit(1)
@@ -170,13 +145,9 @@ var permDeleteUserPermCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.DeleteUserPermission(namespace, repository, permissionUser)
+		err := client.DeleteUserPermission(namespace, repository, permissionUser)
 		if err != nil {
 			fmt.Printf("Error deleting user permission: %v\n", err)
 			os.Exit(1)
@@ -191,11 +162,7 @@ var permUserTransitiveCmd = &cobra.Command{
 	Use:   "user-transitive-permission",
 	Short: "Get user transitive permission on repository",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		permission, err := client.GetUserTransitivePermission(namespace, repository, permissionUser)
 		if err != nil {
@@ -211,11 +178,7 @@ var permTeamPermissionsCmd = &cobra.Command{
 	Use:   "team-permissions",
 	Short: "List team permissions on repository",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		permissions, err := client.ListTeamPermissions(namespace, repository)
 		if err != nil {
@@ -231,11 +194,7 @@ var permTeamPermissionCmd = &cobra.Command{
 	Use:   "team-permission",
 	Short: "Get specific team permission on repository",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		permission, err := client.GetTeamPermission(namespace, repository, permissionTeamName)
 		if err != nil {
@@ -251,13 +210,9 @@ var permSetTeamPermCmd = &cobra.Command{
 	Use:   "set-team-permission",
 	Short: "Set team permission on repository",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.SetTeamPermission(namespace, repository, permissionTeamName, permissionRole)
+		err := client.SetTeamPermission(namespace, repository, permissionTeamName, permissionRole)
 		if err != nil {
 			fmt.Printf("Error setting team permission: %v\n", err)
 			os.Exit(1)
@@ -279,13 +234,9 @@ var permDeleteTeamPermCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.DeleteTeamPermission(namespace, repository, permissionTeamName)
+		err := client.DeleteTeamPermission(namespace, repository, permissionTeamName)
 		if err != nil {
 			fmt.Printf("Error deleting team permission: %v\n", err)
 			os.Exit(1)

--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -45,11 +45,7 @@ var prototypeListCmd = &cobra.Command{
 	Short: "List all permission prototypes",
 	Long:  `List all permission prototypes for an organization.`,
 	Run: func(_ *cobra.Command, _ []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		prototypes, err := client.GetPrototypes(prototypeOrg)
 		if err != nil {
@@ -77,11 +73,7 @@ var prototypeInfoCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		prototype, err := client.GetPrototype(prototypeOrg, prototypeUUID)
 		if err != nil {
@@ -127,11 +119,7 @@ Roles:
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		createReq := &lib.CreatePrototypeRequest{
 			Delegate: lib.PrototypeDelegateRequest{
@@ -171,11 +159,7 @@ var prototypeUpdateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		updateReq := &lib.UpdatePrototypeRequest{
 			Role: prototypeRole,
@@ -211,13 +195,9 @@ var prototypeDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.DeletePrototype(prototypeOrg, prototypeUUID)
+		err := client.DeletePrototype(prototypeOrg, prototypeUUID)
 		if err != nil {
 			fmt.Println("Error deleting prototype:", err)
 			os.Exit(1)

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -8,7 +8,6 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
 )
 
@@ -47,11 +46,7 @@ var repoInfoCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		repo, err := client.GetRepository(namespace, repository)
 		if err != nil {
@@ -74,11 +69,7 @@ var repoCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		repo, err := client.CreateRepository(namespace, repository, repoVisibility, repoDescription)
 		if err != nil {
@@ -102,11 +93,7 @@ var repoUpdateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		repo, err := client.UpdateRepository(namespace, repository, repoDescription, repoVisibility)
 		if err != nil {
@@ -136,13 +123,9 @@ var repoDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.DeleteRepository(namespace, repository)
+		err := client.DeleteRepository(namespace, repository)
 		if err != nil {
 			fmt.Printf("Error deleting repository: %v\n", err)
 			os.Exit(1)
@@ -168,11 +151,7 @@ Use --table with --popularity for an enriched dashboard sorted by pull count:
   certsuite                   774    6             51    unstable    2026-06-15  yes
   collector                   32     4             46    unstable    2026-06-15  no`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		repos, err := client.ListRepositories(namespace, repoPublic, repoStarred, repoPopularity, repoPage, repoLimit)
 		if err != nil {
@@ -250,13 +229,9 @@ var repoChangeVisibilityCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.ChangeRepositoryVisibility(namespace, repository, repoVisibility)
+		err := client.ChangeRepositoryVisibility(namespace, repository, repoVisibility)
 		if err != nil {
 			fmt.Printf("Error changing repository visibility: %v\n", err)
 			os.Exit(1)

--- a/cmd/repotoken.go
+++ b/cmd/repotoken.go
@@ -46,11 +46,7 @@ var repotokenListCmd = &cobra.Command{
 	Short: "List all repository tokens",
 	Long:  `List all tokens for a repository. (DEPRECATED - use robot accounts)`,
 	Run: func(_ *cobra.Command, _ []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		tokens, err := client.GetRepoTokens(repoTokenNamespace, repoTokenRepository) //nolint:staticcheck // Intentionally using deprecated API
 		if err != nil {
@@ -78,11 +74,7 @@ var repotokenInfoCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		repoToken, err := client.GetRepoToken(repoTokenNamespace, repoTokenRepository, repoTokenCode) //nolint:staticcheck // Intentionally using deprecated API
 		if err != nil {
@@ -110,11 +102,7 @@ var repotokenCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		createReq := &lib.CreateRepoTokenRequest{
 			FriendlyName: repoTokenName,
@@ -150,11 +138,7 @@ var repotokenUpdateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		updateReq := &lib.UpdateRepoTokenRequest{
 			Role: repoTokenRole,
@@ -190,13 +174,9 @@ var repotokenDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.DeleteRepoToken(repoTokenNamespace, repoTokenRepository, repoTokenCode) //nolint:staticcheck // Intentionally using deprecated API
+		err := client.DeleteRepoToken(repoTokenNamespace, repoTokenRepository, repoTokenCode) //nolint:staticcheck // Intentionally using deprecated API
 		if err != nil {
 			fmt.Println("Error deleting token:", err)
 			os.Exit(1)

--- a/cmd/robot.go
+++ b/cmd/robot.go
@@ -40,11 +40,7 @@ var robotListCmd = &cobra.Command{
 	Short: "List all robot accounts",
 	Long:  `List all robot accounts associated with your user account.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		robots, err := client.GetUserRobotAccounts()
 		if err != nil {
@@ -63,11 +59,7 @@ var robotInfoCmd = &cobra.Command{
 	Short: "Get robot account details",
 	Long:  `Get detailed information about a specific robot account including its token.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		robot, err := client.GetUserRobotAccount(robotShortname)
 		if err != nil {
@@ -86,11 +78,7 @@ var robotCreateCmd = &cobra.Command{
 	Short: "Create a new robot account",
 	Long:  `Create a new robot account with the specified name and description.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		robot, err := client.CreateUserRobotAccount(robotShortname, robotDescription, nil)
 		if err != nil {
@@ -116,13 +104,9 @@ var robotDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.DeleteUserRobotAccount(robotShortname)
+		err := client.DeleteUserRobotAccount(robotShortname)
 		if err != nil {
 			fmt.Printf("Error deleting robot account: %v\n", err)
 			os.Exit(1)
@@ -138,11 +122,7 @@ var robotRegenerateCmd = &cobra.Command{
 	Short: "Regenerate robot token",
 	Long:  `Regenerate the token for a robot account. The old token will be invalidated.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		robot, err := client.RegenerateUserRobotToken(robotShortname)
 		if err != nil {
@@ -162,11 +142,7 @@ var robotPermissionsCmd = &cobra.Command{
 	Short: "Get robot repository permissions",
 	Long:  `Get the repository permissions assigned to a robot account.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		permissions, err := client.GetUserRobotPermissions(robotShortname)
 		if err != nil {
@@ -184,11 +160,7 @@ var robotFederationGetCmd = &cobra.Command{
 	Use:   "federation-get",
 	Short: "Get robot federation configuration",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		federation, err := client.GetUserRobotFederation(robotShortname)
 		if err != nil {
@@ -205,17 +177,13 @@ var robotFederationCreateCmd = &cobra.Command{
 	Use:   "federation-create",
 	Short: "Create or update robot federation configuration",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		configs := []lib.RobotFederationConfig{
 			{Issuer: federationIssuer, Subject: federationSubject},
 		}
 
-		err = client.CreateUserRobotFederation(robotShortname, configs)
+		err := client.CreateUserRobotFederation(robotShortname, configs)
 		if err != nil {
 			fmt.Printf("Error creating robot federation: %v\n", err)
 			os.Exit(1)
@@ -230,13 +198,9 @@ var robotFederationDeleteCmd = &cobra.Command{
 	Use:   "federation-delete",
 	Short: "Delete robot federation configuration",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.DeleteUserRobotFederation(robotShortname)
+		err := client.DeleteUserRobotFederation(robotShortname)
 		if err != nil {
 			fmt.Printf("Error deleting robot federation: %v\n", err)
 			os.Exit(1)

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
 )
 
@@ -30,11 +29,7 @@ var searchReposCmd = &cobra.Command{
 	Short: "Search for repositories",
 	Long:  `Search for repositories on Quay.io by name or description.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		result, err := client.SearchRepositories(searchQuery, searchPage)
 		if err != nil {
@@ -60,11 +55,7 @@ Results include a 'kind' field indicating the entity type:
   - team: Team within an organization
   - robot: Robot account`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		result, err := client.SearchAll(searchQuery)
 		if err != nil {

--- a/cmd/secscan.go
+++ b/cmd/secscan.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
 )
 
@@ -39,11 +38,7 @@ The scan status can be:
   - unsupported: Image type is not supported for scanning
   - failed: Scan failed`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		security, err := client.GetManifestSecurity(namespace, repository, secScanManifestRef, includeVulnerabilities)
 		if err != nil {

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
 )
 
@@ -35,11 +34,7 @@ var tagInfoCmd = &cobra.Command{
 	Short: "Get detailed tag information",
 	Long:  `Get detailed information about a specific tag including metadata, manifest digest, and size.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		tag, err := client.GetTag(namespace, repository, tagName)
 		if err != nil {
@@ -58,11 +53,7 @@ var tagUpdateCmd = &cobra.Command{
 	Short: "Update tag metadata",
 	Long:  `Update tag metadata such as expiration date.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		tag, err := client.UpdateTag(namespace, repository, tagName, tagExpiration)
 		if err != nil {
@@ -87,13 +78,9 @@ var tagDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.DeleteTag(namespace, repository, tagName)
+		err := client.DeleteTag(namespace, repository, tagName)
 		if err != nil {
 			fmt.Printf("Error deleting tag: %v\n", err)
 			os.Exit(1)
@@ -109,11 +96,7 @@ var tagHistoryCmd = &cobra.Command{
 	Short: "Get tag history",
 	Long:  `Get the history of changes for a specific tag, including previous versions and modifications.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		history, err := client.GetTagHistory(namespace, repository, tagName)
 		if err != nil {
@@ -132,11 +115,7 @@ var tagRevertCmd = &cobra.Command{
 	Short: "Revert tag to a previous state",
 	Long:  `Revert a tag to a previous state using its manifest digest.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		tag, err := client.RevertTag(namespace, repository, tagName, manifestDigest)
 		if err != nil {
@@ -154,13 +133,9 @@ var tagRestoreCmd = &cobra.Command{
 	Short: "Restore a tag from a previous state",
 	Long:  `Restore a previously deleted or modified tag using its manifest digest.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.RestoreTag(namespace, repository, tagName, manifestDigest)
+		err := client.RestoreTag(namespace, repository, tagName, manifestDigest)
 		if err != nil {
 			fmt.Printf("Error restoring tag: %v\n", err)
 			os.Exit(1)

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
 )
 
@@ -49,11 +48,7 @@ var teamListCmd = &cobra.Command{
 	Short: "List all teams in an organization",
 	Long:  `List all teams within the specified organization.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		teams, err := client.GetTeams(teamCmdOrgname)
 		if err != nil {
@@ -72,11 +67,7 @@ var teamCmdInfoCmd = &cobra.Command{
 	Short: "Get team details",
 	Long:  `Get detailed information about a specific team.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		team, err := client.GetTeam(teamCmdOrgname, teamCmdName)
 		if err != nil {
@@ -100,11 +91,7 @@ Roles:
   - creator: Can create new repositories
   - admin: Full administrative access`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		team, err := client.CreateTeam(teamCmdOrgname, teamCmdName, teamCmdDescription, teamCmdRole)
 		if err != nil {
@@ -123,11 +110,7 @@ var teamUpdateCmd = &cobra.Command{
 	Short: "Update team settings",
 	Long:  `Update team description and role.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		team, err := client.UpdateTeam(teamCmdOrgname, teamCmdName, teamCmdDescription, teamCmdRole)
 		if err != nil {
@@ -152,13 +135,9 @@ var teamDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.DeleteTeam(teamCmdOrgname, teamCmdName)
+		err := client.DeleteTeam(teamCmdOrgname, teamCmdName)
 		if err != nil {
 			fmt.Printf("Error deleting team: %v\n", err)
 			os.Exit(1)
@@ -174,11 +153,7 @@ var teamCmdMembersCmd = &cobra.Command{
 	Short: "List team members",
 	Long:  `List all members of a specific team.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		members, err := client.GetTeamMembers(teamCmdOrgname, teamCmdName)
 		if err != nil {
@@ -197,13 +172,9 @@ var teamAddMemberCmd = &cobra.Command{
 	Short: "Add a member to a team",
 	Long:  `Add a user or robot account to a team.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.AddTeamMember(teamCmdOrgname, teamCmdName, teamCmdMemberName)
+		err := client.AddTeamMember(teamCmdOrgname, teamCmdName, teamCmdMemberName)
 		if err != nil {
 			fmt.Printf("Error adding team member: %v\n", err)
 			os.Exit(1)
@@ -225,13 +196,9 @@ var teamRemoveMemberCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.RemoveTeamMember(teamCmdOrgname, teamCmdName, teamCmdMemberName)
+		err := client.RemoveTeamMember(teamCmdOrgname, teamCmdName, teamCmdMemberName)
 		if err != nil {
 			fmt.Printf("Error removing team member: %v\n", err)
 			os.Exit(1)
@@ -247,11 +214,7 @@ var teamPermissionsCmd = &cobra.Command{
 	Short: "List team repository permissions",
 	Long:  `List all repository permissions for a team.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		permissions, err := client.GetTeamPermissions(teamCmdOrgname, teamCmdName)
 		if err != nil {
@@ -275,13 +238,9 @@ Permission roles:
   - write: Pull and push images
   - admin: Full administrative access`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.SetTeamRepositoryPermission(teamCmdOrgname, teamCmdName, teamCmdRepository, teamCmdPermissionRole)
+		err := client.SetTeamRepositoryPermission(teamCmdOrgname, teamCmdName, teamCmdRepository, teamCmdPermissionRole)
 		if err != nil {
 			fmt.Printf("Error setting team permission: %v\n", err)
 			os.Exit(1)
@@ -305,13 +264,9 @@ var teamRemovePermissionCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.RemoveTeamRepositoryPermission(teamCmdOrgname, teamCmdName, teamCmdRepository)
+		err := client.RemoveTeamRepositoryPermission(teamCmdOrgname, teamCmdName, teamCmdRepository)
 		if err != nil {
 			fmt.Printf("Error removing team permission: %v\n", err)
 			os.Exit(1)

--- a/cmd/trigger.go
+++ b/cmd/trigger.go
@@ -46,11 +46,7 @@ var triggerListCmd = &cobra.Command{
 	Short: "List all build triggers for a repository",
 	Long:  `List all build triggers configured for a repository.`,
 	Run: func(_ *cobra.Command, _ []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		triggers, err := client.GetTriggers(triggerNamespace, triggerRepository)
 		if err != nil {
@@ -78,11 +74,7 @@ var triggerInfoCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		trigger, err := client.GetTrigger(triggerNamespace, triggerRepository, triggerUUID)
 		if err != nil {
@@ -110,13 +102,9 @@ var triggerDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.DeleteTrigger(triggerNamespace, triggerRepository, triggerUUID)
+		err := client.DeleteTrigger(triggerNamespace, triggerRepository, triggerUUID)
 		if err != nil {
 			fmt.Println("Error deleting trigger:", err)
 			os.Exit(1)
@@ -137,11 +125,7 @@ var triggerEnableCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		trigger, err := client.UpdateTrigger(triggerNamespace, triggerRepository, triggerUUID, true)
 		if err != nil {
@@ -169,11 +153,7 @@ var triggerDisableCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		trigger, err := client.UpdateTrigger(triggerNamespace, triggerRepository, triggerUUID, false)
 		if err != nil {
@@ -201,11 +181,7 @@ var triggerStartCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		var triggerReq *lib.ManualTriggerRequest
 		if triggerCommitSHA != "" {
@@ -240,11 +216,7 @@ var triggerActivateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		activateReq := &lib.ActivateTriggerRequest{}
 		if triggerPullRobot != "" {
@@ -276,11 +248,7 @@ var triggerBuildsCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Println("Error creating client:", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		builds, err := client.GetTriggerBuilds(triggerNamespace, triggerRepository, triggerUUID, triggerBuildLimit)
 		if err != nil {

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
 )
 
@@ -27,11 +26,7 @@ var userInfoCmd = &cobra.Command{
 	Short: "Get current user information",
 	Long:  `Get detailed information about the currently authenticated user account.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		user, err := client.GetUser()
 		if err != nil {
@@ -50,11 +45,7 @@ var userStarredCmd = &cobra.Command{
 	Short: "List starred repositories",
 	Long:  `List all repositories starred by the current user.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		starred, err := client.GetStarredRepositories()
 		if err != nil {
@@ -73,13 +64,9 @@ var starRepoCmd = &cobra.Command{
 	Short: "Star a repository",
 	Long:  `Add a repository to your starred list for easy discovery.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.StarRepository(namespace, repository)
+		err := client.StarRepository(namespace, repository)
 		if err != nil {
 			fmt.Printf("Error starring repository: %v\n", err)
 			os.Exit(1)
@@ -95,13 +82,9 @@ var unstarRepoCmd = &cobra.Command{
 	Short: "Unstar a repository",
 	Long:  `Remove a repository from your starred list.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.UnstarRepository(namespace, repository)
+		err := client.UnstarRepository(namespace, repository)
 		if err != nil {
 			fmt.Printf("Error unstarring repository: %v\n", err)
 			os.Exit(1)
@@ -118,11 +101,7 @@ var userLookupCmd = &cobra.Command{
 	Short: "Look up a user by username",
 	Long:  `Get information about a specific user by their username.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		user, err := client.GetUserByUsername(lookupUsername)
 		if err != nil {
@@ -139,11 +118,7 @@ var userMarketplaceCmd = &cobra.Command{
 	Short: "Get user marketplace information",
 	Long:  `Get marketplace subscription information for the current user.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
 		marketplace, err := client.GetUserMarketplace()
 		if err != nil {
@@ -160,13 +135,9 @@ var starUserRepoCmd = &cobra.Command{
 	Short: "Star a repository (user endpoint)",
 	Long:  `Add a repository to your starred list using the user star endpoint.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.StarUserRepository(namespace, repository)
+		err := client.StarUserRepository(namespace, repository)
 		if err != nil {
 			fmt.Printf("Error starring repository: %v\n", err)
 			os.Exit(1)
@@ -181,13 +152,9 @@ var unstarUserRepoCmd = &cobra.Command{
 	Short: "Unstar a repository (user endpoint)",
 	Long:  `Remove a repository from your starred list using the user star endpoint.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithURL(token, quayURL)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := mustGetClient()
 
-		err = client.UnstarUserRepository(namespace, repository)
+		err := client.UnstarUserRepository(namespace, repository)
 		if err != nil {
 			fmt.Printf("Error unstarring repository: %v\n", err)
 			os.Exit(1)


### PR DESCRIPTION
Adds `mustGetClient()` helper and replaces **167 instances** of duplicated client creation boilerplate across all command files.

## Problem
Every command file had this 6-line pattern repeated:
```go
client, err := lib.NewClientWithURL(token, quayURL)
if err != nil {
    fmt.Printf("Error creating client: %v\n", err)
    os.Exit(1)
}
```

167 instances × 6 lines = ~1000 lines of duplication across 21 files.

## Solution
Extract to helper:
```go
func mustGetClient() *lib.Client {
    client, err := lib.NewClientWithURL(token, quayURL)
    if err != nil {
        fmt.Printf("Error creating client: %v\n", err)
        os.Exit(1)
    }
    return client
}
```

Replace all with:
```go
client := mustGetClient()
```

## Impact
- ✅ **663 lines removed** (-894 +231)
- ✅ Consistent client creation across all commands
- ✅ Easier to update error handling or client initialization in future
- ✅ All tests pass

## Files Changed
21 command files + helpers.go