### PR TITLE
refactor: migrate manual json.MarshalIndent calls to printJSON helper

### DIFF
--- a/cmd/errortype.go
+++ b/cmd/errortype.go
@@ -7,7 +7,6 @@ This file contains the commands for the Error API:
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -39,12 +38,7 @@ This endpoint provides details about error types that can be returned by the Qua
 			os.Exit(1)
 		}
 
-		output, err := json.MarshalIndent(errType, "", "  ")
-		if err != nil {
-			fmt.Println("Error marshaling response:", err)
-			os.Exit(1)
-		}
-		fmt.Println(string(output))
+		printJSON(errType)
 	},
 }
 

--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -11,7 +11,6 @@ This file contains the commands for the Prototype API:
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -53,12 +52,7 @@ var prototypeListCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		output, err := json.MarshalIndent(prototypes, "", "  ")
-		if err != nil {
-			fmt.Println("Error marshaling response:", err)
-			os.Exit(1)
-		}
-		fmt.Println(string(output))
+		printJSON(prototypes)
 	},
 }
 
@@ -81,12 +75,7 @@ var prototypeInfoCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		output, err := json.MarshalIndent(prototype, "", "  ")
-		if err != nil {
-			fmt.Println("Error marshaling response:", err)
-			os.Exit(1)
-		}
-		fmt.Println(string(output))
+		printJSON(prototype)
 	},
 }
 
@@ -135,12 +124,7 @@ Roles:
 			os.Exit(1)
 		}
 
-		output, err := json.MarshalIndent(prototype, "", "  ")
-		if err != nil {
-			fmt.Println("Error marshaling response:", err)
-			os.Exit(1)
-		}
-		fmt.Println(string(output))
+		printJSON(prototype)
 	},
 }
 
@@ -171,12 +155,7 @@ var prototypeUpdateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		output, err := json.MarshalIndent(prototype, "", "  ")
-		if err != nil {
-			fmt.Println("Error marshaling response:", err)
-			os.Exit(1)
-		}
-		fmt.Println(string(output))
+		printJSON(prototype)
 	},
 }
 

--- a/cmd/repotoken.go
+++ b/cmd/repotoken.go
@@ -13,7 +13,6 @@ WARNING: Repository tokens are deprecated. Use robot accounts instead.
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -54,12 +53,7 @@ var repotokenListCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		output, err := json.MarshalIndent(tokens, "", "  ")
-		if err != nil {
-			fmt.Println("Error marshaling response:", err)
-			os.Exit(1)
-		}
-		fmt.Println(string(output))
+		printJSON(tokens)
 	},
 }
 
@@ -82,12 +76,7 @@ var repotokenInfoCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		output, err := json.MarshalIndent(repoToken, "", "  ")
-		if err != nil {
-			fmt.Println("Error marshaling response:", err)
-			os.Exit(1)
-		}
-		fmt.Println(string(output))
+		printJSON(repoToken)
 	},
 }
 
@@ -114,12 +103,7 @@ var repotokenCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		output, err := json.MarshalIndent(repoToken, "", "  ")
-		if err != nil {
-			fmt.Println("Error marshaling response:", err)
-			os.Exit(1)
-		}
-		fmt.Println(string(output))
+		printJSON(repoToken)
 	},
 }
 
@@ -150,12 +134,7 @@ var repotokenUpdateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		output, err := json.MarshalIndent(repoToken, "", "  ")
-		if err != nil {
-			fmt.Println("Error marshaling response:", err)
-			os.Exit(1)
-		}
-		fmt.Println(string(output))
+		printJSON(repoToken)
 	},
 }
 

--- a/cmd/trigger.go
+++ b/cmd/trigger.go
@@ -13,7 +13,6 @@ This file contains the commands for the Trigger API:
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -54,12 +53,7 @@ var triggerListCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		output, err := json.MarshalIndent(triggers, "", "  ")
-		if err != nil {
-			fmt.Println("Error marshaling response:", err)
-			os.Exit(1)
-		}
-		fmt.Println(string(output))
+		printJSON(triggers)
 	},
 }
 
@@ -82,12 +76,7 @@ var triggerInfoCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		output, err := json.MarshalIndent(trigger, "", "  ")
-		if err != nil {
-			fmt.Println("Error marshaling response:", err)
-			os.Exit(1)
-		}
-		fmt.Println(string(output))
+		printJSON(trigger)
 	},
 }
 
@@ -133,12 +122,7 @@ var triggerEnableCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		output, err := json.MarshalIndent(trigger, "", "  ")
-		if err != nil {
-			fmt.Println("Error marshaling response:", err)
-			os.Exit(1)
-		}
-		fmt.Println(string(output))
+		printJSON(trigger)
 	},
 }
 
@@ -161,12 +145,7 @@ var triggerDisableCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		output, err := json.MarshalIndent(trigger, "", "  ")
-		if err != nil {
-			fmt.Println("Error marshaling response:", err)
-			os.Exit(1)
-		}
-		fmt.Println(string(output))
+		printJSON(trigger)
 	},
 }
 
@@ -196,12 +175,7 @@ var triggerStartCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		output, err := json.MarshalIndent(build, "", "  ")
-		if err != nil {
-			fmt.Println("Error marshaling response:", err)
-			os.Exit(1)
-		}
-		fmt.Println(string(output))
+		printJSON(build)
 	},
 }
 
@@ -229,12 +203,7 @@ var triggerActivateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		output, err := json.MarshalIndent(trigger, "", "  ")
-		if err != nil {
-			fmt.Println("Error marshaling response:", err)
-			os.Exit(1)
-		}
-		fmt.Println(string(output))
+		printJSON(trigger)
 	},
 }
 


### PR DESCRIPTION
## Summary
- Replace 15 duplicated `json.MarshalIndent` + error-handle + print blocks with the shared `printJSON()` helper
- Affected files: `cmd/trigger.go`, `cmd/prototype.go`, `cmd/repotoken.go`, `cmd/errortype.go`
- Remove now-unused `encoding/json` imports from all four files

Net: -79 lines of duplicated code.

Closes #124