### PR TITLE
security: escape URL path segments and bound error response reads

### DIFF
--- a/lib/billing.go
+++ b/lib/billing.go
@@ -26,7 +26,7 @@ import (
 // GetOrganizationBilling returns billing information for an organization
 func (c *Client) GetOrganizationBilling(orgname string) (*BillingInfo, error) {
 	// Get new request
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/plan", c.BaseURL, orgname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/plan", orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (c *Client) GetUserBilling() (*BillingInfo, error) {
 // GetOrganizationSubscription returns subscription details for an organization
 func (c *Client) GetOrganizationSubscription(orgname string) (*Subscription, error) {
 	// Get new request
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/plan", c.BaseURL, orgname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/plan", orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func (c *Client) GetUserSubscription() (*Subscription, error) {
 // GetOrganizationInvoices returns invoices for an organization
 func (c *Client) GetOrganizationInvoices(orgname string) ([]Invoice, error) {
 	// Get new request
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/invoices", c.BaseURL, orgname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/invoices", orgname), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/build.go
+++ b/lib/build.go
@@ -21,7 +21,7 @@ import (
 
 // GetBuilds retrieves a list of builds for a repository
 func (c *Client) GetBuilds(namespace, repository string, limit int) (*Builds, error) {
-	url := fmt.Sprintf("%s/repository/%s/%s/build/", c.BaseURL, namespace, repository)
+	url := c.buildURL("/repository/%s/%s/build/", namespace, repository)
 	if limit > 0 {
 		url = fmt.Sprintf("%s?limit=%d", url, limit)
 	}
@@ -41,7 +41,7 @@ func (c *Client) GetBuilds(namespace, repository string, limit int) (*Builds, er
 
 // GetBuild retrieves a specific build by UUID
 func (c *Client) GetBuild(namespace, repository, buildUUID string) (*Build, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/build/%s", c.BaseURL, namespace, repository, buildUUID), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/build/%s", namespace, repository, buildUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get build request: %w", err)
 	}
@@ -56,7 +56,7 @@ func (c *Client) GetBuild(namespace, repository, buildUUID string) (*Build, erro
 
 // GetBuildLogs retrieves the logs for a specific build
 func (c *Client) GetBuildLogs(namespace, repository, buildUUID string) (*BuildLogs, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/build/%s/logs", c.BaseURL, namespace, repository, buildUUID), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/build/%s/logs", namespace, repository, buildUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get build logs request: %w", err)
 	}
@@ -71,7 +71,7 @@ func (c *Client) GetBuildLogs(namespace, repository, buildUUID string) (*BuildLo
 
 // RequestBuild triggers a new build for a repository
 func (c *Client) RequestBuild(namespace, repository string, buildRequest *RequestBuildRequest) (*Build, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/build/", c.BaseURL, namespace, repository), buildRequest)
+	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/build/", namespace, repository), buildRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request build request: %w", err)
 	}
@@ -86,7 +86,7 @@ func (c *Client) RequestBuild(namespace, repository string, buildRequest *Reques
 
 // CancelBuild cancels an ongoing build
 func (c *Client) CancelBuild(namespace, repository, buildUUID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/build/%s", c.BaseURL, namespace, repository, buildUUID), nil)
+	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/build/%s", namespace, repository, buildUUID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create cancel build request: %w", err)
 	}
@@ -100,7 +100,7 @@ func (c *Client) CancelBuild(namespace, repository, buildUUID string) error {
 
 // GetBuildStatus gets the status of a build
 func (c *Client) GetBuildStatus(namespace, repository, buildUUID string) (*BuildStatus, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/build/%s/status", c.BaseURL, namespace, repository, buildUUID), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/build/%s/status", namespace, repository, buildUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get build status request: %w", err)
 	}

--- a/lib/client.go
+++ b/lib/client.go
@@ -33,8 +33,11 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 )
+
+const maxErrorBodySize = 1 << 20 // 1 MB
 
 // DefaultQuayURL is the default Quay.io API base URL.
 const DefaultQuayURL = "https://quay.io/api/v1"
@@ -67,6 +70,18 @@ func NewClient(bearerToken string) (*Client, error) {
 	return NewClientWithURL(bearerToken, DefaultQuayURL)
 }
 
+func (c *Client) buildURL(pathFmt string, args ...any) string {
+	escaped := make([]any, len(args))
+	for i, a := range args {
+		if s, ok := a.(string); ok {
+			escaped[i] = url.PathEscape(s)
+		} else {
+			escaped[i] = a
+		}
+	}
+	return c.BaseURL + fmt.Sprintf(pathFmt, escaped...)
+}
+
 func (c *Client) get(req *http.Request, v any) error {
 	if c.BearerToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.BearerToken)
@@ -81,7 +96,7 @@ func (c *Client) get(req *http.Request, v any) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
 		return fmt.Errorf("unexpected status code: %d, response: %s", resp.StatusCode, string(body))
 	}
 
@@ -102,7 +117,7 @@ func (c *Client) post(req *http.Request, v any) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
 		return fmt.Errorf("unexpected status code: %d, response: %s", resp.StatusCode, string(body))
 	}
 
@@ -127,7 +142,7 @@ func (c *Client) put(req *http.Request, v any) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
 		return fmt.Errorf("unexpected status code: %d, response: %s", resp.StatusCode, string(body))
 	}
 
@@ -152,7 +167,7 @@ func (c *Client) delete(req *http.Request) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
 		return fmt.Errorf("unexpected status code: %d, response: %s", resp.StatusCode, string(body))
 	}
 

--- a/lib/discovery.go
+++ b/lib/discovery.go
@@ -17,7 +17,7 @@ import (
 
 // GetDiscovery retrieves API discovery information
 func (c *Client) GetDiscovery() (*Discovery, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/discovery", c.BaseURL), nil)
+	req, err := newRequest("GET", c.buildURL("/discovery"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discovery request: %w", err)
 	}
@@ -32,7 +32,7 @@ func (c *Client) GetDiscovery() (*Discovery, error) {
 
 // GetRegistryCapabilities retrieves the registry capabilities including sparse manifest support and mirror architectures
 func (c *Client) GetRegistryCapabilities() (*RegistryCapabilities, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/registry/capabilities", c.BaseURL), nil)
+	req, err := newRequest("GET", c.buildURL("/registry/capabilities"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create registry capabilities request: %w", err)
 	}
@@ -47,7 +47,7 @@ func (c *Client) GetRegistryCapabilities() (*RegistryCapabilities, error) {
 
 // GetAppInfo retrieves public information about an OAuth application by client ID
 func (c *Client) GetAppInfo(clientID string) (*Application, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/app/%s", c.BaseURL, clientID), nil)
+	req, err := newRequest("GET", c.buildURL("/app/%s", clientID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get app info request: %w", err)
 	}
@@ -62,7 +62,7 @@ func (c *Client) GetAppInfo(clientID string) (*Application, error) {
 
 // GetEntities searches for entities (users, robots, teams) matching a prefix
 func (c *Client) GetEntities(prefix string, includeOrgs, includeTeams bool) (*Entities, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/entities/%s", c.BaseURL, prefix), nil)
+	req, err := newRequest("GET", c.buildURL("/entities/%s", prefix), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get entities request: %w", err)
 	}

--- a/lib/error.go
+++ b/lib/error.go
@@ -17,7 +17,7 @@ import (
 
 // GetErrorType retrieves details about a specific error type
 func (c *Client) GetErrorType(errorType string) (*ErrorType, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/error/%s", c.BaseURL, errorType), nil)
+	req, err := newRequest("GET", c.buildURL("/error/%s", errorType), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create error type request: %w", err)
 	}

--- a/lib/logs.go
+++ b/lib/logs.go
@@ -15,7 +15,6 @@ All log endpoints support pagination via next_page parameter.
 package lib
 
 import (
-	"fmt"
 	"net/http"
 )
 
@@ -53,7 +52,7 @@ func addLogQueryParams(req *http.Request, nextPage, startDate, endDate string) {
 // GetAggregatedLogs returns the aggregated logs for a repository
 func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate string) (*AggregatedLogs, error) {
 	// Get new request
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/aggregatelogs", c.BaseURL, namespace, repository), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/aggregatelogs", namespace, repository), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +73,7 @@ func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate str
 
 // GetLogs returns the logs for a repository
 func (c *Client) GetLogs(namespace, repository, nextPage, startDate, endDate string) (*Logs, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/logs", c.BaseURL, namespace, repository), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/logs", namespace, repository), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +90,7 @@ func (c *Client) GetLogs(namespace, repository, nextPage, startDate, endDate str
 
 // GetOrganizationLogs returns the logs for an organization
 func (c *Client) GetOrganizationLogs(orgname, nextPage, startDate, endDate string) (*Logs, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/logs", c.BaseURL, orgname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/logs", orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +107,7 @@ func (c *Client) GetOrganizationLogs(orgname, nextPage, startDate, endDate strin
 
 // GetOrganizationAggregatedLogs returns the aggregated logs for an organization
 func (c *Client) GetOrganizationAggregatedLogs(orgname, startDate, endDate string) (*AggregatedLogs, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/aggregatelogs", c.BaseURL, orgname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/aggregatelogs", orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +127,7 @@ func (c *Client) GetOrganizationAggregatedLogs(orgname, startDate, endDate strin
 
 // ExportOrganizationLogs exports the logs for an organization
 func (c *Client) ExportOrganizationLogs(orgname string, request *ExportLogsRequest) error {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/exportlogs", c.BaseURL, orgname), request)
+	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/exportlogs", orgname), request)
 	if err != nil {
 		return err
 	}
@@ -142,7 +141,7 @@ func (c *Client) ExportOrganizationLogs(orgname string, request *ExportLogsReque
 
 // GetUserLogs returns the logs for the current user
 func (c *Client) GetUserLogs(nextPage, startDate, endDate string) (*Logs, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/user/logs", c.BaseURL), nil)
+	req, err := newRequest("GET", c.buildURL("/user/logs"), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +158,7 @@ func (c *Client) GetUserLogs(nextPage, startDate, endDate string) (*Logs, error)
 
 // GetUserAggregatedLogs returns the aggregated logs for the current user
 func (c *Client) GetUserAggregatedLogs(startDate, endDate string) (*AggregatedLogs, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/user/aggregatelogs", c.BaseURL), nil)
+	req, err := newRequest("GET", c.buildURL("/user/aggregatelogs"), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +178,7 @@ func (c *Client) GetUserAggregatedLogs(startDate, endDate string) (*AggregatedLo
 
 // ExportUserLogs exports the logs for the current user
 func (c *Client) ExportUserLogs(request *ExportLogsRequest) error {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/user/exportlogs", c.BaseURL), request)
+	req, err := newRequestWithBody("POST", c.buildURL("/user/exportlogs"), request)
 	if err != nil {
 		return err
 	}
@@ -193,7 +192,7 @@ func (c *Client) ExportUserLogs(request *ExportLogsRequest) error {
 
 // ExportRepositoryLogs exports the logs for a repository
 func (c *Client) ExportRepositoryLogs(namespace, repository string, request *ExportLogsRequest) error {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/exportlogs", c.BaseURL, namespace, repository), request)
+	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/exportlogs", namespace, repository), request)
 	if err != nil {
 		return err
 	}

--- a/lib/manifest.go
+++ b/lib/manifest.go
@@ -24,7 +24,7 @@ import (
 
 // GetManifest retrieves detailed information about a specific manifest
 func (c *Client) GetManifest(namespace, repository, manifestRef string) (*Manifest, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/manifest/%s", c.BaseURL, namespace, repository, manifestRef), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/manifest/%s", namespace, repository, manifestRef), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest request: %w", err)
 	}
@@ -39,7 +39,7 @@ func (c *Client) GetManifest(namespace, repository, manifestRef string) (*Manife
 
 // DeleteManifest deletes a specific manifest from a repository
 func (c *Client) DeleteManifest(namespace, repository, manifestRef string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/manifest/%s", c.BaseURL, namespace, repository, manifestRef), nil)
+	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/manifest/%s", namespace, repository, manifestRef), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete manifest request: %w", err)
 	}
@@ -53,7 +53,7 @@ func (c *Client) DeleteManifest(namespace, repository, manifestRef string) error
 
 // GetManifestLabels retrieves all labels for a specific manifest
 func (c *Client) GetManifestLabels(namespace, repository, manifestRef string) (*ManifestLabels, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/manifest/%s/labels", c.BaseURL, namespace, repository, manifestRef), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/manifest/%s/labels", namespace, repository, manifestRef), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest labels request: %w", err)
 	}
@@ -77,7 +77,7 @@ func (c *Client) AddManifestLabel(namespace, repository, manifestRef, key, value
 		addReq.MediaType = mediaType
 	}
 
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/manifest/%s/labels", c.BaseURL, namespace, repository, manifestRef), addReq)
+	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/manifest/%s/labels", namespace, repository, manifestRef), addReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create add manifest label request: %w", err)
 	}
@@ -92,7 +92,7 @@ func (c *Client) AddManifestLabel(namespace, repository, manifestRef, key, value
 
 // GetManifestLabel retrieves a specific label from a manifest
 func (c *Client) GetManifestLabel(namespace, repository, manifestRef, labelID string) (*ManifestLabel, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/manifest/%s/labels/%s", c.BaseURL, namespace, repository, manifestRef, labelID), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/manifest/%s/labels/%s", namespace, repository, manifestRef, labelID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest label request: %w", err)
 	}
@@ -107,7 +107,7 @@ func (c *Client) GetManifestLabel(namespace, repository, manifestRef, labelID st
 
 // DeleteManifestLabel deletes a specific label from a manifest
 func (c *Client) DeleteManifestLabel(namespace, repository, manifestRef, labelID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/manifest/%s/labels/%s", c.BaseURL, namespace, repository, manifestRef, labelID), nil)
+	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/manifest/%s/labels/%s", namespace, repository, manifestRef, labelID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete manifest label request: %w", err)
 	}

--- a/lib/messages.go
+++ b/lib/messages.go
@@ -17,7 +17,7 @@ import (
 
 // GetMessages retrieves system messages for the user
 func (c *Client) GetMessages() (*Messages, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/messages", c.BaseURL), nil)
+	req, err := newRequest("GET", c.buildURL("/messages"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create messages request: %w", err)
 	}
@@ -50,7 +50,7 @@ func (c *Client) CreateMessage(content, severity, mediaType string) (*Message, e
 		},
 	}
 
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/messages", c.BaseURL), body)
+	req, err := newRequestWithBody("POST", c.buildURL("/messages"), body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create message request: %w", err)
 	}

--- a/lib/notification.go
+++ b/lib/notification.go
@@ -38,7 +38,7 @@ import (
 
 // GetNotifications retrieves all notifications for a repository
 func (c *Client) GetNotifications(namespace, repository string) (*RepositoryNotifications, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/notification/", c.BaseURL, namespace, repository), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/notification/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get notifications request: %w", err)
 	}
@@ -53,7 +53,7 @@ func (c *Client) GetNotifications(namespace, repository string) (*RepositoryNoti
 
 // GetNotification retrieves a specific notification by UUID
 func (c *Client) GetNotification(namespace, repository, uuid string) (*RepositoryNotification, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/notification/%s", c.BaseURL, namespace, repository, uuid), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/notification/%s", namespace, repository, uuid), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get notification request: %w", err)
 	}
@@ -68,7 +68,7 @@ func (c *Client) GetNotification(namespace, repository, uuid string) (*Repositor
 
 // CreateNotification creates a new notification for a repository
 func (c *Client) CreateNotification(namespace, repository string, notificationReq *CreateNotificationRequest) (*RepositoryNotification, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/notification/", c.BaseURL, namespace, repository), notificationReq)
+	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/notification/", namespace, repository), notificationReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create notification request: %w", err)
 	}
@@ -83,7 +83,7 @@ func (c *Client) CreateNotification(namespace, repository string, notificationRe
 
 // DeleteNotification deletes a notification from a repository
 func (c *Client) DeleteNotification(namespace, repository, uuid string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/notification/%s", c.BaseURL, namespace, repository, uuid), nil)
+	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/notification/%s", namespace, repository, uuid), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete notification request: %w", err)
 	}
@@ -97,7 +97,7 @@ func (c *Client) DeleteNotification(namespace, repository, uuid string) error {
 
 // TestNotification tests a notification by sending a test event
 func (c *Client) TestNotification(namespace, repository, uuid string) error {
-	req, err := newRequest("POST", fmt.Sprintf("%s/repository/%s/%s/notification/%s/test", c.BaseURL, namespace, repository, uuid), nil)
+	req, err := newRequest("POST", c.buildURL("/repository/%s/%s/notification/%s/test", namespace, repository, uuid), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create test notification request: %w", err)
 	}
@@ -111,7 +111,7 @@ func (c *Client) TestNotification(namespace, repository, uuid string) error {
 
 // ResetNotification resets failure count for a notification
 func (c *Client) ResetNotification(namespace, repository, uuid string) error {
-	req, err := newRequest("POST", fmt.Sprintf("%s/repository/%s/%s/notification/%s/reset", c.BaseURL, namespace, repository, uuid), nil)
+	req, err := newRequest("POST", c.buildURL("/repository/%s/%s/notification/%s/reset", namespace, repository, uuid), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create reset notification request: %w", err)
 	}
@@ -125,7 +125,7 @@ func (c *Client) ResetNotification(namespace, repository, uuid string) error {
 
 // UpdateNotification updates an existing notification
 func (c *Client) UpdateNotification(namespace, repository, uuid string, notificationReq *CreateNotificationRequest) (*RepositoryNotification, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/notification/%s", c.BaseURL, namespace, repository, uuid), notificationReq)
+	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/notification/%s", namespace, repository, uuid), notificationReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update notification request: %w", err)
 	}

--- a/lib/organization.go
+++ b/lib/organization.go
@@ -115,7 +115,7 @@ func (c *Client) CreateOrganization(name, email string) (*Organization, error) {
 
 // GetOrganization retrieves organization details
 func (c *Client) GetOrganization(orgname string) (*Organization, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s", c.BaseURL, orgname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s", orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (c *Client) GetOrganization(orgname string) (*Organization, error) {
 
 // DeleteOrganization deletes an organization
 func (c *Client) DeleteOrganization(orgname string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s", c.BaseURL, orgname), nil)
+	req, err := newRequest("DELETE", c.buildURL("/organization/%s", orgname), nil)
 	if err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func (c *Client) DeleteOrganization(orgname string) error {
 
 // UpdateOrganization updates organization settings
 func (c *Client) UpdateOrganization(orgname, email string) (*Organization, error) {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s", c.BaseURL, orgname), map[string]interface{}{
+	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s", orgname), map[string]interface{}{
 		"email": email,
 	})
 	if err != nil {
@@ -159,7 +159,7 @@ func (c *Client) UpdateOrganization(orgname, email string) (*Organization, error
 
 // GetOrganizationMembers retrieves organization members
 func (c *Client) GetOrganizationMembers(orgname string) (*OrganizationMembers, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/members", c.BaseURL, orgname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/members", orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func (c *Client) GetOrganizationMembers(orgname string) (*OrganizationMembers, e
 
 // AddOrganizationMember adds a member to an organization
 func (c *Client) AddOrganizationMember(orgname, membername string) error {
-	req, err := newRequest("PUT", fmt.Sprintf("%s/organization/%s/members/%s", c.BaseURL, orgname, membername), nil)
+	req, err := newRequest("PUT", c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
 	if err != nil {
 		return err
 	}
@@ -184,7 +184,7 @@ func (c *Client) AddOrganizationMember(orgname, membername string) error {
 
 // RemoveOrganizationMember removes a member from an organization
 func (c *Client) RemoveOrganizationMember(orgname, membername string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/members/%s", c.BaseURL, orgname, membername), nil)
+	req, err := newRequest("DELETE", c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func (c *Client) RemoveOrganizationMember(orgname, membername string) error {
 
 // GetOrganizationRepositories retrieves repositories for an organization
 func (c *Client) GetOrganizationRepositories(orgname string) (*OrganizationRepositories, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/repositories", c.BaseURL, orgname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/repositories", orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +213,7 @@ func (c *Client) GetOrganizationRepositories(orgname string) (*OrganizationRepos
 
 // GetDefaultPermissions retrieves default permissions for an organization
 func (c *Client) GetDefaultPermissions(orgname string) (*DefaultPermissions, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/prototypes", c.BaseURL, orgname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/prototypes", orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func (c *Client) GetDefaultPermissions(orgname string) (*DefaultPermissions, err
 
 // CreateDefaultPermission creates a default permission for an organization
 func (c *Client) CreateDefaultPermission(orgname, role, delegateType, delegateName string) (*DefaultPermission, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/prototypes", c.BaseURL, orgname), map[string]interface{}{
+	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/prototypes", orgname), map[string]interface{}{
 		fieldRole: role,
 		"delegate": map[string]interface{}{
 			"kind":    delegateType,
@@ -249,7 +249,7 @@ func (c *Client) CreateDefaultPermission(orgname, role, delegateType, delegateNa
 
 // DeleteDefaultPermission deletes a default permission
 func (c *Client) DeleteDefaultPermission(orgname, prototypeid string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/prototypes/%s", c.BaseURL, orgname, prototypeid), nil)
+	req, err := newRequest("DELETE", c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeid), nil)
 	if err != nil {
 		return err
 	}
@@ -261,7 +261,7 @@ func (c *Client) DeleteDefaultPermission(orgname, prototypeid string) error {
 
 // GetProxyCacheConfig retrieves proxy cache configuration for an organization
 func (c *Client) GetProxyCacheConfig(orgname string) (*ProxyCacheConfig, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/proxycache", c.BaseURL, orgname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/proxycache", orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +276,7 @@ func (c *Client) GetProxyCacheConfig(orgname string) (*ProxyCacheConfig, error) 
 
 // CreateProxyCacheConfig creates proxy cache configuration for an organization
 func (c *Client) CreateProxyCacheConfig(orgname, upstreamRegistry string, insecure bool, expiration int) (*ProxyCacheConfig, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/proxycache", c.BaseURL, orgname), map[string]interface{}{
+	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/proxycache", orgname), map[string]interface{}{
 		"upstream_registry": upstreamRegistry,
 		"insecure":          insecure,
 		"expiration":        expiration,
@@ -295,7 +295,7 @@ func (c *Client) CreateProxyCacheConfig(orgname, upstreamRegistry string, insecu
 
 // DeleteProxyCacheConfig deletes proxy cache configuration for an organization
 func (c *Client) DeleteProxyCacheConfig(orgname string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/proxycache", c.BaseURL, orgname), nil)
+	req, err := newRequest("DELETE", c.buildURL("/organization/%s/proxycache", orgname), nil)
 	if err != nil {
 		return err
 	}
@@ -307,7 +307,7 @@ func (c *Client) DeleteProxyCacheConfig(orgname string) error {
 
 // GetTeams retrieves all teams for an organization
 func (c *Client) GetTeams(orgname string) ([]Team, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/teams", c.BaseURL, orgname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/teams", orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +324,7 @@ func (c *Client) GetTeams(orgname string) ([]Team, error) {
 
 // CreateTeam creates a new team in an organization
 func (c *Client) CreateTeam(orgname, teamname, description, role string) (*Team, error) {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/team/%s", c.BaseURL, orgname, teamname), CreateTeamRequest{
+	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/team/%s", orgname, teamname), CreateTeamRequest{
 		Name:        teamname,
 		Description: description,
 		Role:        role,
@@ -343,7 +343,7 @@ func (c *Client) CreateTeam(orgname, teamname, description, role string) (*Team,
 
 // GetTeam retrieves details for a specific team
 func (c *Client) GetTeam(orgname, teamname string) (*Team, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/team/%s", c.BaseURL, orgname, teamname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/team/%s", orgname, teamname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +358,7 @@ func (c *Client) GetTeam(orgname, teamname string) (*Team, error) {
 
 // DeleteTeam deletes a team from an organization
 func (c *Client) DeleteTeam(orgname, teamname string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/team/%s", c.BaseURL, orgname, teamname), nil)
+	req, err := newRequest("DELETE", c.buildURL("/organization/%s/team/%s", orgname, teamname), nil)
 	if err != nil {
 		return err
 	}
@@ -368,7 +368,7 @@ func (c *Client) DeleteTeam(orgname, teamname string) error {
 
 // UpdateTeam updates team settings
 func (c *Client) UpdateTeam(orgname, teamname, description, role string) (*Team, error) {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/team/%s", c.BaseURL, orgname, teamname), map[string]interface{}{
+	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/team/%s", orgname, teamname), map[string]interface{}{
 		"description": description,
 		fieldRole:     role,
 	})
@@ -388,7 +388,7 @@ func (c *Client) UpdateTeam(orgname, teamname, description, role string) (*Team,
 
 // GetTeamMembers retrieves members of a team
 func (c *Client) GetTeamMembers(orgname, teamname string) (*TeamMembers, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/team/%s/members", c.BaseURL, orgname, teamname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/team/%s/members", orgname, teamname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -403,7 +403,7 @@ func (c *Client) GetTeamMembers(orgname, teamname string) (*TeamMembers, error) 
 
 // AddTeamMember adds a member to a team
 func (c *Client) AddTeamMember(orgname, teamname, membername string) error {
-	req, err := newRequest("PUT", fmt.Sprintf("%s/organization/%s/team/%s/members/%s", c.BaseURL, orgname, teamname, membername), nil)
+	req, err := newRequest("PUT", c.buildURL("/organization/%s/team/%s/members/%s", orgname, teamname, membername), nil)
 	if err != nil {
 		return err
 	}
@@ -413,7 +413,7 @@ func (c *Client) AddTeamMember(orgname, teamname, membername string) error {
 
 // RemoveTeamMember removes a member from a team
 func (c *Client) RemoveTeamMember(orgname, teamname, membername string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/team/%s/members/%s", c.BaseURL, orgname, teamname, membername), nil)
+	req, err := newRequest("DELETE", c.buildURL("/organization/%s/team/%s/members/%s", orgname, teamname, membername), nil)
 	if err != nil {
 		return err
 	}
@@ -425,7 +425,7 @@ func (c *Client) RemoveTeamMember(orgname, teamname, membername string) error {
 
 // GetTeamPermissions retrieves repository permissions for a team
 func (c *Client) GetTeamPermissions(orgname, teamname string) (*TeamPermissions, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/team/%s/permissions", c.BaseURL, orgname, teamname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/team/%s/permissions", orgname, teamname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -440,7 +440,7 @@ func (c *Client) GetTeamPermissions(orgname, teamname string) (*TeamPermissions,
 
 // SetTeamRepositoryPermission sets repository permission for a team
 func (c *Client) SetTeamRepositoryPermission(orgname, teamname, repository, role string) error {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/team/%s/permissions/%s", c.BaseURL, orgname, teamname, repository), map[string]interface{}{
+	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/team/%s/permissions/%s", orgname, teamname, repository), map[string]interface{}{
 		fieldRole: role,
 	})
 	if err != nil {
@@ -452,7 +452,7 @@ func (c *Client) SetTeamRepositoryPermission(orgname, teamname, repository, role
 
 // RemoveTeamRepositoryPermission removes repository permission for a team
 func (c *Client) RemoveTeamRepositoryPermission(orgname, teamname, repository string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/team/%s/permissions/%s", c.BaseURL, orgname, teamname, repository), nil)
+	req, err := newRequest("DELETE", c.buildURL("/organization/%s/team/%s/permissions/%s", orgname, teamname, repository), nil)
 	if err != nil {
 		return err
 	}
@@ -464,7 +464,7 @@ func (c *Client) RemoveTeamRepositoryPermission(orgname, teamname, repository st
 
 // GetRobotAccounts retrieves all robot accounts for an organization
 func (c *Client) GetRobotAccounts(orgname string) (*RobotAccounts, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/robots", c.BaseURL, orgname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/robots", orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -479,7 +479,7 @@ func (c *Client) GetRobotAccounts(orgname string) (*RobotAccounts, error) {
 
 // CreateRobotAccount creates a new robot account in an organization
 func (c *Client) CreateRobotAccount(orgname, robotShortname, description string, unstructured map[string]interface{}) (*RobotAccount, error) {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/robots/%s", c.BaseURL, orgname, robotShortname), CreateRobotRequest{
+	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), CreateRobotRequest{
 		Description:  description,
 		Unstructured: unstructured,
 	})
@@ -497,7 +497,7 @@ func (c *Client) CreateRobotAccount(orgname, robotShortname, description string,
 
 // GetRobotAccount retrieves details for a specific robot account
 func (c *Client) GetRobotAccount(orgname, robotShortname string) (*RobotAccount, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/robots/%s", c.BaseURL, orgname, robotShortname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -512,7 +512,7 @@ func (c *Client) GetRobotAccount(orgname, robotShortname string) (*RobotAccount,
 
 // DeleteRobotAccount deletes a robot account from an organization
 func (c *Client) DeleteRobotAccount(orgname, robotShortname string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/robots/%s", c.BaseURL, orgname, robotShortname), nil)
+	req, err := newRequest("DELETE", c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), nil)
 	if err != nil {
 		return err
 	}
@@ -522,7 +522,7 @@ func (c *Client) DeleteRobotAccount(orgname, robotShortname string) error {
 
 // RegenerateRobotToken regenerates the token for a robot account
 func (c *Client) RegenerateRobotToken(orgname, robotShortname string) (*RobotAccount, error) {
-	req, err := newRequest("POST", fmt.Sprintf("%s/organization/%s/robots/%s/regenerate", c.BaseURL, orgname, robotShortname), nil)
+	req, err := newRequest("POST", c.buildURL("/organization/%s/robots/%s/regenerate", orgname, robotShortname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -537,7 +537,7 @@ func (c *Client) RegenerateRobotToken(orgname, robotShortname string) (*RobotAcc
 
 // GetRobotPermissions retrieves repository permissions for a robot account
 func (c *Client) GetRobotPermissions(orgname, robotShortname string) (*RobotPermissions, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/robots/%s/permissions", c.BaseURL, orgname, robotShortname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/robots/%s/permissions", orgname, robotShortname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -552,7 +552,7 @@ func (c *Client) GetRobotPermissions(orgname, robotShortname string) (*RobotPerm
 
 // SetRobotRepositoryPermission sets repository permission for a robot account
 func (c *Client) SetRobotRepositoryPermission(orgname, robotShortname, repository, role string) error {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/robots/%s/permissions/%s", c.BaseURL, orgname, robotShortname, repository), map[string]interface{}{
+	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/robots/%s/permissions/%s", orgname, robotShortname, repository), map[string]interface{}{
 		fieldRole: role,
 	})
 	if err != nil {
@@ -564,7 +564,7 @@ func (c *Client) SetRobotRepositoryPermission(orgname, robotShortname, repositor
 
 // RemoveRobotRepositoryPermission removes repository permission for a robot account
 func (c *Client) RemoveRobotRepositoryPermission(orgname, robotShortname, repository string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/robots/%s/permissions/%s", c.BaseURL, orgname, robotShortname, repository), nil)
+	req, err := newRequest("DELETE", c.buildURL("/organization/%s/robots/%s/permissions/%s", orgname, robotShortname, repository), nil)
 	if err != nil {
 		return err
 	}
@@ -576,7 +576,7 @@ func (c *Client) RemoveRobotRepositoryPermission(orgname, robotShortname, reposi
 
 // GetRobotFederation retrieves the federation configuration for an organization's robot account
 func (c *Client) GetRobotFederation(orgname, robotShortname string) (*RobotFederation, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/robots/%s/federation", c.BaseURL, orgname, robotShortname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/robots/%s/federation", orgname, robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get robot federation request: %w", err)
 	}
@@ -591,7 +591,7 @@ func (c *Client) GetRobotFederation(orgname, robotShortname string) (*RobotFeder
 
 // CreateRobotFederation creates or updates the federation configuration for an organization's robot account
 func (c *Client) CreateRobotFederation(orgname, robotShortname string, configs []RobotFederationConfig) error {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/robots/%s/federation", c.BaseURL, orgname, robotShortname), configs)
+	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/robots/%s/federation", orgname, robotShortname), configs)
 	if err != nil {
 		return fmt.Errorf("failed to create robot federation request: %w", err)
 	}
@@ -605,7 +605,7 @@ func (c *Client) CreateRobotFederation(orgname, robotShortname string, configs [
 
 // DeleteRobotFederation deletes the federation configuration for an organization's robot account
 func (c *Client) DeleteRobotFederation(orgname, robotShortname string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/robots/%s/federation", c.BaseURL, orgname, robotShortname), nil)
+	req, err := newRequest("DELETE", c.buildURL("/organization/%s/robots/%s/federation", orgname, robotShortname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete robot federation request: %w", err)
 	}
@@ -621,7 +621,7 @@ func (c *Client) DeleteRobotFederation(orgname, robotShortname string) error {
 
 // GetQuota retrieves quota information for an organization
 func (c *Client) GetQuota(orgname string) (*Quota, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/quota", c.BaseURL, orgname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/quota", orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -636,7 +636,7 @@ func (c *Client) GetQuota(orgname string) (*Quota, error) {
 
 // CreateQuota creates a quota for an organization
 func (c *Client) CreateQuota(orgname string, limitBytes int64) (*Quota, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/quota", c.BaseURL, orgname), CreateQuotaRequest{
+	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/quota", orgname), CreateQuotaRequest{
 		LimitBytes: limitBytes,
 	})
 	if err != nil {
@@ -653,7 +653,7 @@ func (c *Client) CreateQuota(orgname string, limitBytes int64) (*Quota, error) {
 
 // UpdateQuota updates quota limits for an organization
 func (c *Client) UpdateQuota(orgname string, limitBytes int64) (*Quota, error) {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/quota", c.BaseURL, orgname), CreateQuotaRequest{
+	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/quota", orgname), CreateQuotaRequest{
 		LimitBytes: limitBytes,
 	})
 	if err != nil {
@@ -670,7 +670,7 @@ func (c *Client) UpdateQuota(orgname string, limitBytes int64) (*Quota, error) {
 
 // DeleteQuota deletes quota for an organization
 func (c *Client) DeleteQuota(orgname string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/quota", c.BaseURL, orgname), nil)
+	req, err := newRequest("DELETE", c.buildURL("/organization/%s/quota", orgname), nil)
 	if err != nil {
 		return err
 	}
@@ -682,7 +682,7 @@ func (c *Client) DeleteQuota(orgname string) error {
 
 // GetAutoPrunePolicies retrieves auto-prune policies for an organization
 func (c *Client) GetAutoPrunePolicies(orgname string) (*AutoPrunePolicies, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/autoprunepolicy", c.BaseURL, orgname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/autoprunepolicy", orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -697,7 +697,7 @@ func (c *Client) GetAutoPrunePolicies(orgname string) (*AutoPrunePolicies, error
 
 // CreateAutoPrunePolicy creates an auto-prune policy for an organization
 func (c *Client) CreateAutoPrunePolicy(orgname, method string, value int, tagPattern string) (*AutoPrunePolicy, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/autoprunepolicy", c.BaseURL, orgname), CreateAutoPruneRequest{
+	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/autoprunepolicy", orgname), CreateAutoPruneRequest{
 		Method:     method,
 		Value:      value,
 		TagPattern: tagPattern,
@@ -716,7 +716,7 @@ func (c *Client) CreateAutoPrunePolicy(orgname, method string, value int, tagPat
 
 // GetAutoPrunePolicy retrieves a specific auto-prune policy
 func (c *Client) GetAutoPrunePolicy(orgname, policyUUID string) (*AutoPrunePolicy, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/autoprunepolicy/%s", c.BaseURL, orgname, policyUUID), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -731,7 +731,7 @@ func (c *Client) GetAutoPrunePolicy(orgname, policyUUID string) (*AutoPrunePolic
 
 // UpdateAutoPrunePolicy updates an auto-prune policy
 func (c *Client) UpdateAutoPrunePolicy(orgname, policyUUID, method string, value int, tagPattern string) (*AutoPrunePolicy, error) {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/autoprunepolicy/%s", c.BaseURL, orgname, policyUUID), CreateAutoPruneRequest{
+	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), CreateAutoPruneRequest{
 		Method:     method,
 		Value:      value,
 		TagPattern: tagPattern,
@@ -750,7 +750,7 @@ func (c *Client) UpdateAutoPrunePolicy(orgname, policyUUID, method string, value
 
 // DeleteAutoPrunePolicy deletes an auto-prune policy
 func (c *Client) DeleteAutoPrunePolicy(orgname, policyUUID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/autoprunepolicy/%s", c.BaseURL, orgname, policyUUID), nil)
+	req, err := newRequest("DELETE", c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), nil)
 	if err != nil {
 		return err
 	}
@@ -762,7 +762,7 @@ func (c *Client) DeleteAutoPrunePolicy(orgname, policyUUID string) error {
 
 // GetApplications retrieves applications for an organization
 func (c *Client) GetApplications(orgname string) (*Applications, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/applications", c.BaseURL, orgname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/applications", orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -777,7 +777,7 @@ func (c *Client) GetApplications(orgname string) (*Applications, error) {
 
 // CreateApplication creates a new application for an organization
 func (c *Client) CreateApplication(orgname, name, description, applicationURI, redirectURI string) (*Application, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/applications", c.BaseURL, orgname), CreateApplicationRequest{
+	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/applications", orgname), CreateApplicationRequest{
 		Name:           name,
 		Description:    description,
 		ApplicationURI: applicationURI,
@@ -797,7 +797,7 @@ func (c *Client) CreateApplication(orgname, name, description, applicationURI, r
 
 // GetApplication retrieves details for a specific application
 func (c *Client) GetApplication(orgname, clientID string) (*Application, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/applications/%s", c.BaseURL, orgname, clientID), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/applications/%s", orgname, clientID), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -812,7 +812,7 @@ func (c *Client) GetApplication(orgname, clientID string) (*Application, error) 
 
 // UpdateApplication updates an application
 func (c *Client) UpdateApplication(orgname, clientID, name, description, applicationURI, redirectURI string) (*Application, error) {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/applications/%s", c.BaseURL, orgname, clientID), CreateApplicationRequest{
+	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/applications/%s", orgname, clientID), CreateApplicationRequest{
 		Name:           name,
 		Description:    description,
 		ApplicationURI: applicationURI,
@@ -832,7 +832,7 @@ func (c *Client) UpdateApplication(orgname, clientID, name, description, applica
 
 // DeleteApplication deletes an application
 func (c *Client) DeleteApplication(orgname, clientID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/applications/%s", c.BaseURL, orgname, clientID), nil)
+	req, err := newRequest("DELETE", c.buildURL("/organization/%s/applications/%s", orgname, clientID), nil)
 	if err != nil {
 		return err
 	}
@@ -842,7 +842,7 @@ func (c *Client) DeleteApplication(orgname, clientID string) error {
 
 // ResetApplicationClientSecret resets the client secret for an application
 func (c *Client) ResetApplicationClientSecret(orgname, clientID string) (*Application, error) {
-	req, err := newRequest("POST", fmt.Sprintf("%s/organization/%s/applications/%s/resetclientsecret", c.BaseURL, orgname, clientID), nil)
+	req, err := newRequest("POST", c.buildURL("/organization/%s/applications/%s/resetclientsecret", orgname, clientID), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -857,7 +857,7 @@ func (c *Client) ResetApplicationClientSecret(orgname, clientID string) (*Applic
 
 // GetOrganizationCollaborators gets the list of collaborators for an organization
 func (c *Client) GetOrganizationCollaborators(orgname string) (*Collaborators, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/collaborators", c.BaseURL, orgname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/collaborators", orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -872,7 +872,7 @@ func (c *Client) GetOrganizationCollaborators(orgname string) (*Collaborators, e
 
 // GetOrganizationMember gets information about a specific organization member
 func (c *Client) GetOrganizationMember(orgname, membername string) (*OrganizationMember, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/members/%s", c.BaseURL, orgname, membername), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -887,7 +887,7 @@ func (c *Client) GetOrganizationMember(orgname, membername string) (*Organizatio
 
 // GetOrganizationMarketplace gets marketplace information for an organization
 func (c *Client) GetOrganizationMarketplace(orgname string) (*MarketplaceInfo, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/marketplace", c.BaseURL, orgname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/marketplace", orgname), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -902,7 +902,7 @@ func (c *Client) GetOrganizationMarketplace(orgname string) (*MarketplaceInfo, e
 
 // CreateOrganizationMarketplaceSubscription creates a marketplace subscription
 func (c *Client) CreateOrganizationMarketplaceSubscription(orgname string, subscription *MarketplaceSubscriptionRequest) error {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/marketplace", c.BaseURL, orgname), subscription)
+	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/marketplace", orgname), subscription)
 	if err != nil {
 		return err
 	}
@@ -917,7 +917,7 @@ func (c *Client) BatchRemoveOrganizationMarketplaceSubscriptions(orgname string,
 	}{
 		SubscriptionIDs: subscriptionIDs,
 	}
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/marketplace/batchremove", c.BaseURL, orgname), body)
+	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/marketplace/batchremove", orgname), body)
 	if err != nil {
 		return err
 	}
@@ -927,7 +927,7 @@ func (c *Client) BatchRemoveOrganizationMarketplaceSubscriptions(orgname string,
 
 // DeleteOrganizationMarketplaceSubscription removes a specific marketplace subscription
 func (c *Client) DeleteOrganizationMarketplaceSubscription(orgname, subscriptionID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/marketplace/%s", c.BaseURL, orgname, subscriptionID), nil)
+	req, err := newRequest("DELETE", c.buildURL("/organization/%s/marketplace/%s", orgname, subscriptionID), nil)
 	if err != nil {
 		return err
 	}
@@ -937,7 +937,7 @@ func (c *Client) DeleteOrganizationMarketplaceSubscription(orgname, subscription
 
 // InviteTeamMember invites a member to a team via email
 func (c *Client) InviteTeamMember(orgname, teamname, email string) error {
-	req, err := newRequest("PUT", fmt.Sprintf("%s/organization/%s/team/%s/invite/%s", c.BaseURL, orgname, teamname, email), nil)
+	req, err := newRequest("PUT", c.buildURL("/organization/%s/team/%s/invite/%s", orgname, teamname, email), nil)
 	if err != nil {
 		return err
 	}
@@ -947,7 +947,7 @@ func (c *Client) InviteTeamMember(orgname, teamname, email string) error {
 
 // DeleteTeamInvite deletes a pending team invitation
 func (c *Client) DeleteTeamInvite(orgname, teamname, email string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/team/%s/invite/%s", c.BaseURL, orgname, teamname, email), nil)
+	req, err := newRequest("DELETE", c.buildURL("/organization/%s/team/%s/invite/%s", orgname, teamname, email), nil)
 	if err != nil {
 		return err
 	}

--- a/lib/permissions.go
+++ b/lib/permissions.go
@@ -19,7 +19,7 @@ import (
 
 // GetRepositoryPermissions retrieves permissions for a repository
 func (c *Client) GetRepositoryPermissions(namespace, repository string) (*RepositoryPermissions, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/permissions", c.BaseURL, namespace, repository), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/permissions", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repository permissions request: %w", err)
 	}
@@ -35,7 +35,7 @@ func (c *Client) GetRepositoryPermissions(namespace, repository string) (*Reposi
 // SetRepositoryPermission sets permission for a user/robot on a repository
 // role should be one of: "read", "write", "admin"
 func (c *Client) SetRepositoryPermission(namespace, repository, username, role string) error {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/permissions/%s", c.BaseURL, namespace, repository, username), SetRepositoryPermissionRequest{
+	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/permissions/%s", namespace, repository, username), SetRepositoryPermissionRequest{
 		Role: role,
 	})
 	if err != nil {
@@ -51,7 +51,7 @@ func (c *Client) SetRepositoryPermission(namespace, repository, username, role s
 
 // RemoveRepositoryPermission removes permission for a user/robot from a repository
 func (c *Client) RemoveRepositoryPermission(namespace, repository, username string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/permissions/%s", c.BaseURL, namespace, repository, username), nil)
+	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/permissions/%s", namespace, repository, username), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create remove repository permission request: %w", err)
 	}
@@ -67,7 +67,7 @@ func (c *Client) RemoveRepositoryPermission(namespace, repository, username stri
 
 // ListUserPermissions lists all user permissions for a repository
 func (c *Client) ListUserPermissions(namespace, repository string) (*RepositoryPermissions, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/permissions/user/", c.BaseURL, namespace, repository), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/permissions/user/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list user permissions request: %w", err)
 	}
@@ -82,7 +82,7 @@ func (c *Client) ListUserPermissions(namespace, repository string) (*RepositoryP
 
 // GetUserPermission gets permission for a specific user on a repository
 func (c *Client) GetUserPermission(namespace, repository, username string) (*RepositoryPermission, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/permissions/user/%s", c.BaseURL, namespace, repository, username), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/permissions/user/%s", namespace, repository, username), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user permission request: %w", err)
 	}
@@ -98,7 +98,7 @@ func (c *Client) GetUserPermission(namespace, repository, username string) (*Rep
 // SetUserPermission sets permission for a user on a repository
 // role should be one of: "read", "write", "admin"
 func (c *Client) SetUserPermission(namespace, repository, username, role string) error {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/permissions/user/%s", c.BaseURL, namespace, repository, username), SetRepositoryPermissionRequest{
+	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/permissions/user/%s", namespace, repository, username), SetRepositoryPermissionRequest{
 		Role: role,
 	})
 	if err != nil {
@@ -114,7 +114,7 @@ func (c *Client) SetUserPermission(namespace, repository, username, role string)
 
 // DeleteUserPermission removes permission for a user from a repository
 func (c *Client) DeleteUserPermission(namespace, repository, username string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/permissions/user/%s", c.BaseURL, namespace, repository, username), nil)
+	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/permissions/user/%s", namespace, repository, username), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete user permission request: %w", err)
 	}
@@ -128,7 +128,7 @@ func (c *Client) DeleteUserPermission(namespace, repository, username string) er
 
 // GetUserTransitivePermission gets the transitive permission for a user on a repository
 func (c *Client) GetUserTransitivePermission(namespace, repository, username string) (*RepositoryPermission, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/permissions/user/%s/transitive", c.BaseURL, namespace, repository, username), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/permissions/user/%s/transitive", namespace, repository, username), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user transitive permission request: %w", err)
 	}
@@ -145,7 +145,7 @@ func (c *Client) GetUserTransitivePermission(namespace, repository, username str
 
 // ListTeamPermissions lists all team permissions for a repository
 func (c *Client) ListTeamPermissions(namespace, repository string) (*RepositoryPermissions, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/permissions/team/", c.BaseURL, namespace, repository), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/permissions/team/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list team permissions request: %w", err)
 	}
@@ -160,7 +160,7 @@ func (c *Client) ListTeamPermissions(namespace, repository string) (*RepositoryP
 
 // GetTeamPermission gets permission for a specific team on a repository
 func (c *Client) GetTeamPermission(namespace, repository, teamname string) (*RepositoryPermission, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/permissions/team/%s", c.BaseURL, namespace, repository, teamname), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/permissions/team/%s", namespace, repository, teamname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get team permission request: %w", err)
 	}
@@ -176,7 +176,7 @@ func (c *Client) GetTeamPermission(namespace, repository, teamname string) (*Rep
 // SetTeamPermission sets permission for a team on a repository
 // role should be one of: "read", "write", "admin"
 func (c *Client) SetTeamPermission(namespace, repository, teamname, role string) error {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/permissions/team/%s", c.BaseURL, namespace, repository, teamname), SetRepositoryPermissionRequest{
+	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/permissions/team/%s", namespace, repository, teamname), SetRepositoryPermissionRequest{
 		Role: role,
 	})
 	if err != nil {
@@ -192,7 +192,7 @@ func (c *Client) SetTeamPermission(namespace, repository, teamname, role string)
 
 // DeleteTeamPermission removes permission for a team from a repository
 func (c *Client) DeleteTeamPermission(namespace, repository, teamname string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/permissions/team/%s", c.BaseURL, namespace, repository, teamname), nil)
+	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/permissions/team/%s", namespace, repository, teamname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete team permission request: %w", err)
 	}

--- a/lib/prototype.go
+++ b/lib/prototype.go
@@ -27,7 +27,7 @@ import (
 
 // GetPrototypes retrieves all permission prototypes for an organization
 func (c *Client) GetPrototypes(orgname string) (*Prototypes, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/prototypes", c.BaseURL, orgname), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/prototypes", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get prototypes request: %w", err)
 	}
@@ -42,7 +42,7 @@ func (c *Client) GetPrototypes(orgname string) (*Prototypes, error) {
 
 // CreatePrototype creates a new permission prototype for an organization
 func (c *Client) CreatePrototype(orgname string, createReq *CreatePrototypeRequest) (*Prototype, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/organization/%s/prototypes", c.BaseURL, orgname), createReq)
+	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/prototypes", orgname), createReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create prototype request: %w", err)
 	}
@@ -57,7 +57,7 @@ func (c *Client) CreatePrototype(orgname string, createReq *CreatePrototypeReque
 
 // GetPrototype retrieves a specific prototype by UUID
 func (c *Client) GetPrototype(orgname, prototypeUUID string) (*Prototype, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/organization/%s/prototypes/%s", c.BaseURL, orgname, prototypeUUID), nil)
+	req, err := newRequest("GET", c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get prototype request: %w", err)
 	}
@@ -72,7 +72,7 @@ func (c *Client) GetPrototype(orgname, prototypeUUID string) (*Prototype, error)
 
 // UpdatePrototype updates an existing prototype
 func (c *Client) UpdatePrototype(orgname, prototypeUUID string, updateReq *UpdatePrototypeRequest) (*Prototype, error) {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/organization/%s/prototypes/%s", c.BaseURL, orgname, prototypeUUID), updateReq)
+	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeUUID), updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update prototype request: %w", err)
 	}
@@ -87,7 +87,7 @@ func (c *Client) UpdatePrototype(orgname, prototypeUUID string, updateReq *Updat
 
 // DeletePrototype deletes a prototype
 func (c *Client) DeletePrototype(orgname, prototypeUUID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/organization/%s/prototypes/%s", c.BaseURL, orgname, prototypeUUID), nil)
+	req, err := newRequest("DELETE", c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeUUID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete prototype request: %w", err)
 	}

--- a/lib/repository.go
+++ b/lib/repository.go
@@ -48,7 +48,7 @@ type RepositoryWithTags struct {
 
 // GetRepository returns a repository with tags information baked in
 func (c *Client) GetRepository(namespace, repository string) (RepositoryWithTags, error) {
-	repoURL := fmt.Sprintf("%s/repository/%s/%s", c.BaseURL, namespace, repository)
+	repoURL := c.buildURL("/repository/%s/%s", namespace, repository)
 	req, err := newRequest("GET", repoURL, nil)
 	if err != nil {
 		return RepositoryWithTags{}, fmt.Errorf("failed to create request for repository: %w", err)
@@ -102,7 +102,7 @@ func (c *Client) UpdateRepository(namespace, repository, description, visibility
 		updateReq.Visibility = visibility
 	}
 
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s", c.BaseURL, namespace, repository), updateReq)
+	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s", namespace, repository), updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update repository request: %w", err)
 	}
@@ -117,7 +117,7 @@ func (c *Client) UpdateRepository(namespace, repository, description, visibility
 
 // DeleteRepository deletes a repository
 func (c *Client) DeleteRepository(namespace, repository string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s", c.BaseURL, namespace, repository), nil)
+	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s", namespace, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete repository request: %w", err)
 	}
@@ -131,7 +131,7 @@ func (c *Client) DeleteRepository(namespace, repository string) error {
 
 // ListRepositories lists all repositories visible to the user
 func (c *Client) ListRepositories(namespace string, public, starred, popularity bool, page, limit int) (*RepositoryList, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository", c.BaseURL), nil)
+	req, err := newRequest("GET", c.buildURL("/repository"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list repositories request: %w", err)
 	}
@@ -172,7 +172,7 @@ func (c *Client) ChangeRepositoryVisibility(namespace, repository, visibility st
 	}{
 		Visibility: visibility,
 	}
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/changevisibility", c.BaseURL, namespace, repository), body)
+	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/changevisibility", namespace, repository), body)
 	if err != nil {
 		return fmt.Errorf("failed to create change visibility request: %w", err)
 	}
@@ -186,7 +186,7 @@ func (c *Client) ChangeRepositoryVisibility(namespace, repository, visibility st
 
 // ListTags lists tags for a repository
 func (c *Client) ListTags(namespace, repository string, limit int, onlyActive bool) (*RepositoryTags, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/tag/", c.BaseURL, namespace, repository), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/tag/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list tags request: %w", err)
 	}

--- a/lib/repotoken.go
+++ b/lib/repotoken.go
@@ -23,7 +23,7 @@ import (
 //
 // Deprecated: Use robot accounts instead.
 func (c *Client) GetRepoTokens(namespace, repository string) (*RepoTokens, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/tokens", c.BaseURL, namespace, repository), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/tokens", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repo tokens request: %w", err)
 	}
@@ -40,7 +40,7 @@ func (c *Client) GetRepoTokens(namespace, repository string) (*RepoTokens, error
 //
 // Deprecated: Use robot accounts instead.
 func (c *Client) CreateRepoToken(namespace, repository string, createReq *CreateRepoTokenRequest) (*RepoToken, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/tokens", c.BaseURL, namespace, repository), createReq)
+	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/tokens", namespace, repository), createReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create repo token request: %w", err)
 	}
@@ -57,7 +57,7 @@ func (c *Client) CreateRepoToken(namespace, repository string, createReq *Create
 //
 // Deprecated: Use robot accounts instead.
 func (c *Client) GetRepoToken(namespace, repository, code string) (*RepoToken, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/tokens/%s", c.BaseURL, namespace, repository, code), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/tokens/%s", namespace, repository, code), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repo token request: %w", err)
 	}
@@ -74,7 +74,7 @@ func (c *Client) GetRepoToken(namespace, repository, code string) (*RepoToken, e
 //
 // Deprecated: Use robot accounts instead.
 func (c *Client) UpdateRepoToken(namespace, repository, code string, updateReq *UpdateRepoTokenRequest) (*RepoToken, error) {
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/tokens/%s", c.BaseURL, namespace, repository, code), updateReq)
+	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/tokens/%s", namespace, repository, code), updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update repo token request: %w", err)
 	}
@@ -91,7 +91,7 @@ func (c *Client) UpdateRepoToken(namespace, repository, code string, updateReq *
 //
 // Deprecated: Use robot accounts instead.
 func (c *Client) DeleteRepoToken(namespace, repository, code string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/tokens/%s", c.BaseURL, namespace, repository, code), nil)
+	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/tokens/%s", namespace, repository, code), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete repo token request: %w", err)
 	}

--- a/lib/robot.go
+++ b/lib/robot.go
@@ -37,7 +37,7 @@ func (c *Client) GetUserRobotAccounts() (*RobotAccounts, error) {
 
 // GetUserRobotAccount retrieves a specific robot account for the authenticated user
 func (c *Client) GetUserRobotAccount(robotShortname string) (*RobotAccount, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/user/robots/%s", c.BaseURL, robotShortname), nil)
+	req, err := newRequest("GET", c.buildURL("/user/robots/%s", robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user robot request: %w", err)
 	}
@@ -57,7 +57,7 @@ func (c *Client) CreateUserRobotAccount(robotShortname, description string, unst
 		Unstructured: unstructured,
 	}
 
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/user/robots/%s", c.BaseURL, robotShortname), createReq)
+	req, err := newRequestWithBody("PUT", c.buildURL("/user/robots/%s", robotShortname), createReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user robot request: %w", err)
 	}
@@ -72,7 +72,7 @@ func (c *Client) CreateUserRobotAccount(robotShortname, description string, unst
 
 // DeleteUserRobotAccount deletes a robot account for the authenticated user
 func (c *Client) DeleteUserRobotAccount(robotShortname string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/user/robots/%s", c.BaseURL, robotShortname), nil)
+	req, err := newRequest("DELETE", c.buildURL("/user/robots/%s", robotShortname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete user robot request: %w", err)
 	}
@@ -86,7 +86,7 @@ func (c *Client) DeleteUserRobotAccount(robotShortname string) error {
 
 // RegenerateUserRobotToken regenerates the token for a user's robot account
 func (c *Client) RegenerateUserRobotToken(robotShortname string) (*RobotAccount, error) {
-	req, err := newRequest("POST", fmt.Sprintf("%s/user/robots/%s/regenerate", c.BaseURL, robotShortname), nil)
+	req, err := newRequest("POST", c.buildURL("/user/robots/%s/regenerate", robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create regenerate user robot token request: %w", err)
 	}
@@ -101,7 +101,7 @@ func (c *Client) RegenerateUserRobotToken(robotShortname string) (*RobotAccount,
 
 // GetUserRobotPermissions retrieves the repository permissions for a user's robot account
 func (c *Client) GetUserRobotPermissions(robotShortname string) (*RobotPermissions, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/user/robots/%s/permissions", c.BaseURL, robotShortname), nil)
+	req, err := newRequest("GET", c.buildURL("/user/robots/%s/permissions", robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user robot permissions request: %w", err)
 	}
@@ -116,7 +116,7 @@ func (c *Client) GetUserRobotPermissions(robotShortname string) (*RobotPermissio
 
 // GetUserRobotFederation retrieves the federation configuration for a user's robot account
 func (c *Client) GetUserRobotFederation(robotShortname string) (*RobotFederation, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/user/robots/%s/federation", c.BaseURL, robotShortname), nil)
+	req, err := newRequest("GET", c.buildURL("/user/robots/%s/federation", robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user robot federation request: %w", err)
 	}
@@ -131,7 +131,7 @@ func (c *Client) GetUserRobotFederation(robotShortname string) (*RobotFederation
 
 // CreateUserRobotFederation creates or updates the federation configuration for a user's robot account
 func (c *Client) CreateUserRobotFederation(robotShortname string, configs []RobotFederationConfig) error {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/user/robots/%s/federation", c.BaseURL, robotShortname), configs)
+	req, err := newRequestWithBody("POST", c.buildURL("/user/robots/%s/federation", robotShortname), configs)
 	if err != nil {
 		return fmt.Errorf("failed to create user robot federation request: %w", err)
 	}
@@ -145,7 +145,7 @@ func (c *Client) CreateUserRobotFederation(robotShortname string, configs []Robo
 
 // DeleteUserRobotFederation deletes the federation configuration for a user's robot account
 func (c *Client) DeleteUserRobotFederation(robotShortname string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/user/robots/%s/federation", c.BaseURL, robotShortname), nil)
+	req, err := newRequest("DELETE", c.buildURL("/user/robots/%s/federation", robotShortname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete user robot federation request: %w", err)
 	}

--- a/lib/secscan.go
+++ b/lib/secscan.go
@@ -17,7 +17,7 @@ import (
 
 // GetManifestSecurity retrieves security scan information for a specific manifest
 func (c *Client) GetManifestSecurity(namespace, repository, manifestRef string, vulnerabilities bool) (*SecurityScan, error) {
-	url := fmt.Sprintf("%s/repository/%s/%s/manifest/%s/security", c.BaseURL, namespace, repository, manifestRef)
+	url := c.buildURL("/repository/%s/%s/manifest/%s/security", namespace, repository, manifestRef)
 
 	// Add query parameter to include vulnerabilities
 	if vulnerabilities {

--- a/lib/tag.go
+++ b/lib/tag.go
@@ -20,7 +20,7 @@ import (
 
 // GetTag retrieves detailed information about a specific tag
 func (c *Client) GetTag(namespace, repository, tag string) (*Tag, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/tag/%s", c.BaseURL, namespace, repository, tag), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get tag request: %w", err)
 	}
@@ -41,7 +41,7 @@ func (c *Client) UpdateTag(namespace, repository, tag, expiration string) (*Tag,
 		updateReq.Expiration = expiration
 	}
 
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/tag/%s", c.BaseURL, namespace, repository, tag), updateReq)
+	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update tag request: %w", err)
 	}
@@ -56,7 +56,7 @@ func (c *Client) UpdateTag(namespace, repository, tag, expiration string) (*Tag,
 
 // DeleteTag deletes a specific tag from a repository
 func (c *Client) DeleteTag(namespace, repository, tag string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/tag/%s", c.BaseURL, namespace, repository, tag), nil)
+	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete tag request: %w", err)
 	}
@@ -70,7 +70,7 @@ func (c *Client) DeleteTag(namespace, repository, tag string) error {
 
 // GetTagHistory retrieves the history of changes for a specific tag
 func (c *Client) GetTagHistory(namespace, repository, tag string) (*TagHistory, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/tag/%s/history", c.BaseURL, namespace, repository, tag), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/tag/%s/history", namespace, repository, tag), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get tag history request: %w", err)
 	}
@@ -85,7 +85,7 @@ func (c *Client) GetTagHistory(namespace, repository, tag string) (*TagHistory, 
 
 // RevertTag reverts a tag to a previous state by manifest digest
 func (c *Client) RevertTag(namespace, repository, tag, manifestDigest string) (*Tag, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/tag/%s/revert", c.BaseURL, namespace, repository, tag), map[string]interface{}{
+	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/tag/%s/revert", namespace, repository, tag), map[string]interface{}{
 		"manifest_digest": manifestDigest,
 	})
 	if err != nil {
@@ -107,7 +107,7 @@ func (c *Client) RestoreTag(namespace, repository, tag, manifestDigest string) e
 	}{
 		ManifestDigest: manifestDigest,
 	}
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/tag/%s/restore", c.BaseURL, namespace, repository, tag), body)
+	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/tag/%s/restore", namespace, repository, tag), body)
 	if err != nil {
 		return fmt.Errorf("failed to create restore tag request: %w", err)
 	}

--- a/lib/trigger.go
+++ b/lib/trigger.go
@@ -28,7 +28,7 @@ import (
 
 // GetTriggers retrieves all build triggers for a repository
 func (c *Client) GetTriggers(namespace, repository string) (*BuildTriggers, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/trigger/", c.BaseURL, namespace, repository), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/trigger/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get triggers request: %w", err)
 	}
@@ -43,7 +43,7 @@ func (c *Client) GetTriggers(namespace, repository string) (*BuildTriggers, erro
 
 // GetTrigger retrieves a specific build trigger by UUID
 func (c *Client) GetTrigger(namespace, repository, triggerUUID string) (*BuildTrigger, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/trigger/%s", c.BaseURL, namespace, repository, triggerUUID), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get trigger request: %w", err)
 	}
@@ -58,7 +58,7 @@ func (c *Client) GetTrigger(namespace, repository, triggerUUID string) (*BuildTr
 
 // DeleteTrigger deletes a build trigger
 func (c *Client) DeleteTrigger(namespace, repository, triggerUUID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/trigger/%s", c.BaseURL, namespace, repository, triggerUUID), nil)
+	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete trigger request: %w", err)
 	}
@@ -76,7 +76,7 @@ func (c *Client) UpdateTrigger(namespace, repository, triggerUUID string, enable
 		"enabled": enabled,
 	}
 
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/repository/%s/%s/trigger/%s", c.BaseURL, namespace, repository, triggerUUID), body)
+	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update trigger request: %w", err)
 	}
@@ -96,7 +96,7 @@ func (c *Client) StartTriggerBuild(namespace, repository, triggerUUID string, tr
 		body = triggerReq
 	}
 
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/trigger/%s/start", c.BaseURL, namespace, repository, triggerUUID), body)
+	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/trigger/%s/start", namespace, repository, triggerUUID), body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create start trigger build request: %w", err)
 	}
@@ -111,7 +111,7 @@ func (c *Client) StartTriggerBuild(namespace, repository, triggerUUID string, tr
 
 // ActivateTrigger activates a build trigger with configuration
 func (c *Client) ActivateTrigger(namespace, repository, triggerUUID string, activateReq *ActivateTriggerRequest) (*BuildTrigger, error) {
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/repository/%s/%s/trigger/%s/activate", c.BaseURL, namespace, repository, triggerUUID), activateReq)
+	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/trigger/%s/activate", namespace, repository, triggerUUID), activateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create activate trigger request: %w", err)
 	}
@@ -126,7 +126,7 @@ func (c *Client) ActivateTrigger(namespace, repository, triggerUUID string, acti
 
 // GetTriggerBuilds gets the builds started by a specific trigger
 func (c *Client) GetTriggerBuilds(namespace, repository, triggerUUID string, limit int) (*Builds, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/repository/%s/%s/trigger/%s/builds", c.BaseURL, namespace, repository, triggerUUID), nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/trigger/%s/builds", namespace, repository, triggerUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get trigger builds request: %w", err)
 	}

--- a/lib/user.go
+++ b/lib/user.go
@@ -52,7 +52,7 @@ func (c *Client) GetStarredRepositories() (*StarredRepositories, error) {
 
 // StarRepository adds a repository to the user's starred list
 func (c *Client) StarRepository(namespace, repository string) error {
-	req, err := newRequest("PUT", fmt.Sprintf("%s/repository/%s/%s/star", c.BaseURL, namespace, repository), nil)
+	req, err := newRequest("PUT", c.buildURL("/repository/%s/%s/star", namespace, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create star repository request: %w", err)
 	}
@@ -66,7 +66,7 @@ func (c *Client) StarRepository(namespace, repository string) error {
 
 // UnstarRepository removes a repository from the user's starred list
 func (c *Client) UnstarRepository(namespace, repository string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/repository/%s/%s/star", c.BaseURL, namespace, repository), nil)
+	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/star", namespace, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create unstar repository request: %w", err)
 	}
@@ -85,7 +85,7 @@ func (c *Client) StarUserRepository(namespace, repository string) error {
 	}{
 		Repository: namespace + "/" + repository,
 	}
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/user/starred", c.BaseURL), body)
+	req, err := newRequestWithBody("POST", c.buildURL("/user/starred"), body)
 	if err != nil {
 		return fmt.Errorf("failed to create star user repository request: %w", err)
 	}
@@ -100,7 +100,7 @@ func (c *Client) StarUserRepository(namespace, repository string) error {
 // UnstarUserRepository unstars a repository using the /user/starred endpoint
 func (c *Client) UnstarUserRepository(namespace, repository string) error {
 	// The spec uses {repository} as namespace/repo
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/user/starred/%s/%s", c.BaseURL, namespace, repository), nil)
+	req, err := newRequest("DELETE", c.buildURL("/user/starred/%s/%s", namespace, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create unstar user repository request: %w", err)
 	}
@@ -114,7 +114,7 @@ func (c *Client) UnstarUserRepository(namespace, repository string) error {
 
 // GetUserByUsername retrieves information about a specific user
 func (c *Client) GetUserByUsername(username string) (*UserDetails, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/users/%s", c.BaseURL, username), nil)
+	req, err := newRequest("GET", c.buildURL("/users/%s", username), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user by username request: %w", err)
 	}
@@ -129,7 +129,7 @@ func (c *Client) GetUserByUsername(username string) (*UserDetails, error) {
 
 // GetUserMarketplace retrieves marketplace information for the current user
 func (c *Client) GetUserMarketplace() (*MarketplaceInfo, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/user/marketplace", c.BaseURL), nil)
+	req, err := newRequest("GET", c.buildURL("/user/marketplace"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user marketplace request: %w", err)
 	}


### PR DESCRIPTION
## Summary

- **URL path escaping**: Add `buildURL()` helper that applies `url.PathEscape()` to all string path segments, preventing malformed URLs from user-supplied values containing `/`, `?`, `#`, or `%`. Converts all 152 `fmt.Sprintf` URL constructions across 18 lib files.
- **Bound error reads**: Add `maxErrorBodySize` (1MB) constant and use `io.LimitReader` on all 4 HTTP error response reads to prevent memory exhaustion from oversized error bodies.

## Test plan

- [x] `make lint` passes (0 issues)
- [x] `make test` passes (all 240 tests)
- [ ] CI checks pass

Fixes #121
Fixes #139