### PR TITLE
refactor: remove duplicate star/unstar user-scoped methods

### DIFF
--- a/cmd/user.go
+++ b/cmd/user.go
@@ -14,10 +14,12 @@ var userCmd = &cobra.Command{
 	Long: `Commands for managing user account information and starred repositories.
 
 Available commands:
-  info    - Get current user information
-  starred - List starred repositories
-  star    - Star a repository
-  unstar  - Unstar a repository`,
+  info        - Get current user information
+  starred     - List starred repositories
+  star        - Star a repository
+  unstar      - Unstar a repository
+  lookup      - Look up a user by username
+  marketplace - Get user marketplace information`,
 }
 
 // User Info
@@ -130,40 +132,6 @@ var userMarketplaceCmd = &cobra.Command{
 	},
 }
 
-var starUserRepoCmd = &cobra.Command{
-	Use:   "star-user",
-	Short: "Star a repository (user endpoint)",
-	Long:  `Add a repository to your starred list using the user star endpoint.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-
-		err := client.StarUserRepository(namespace, repository)
-		if err != nil {
-			fmt.Printf("Error starring repository: %v\n", err)
-			os.Exit(1)
-		}
-
-		fmt.Printf("Successfully starred repository %s/%s\n", namespace, repository)
-	},
-}
-
-var unstarUserRepoCmd = &cobra.Command{
-	Use:   "unstar-user",
-	Short: "Unstar a repository (user endpoint)",
-	Long:  `Remove a repository from your starred list using the user star endpoint.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-
-		err := client.UnstarUserRepository(namespace, repository)
-		if err != nil {
-			fmt.Printf("Error unstarring repository: %v\n", err)
-			os.Exit(1)
-		}
-
-		fmt.Printf("Successfully unstarred repository %s/%s\n", namespace, repository)
-	},
-}
-
 func init() {
 	// Add subcommands to user command
 	userCmd.AddCommand(userInfoCmd)
@@ -172,9 +140,6 @@ func init() {
 	userCmd.AddCommand(unstarRepoCmd)
 	userCmd.AddCommand(userLookupCmd)
 	userCmd.AddCommand(userMarketplaceCmd)
-	userCmd.AddCommand(starUserRepoCmd)
-	userCmd.AddCommand(unstarUserRepoCmd)
-
 	// Star command specific flags (requires repository context)
 	starRepoCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
 	starRepoCmd.Flags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
@@ -206,27 +171,4 @@ func init() {
 		os.Exit(1)
 	}
 
-	// Star-user command flags
-	starUserRepoCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
-	starUserRepoCmd.Flags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
-	if err := starUserRepoCmd.MarkFlagRequired("namespace"); err != nil {
-		fmt.Printf("Error marking namespace flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := starUserRepoCmd.MarkFlagRequired("repository"); err != nil {
-		fmt.Printf("Error marking repository flag as required: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Unstar-user command flags
-	unstarUserRepoCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
-	unstarUserRepoCmd.Flags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
-	if err := unstarUserRepoCmd.MarkFlagRequired("namespace"); err != nil {
-		fmt.Printf("Error marking namespace flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := unstarUserRepoCmd.MarkFlagRequired("repository"); err != nil {
-		fmt.Printf("Error marking repository flag as required: %v\n", err)
-		os.Exit(1)
-	}
 }

--- a/lib/user.go
+++ b/lib/user.go
@@ -78,40 +78,6 @@ func (c *Client) UnstarRepository(namespace, repository string) error {
 	return nil
 }
 
-// StarUserRepository stars a repository using the /user/starred endpoint
-func (c *Client) StarUserRepository(namespace, repository string) error {
-	body := struct {
-		Repository string `json:"repository"`
-	}{
-		Repository: namespace + "/" + repository,
-	}
-	req, err := newRequestWithBody("POST", c.buildURL("/user/starred"), body)
-	if err != nil {
-		return fmt.Errorf("failed to create star user repository request: %w", err)
-	}
-
-	if err := c.post(req, nil); err != nil {
-		return fmt.Errorf("failed to star repository: %w", err)
-	}
-
-	return nil
-}
-
-// UnstarUserRepository unstars a repository using the /user/starred endpoint
-func (c *Client) UnstarUserRepository(namespace, repository string) error {
-	// The spec uses {repository} as namespace/repo
-	req, err := newRequest("DELETE", c.buildURL("/user/starred/%s/%s", namespace, repository), nil)
-	if err != nil {
-		return fmt.Errorf("failed to create unstar user repository request: %w", err)
-	}
-
-	if err := c.delete(req); err != nil {
-		return fmt.Errorf("failed to unstar repository: %w", err)
-	}
-
-	return nil
-}
-
 // GetUserByUsername retrieves information about a specific user
 func (c *Client) GetUserByUsername(username string) (*UserDetails, error) {
 	req, err := newRequest("GET", c.buildURL("/users/%s", username), nil)

--- a/lib/user_test.go
+++ b/lib/user_test.go
@@ -208,65 +208,6 @@ func TestUnstarRepository(t *testing.T) {
 	}
 }
 
-func TestStarUserRepository(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpMethodPost {
-			t.Errorf("Expected POST request, got %s", r.Method)
-		}
-		expectedPath := "/api/v1/user/starred"
-		if r.URL.Path != expectedPath {
-			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
-		}
-
-		var req map[string]interface{}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Errorf("Failed to decode request body: %v", err)
-		}
-
-		expectedRepo := testNamespace + "/" + testRepository
-		if req["repository"] != expectedRepo {
-			t.Errorf("Expected repository '%s', got '%v'", expectedRepo, req["repository"])
-		}
-
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
-	if err != nil {
-		t.Fatalf("Failed to create client: %v", err)
-	}
-
-	err = client.StarUserRepository(testNamespace, testRepository)
-	if err != nil {
-		t.Fatalf("StarUserRepository returned error: %v", err)
-	}
-}
-
-func TestUnstarUserRepository(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != httpMethodDelete {
-			t.Errorf("Expected DELETE request, got %s", r.Method)
-		}
-		expectedPath := "/api/v1/user/starred/" + testNamespace + "/" + testRepository
-		if r.URL.Path != expectedPath {
-			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
-		}
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	defer server.Close()
-
-	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
-	if err != nil {
-		t.Fatalf("Failed to create client: %v", err)
-	}
-
-	err = client.UnstarUserRepository(testNamespace, testRepository)
-	if err != nil {
-		t.Fatalf("UnstarUserRepository returned error: %v", err)
-	}
-}
-
 func TestGetUserByUsername(t *testing.T) {
 	mockUser := UserDetails{
 		Username:      testUserName,
@@ -421,16 +362,6 @@ func TestUserHTTPErrors(t *testing.T) {
 	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
-	}
-
-	err = client.StarUserRepository(testNamespace, testRepository)
-	if err == nil {
-		t.Error("Expected error from StarUserRepository, got nil")
-	}
-
-	err = client.UnstarUserRepository(testNamespace, testRepository)
-	if err == nil {
-		t.Error("Expected error from UnstarUserRepository, got nil")
 	}
 
 	_, err = client.GetUserByUsername(testUserName)


### PR DESCRIPTION
## Summary
- Remove `StarUserRepository`/`UnstarUserRepository` (POST/DELETE `/user/starred`) from `lib/user.go`
- Remove `star-user` and `unstar-user` CLI commands from `cmd/user.go`
- Remove corresponding tests from `lib/user_test.go`
- Keep the simpler repository-scoped `StarRepository`/`UnstarRepository` (PUT/DELETE `/repository/{ns}/{repo}/star`)

Both method pairs achieved the same result via different API endpoints. The repository-scoped pair is simpler and more direct.

Closes #147