### PR TITLE
fix: handle Execute() error in main and make auth header consistent

### DIFF
--- a/lib/client.go
+++ b/lib/client.go
@@ -89,7 +89,9 @@ func (c *Client) get(req *http.Request, v any) error {
 }
 
 func (c *Client) post(req *http.Request, v any) error {
-	req.Header.Set("Authorization", "Bearer "+c.BearerToken)
+	if c.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.BearerToken)
+	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.HTTPClient.Do(req)
@@ -112,7 +114,9 @@ func (c *Client) post(req *http.Request, v any) error {
 }
 
 func (c *Client) put(req *http.Request, v any) error {
-	req.Header.Set("Authorization", "Bearer "+c.BearerToken)
+	if c.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.BearerToken)
+	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.HTTPClient.Do(req)
@@ -135,7 +139,9 @@ func (c *Client) put(req *http.Request, v any) error {
 }
 
 func (c *Client) delete(req *http.Request) error {
-	req.Header.Set("Authorization", "Bearer "+c.BearerToken)
+	if c.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.BearerToken)
+	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.HTTPClient.Do(req)

--- a/main.go
+++ b/main.go
@@ -1,10 +1,16 @@
 package main
 
-import "github.com/sebrandon1/go-quay/cmd"
+import (
+	"os"
+
+	"github.com/sebrandon1/go-quay/cmd"
+)
 
 var version = "dev"
 
 func main() {
 	cmd.SetVersion(version)
-	_ = cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
## Summary

- **main.go**: Exit with code 1 when `cmd.Execute()` returns an error instead of silently swallowing it with `_ = cmd.Execute()`. Scripts relying on exit codes can now detect failures.
- **lib/client.go**: Make `post()`, `put()`, and `delete()` conditionally set the Authorization header (matching `get()`) to avoid sending a malformed `Authorization: Bearer ` header when the token is empty.

## Test plan

- [x] `make lint` passes (0 issues)
- [x] `make test` passes (all 240 tests)
- [ ] CI checks pass

Fixes #119
Fixes #120