### PR TITLE
refactor: remove commented-out billing methods and unused PaymentMethod struct

### DIFF
--- a/lib/billing.go
+++ b/lib/billing.go
@@ -15,7 +15,7 @@ User Billing:
 Plans:
   - GET /api/v1/plans                                - GetAvailablePlans()
 
-Note: User invoice endpoints and payment method endpoints are not available in Quay API.
+Note: User invoice endpoint is not available in Quay API.
 */
 package lib
 
@@ -109,37 +109,6 @@ func (c *Client) GetOrganizationInvoices(orgname string) ([]Invoice, error) {
 func (c *Client) GetUserInvoices() ([]Invoice, error) {
 	return nil, fmt.Errorf("user invoices endpoint not available in Quay API")
 }
-
-// Original implementation commented out due to 404 errors:
-// func (c *Client) GetUserInvoices() ([]Invoice, error) {
-// 	// Get new request
-// 	req, err := newRequest("GET", c.BaseURL+"/user/invoices", nil)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-//
-// 	var invoicesResp struct {
-// 		Invoices []Invoice `json:"invoices"`
-// 	}
-// 	if err := c.get(req, &invoicesResp); err != nil {
-// 		return nil, err
-// 	}
-//
-// 	return invoicesResp.Invoices, nil
-// }
-
-// NOTE: The following endpoints don't exist in the actual Quay API
-// They are commented out to prevent API errors
-
-// GetOrganizationPaymentMethods - NOT AVAILABLE in Quay API
-// func (c *Client) GetOrganizationPaymentMethods(orgname string) ([]PaymentMethod, error) {
-// 	return nil, fmt.Errorf("payment methods endpoint not available in Quay API")
-// }
-
-// GetUserPaymentMethods - NOT AVAILABLE in Quay API
-// func (c *Client) GetUserPaymentMethods() ([]PaymentMethod, error) {
-// 	return nil, fmt.Errorf("payment methods endpoint not available in Quay API")
-// }
 
 // GetAvailablePlans returns available subscription plans
 func (c *Client) GetAvailablePlans() ([]Subscription, error) {

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -20,7 +20,7 @@ Log Types:
   - LogEntry, AggregatedLogEntry, Logs, AggregatedLogs - Logging data
 
 Billing Types:
-  - BillingInfo, Subscription, PaymentMethod, Invoice - Billing and subscription data
+  - BillingInfo, Subscription, Invoice - Billing and subscription data
 
 Organization Types:
   - Organization, OrganizationMember, OrganizationMembers, OrganizationRepository, OrganizationRepositories
@@ -181,18 +181,6 @@ type MarketplaceSubscription struct {
 	ExpiresAt     string `json:"expires_at,omitempty"`
 	PlanID        string `json:"plan_id,omitempty"`
 	VendorAccount string `json:"vendor_account,omitempty"`
-}
-
-// PaymentMethod represents a payment method.
-type PaymentMethod struct {
-	ID          string `json:"id,omitempty"`
-	Type        string `json:"type,omitempty"`
-	LastFour    string `json:"last_four,omitempty"`
-	Brand       string `json:"brand,omitempty"`
-	ExpiryMonth int    `json:"expiry_month,omitempty"`
-	ExpiryYear  int    `json:"expiry_year,omitempty"`
-	IsDefault   bool   `json:"is_default,omitempty"`
-	CreatedAt   string `json:"created_at,omitempty"`
 }
 
 // Invoice represents a billing invoice.


### PR DESCRIPTION
## Summary
- Remove commented-out `GetOrganizationPaymentMethods` and `GetUserPaymentMethods` stubs
- Remove commented-out original `GetUserInvoices` implementation
- Remove unused `PaymentMethod` struct from `structs.go`
- Keep the active `GetUserInvoices` stub that returns a descriptive error

Net: -43 lines of dead code.

Closes #146