### PR TITLE
refactor: standardize query parameter construction on addQueryParams

### DIFF
--- a/lib/client.go
+++ b/lib/client.go
@@ -38,6 +38,7 @@ import (
 )
 
 const maxErrorBodySize = 1 << 20 // 1 MB
+const queryValueTrue = "true"
 
 // DefaultQuayURL is the default Quay.io API base URL.
 const DefaultQuayURL = "https://quay.io/api/v1"
@@ -172,6 +173,14 @@ func (c *Client) delete(req *http.Request) error {
 	}
 
 	return nil
+}
+
+func addQueryParams(req *http.Request, params map[string]string) {
+	q := req.URL.Query()
+	for key, value := range params {
+		q.Add(key, value)
+	}
+	req.URL.RawQuery = q.Encode()
 }
 
 func decodeJSON(r io.Reader, v any) error {

--- a/lib/discovery.go
+++ b/lib/discovery.go
@@ -67,14 +67,14 @@ func (c *Client) GetEntities(prefix string, includeOrgs, includeTeams bool) (*En
 		return nil, fmt.Errorf("failed to create get entities request: %w", err)
 	}
 
-	q := req.URL.Query()
+	params := map[string]string{}
 	if includeOrgs {
-		q.Add("includeOrgs", "true")
+		params["includeOrgs"] = queryValueTrue
 	}
 	if includeTeams {
-		q.Add("includeTeams", "true")
+		params["includeTeams"] = queryValueTrue
 	}
-	req.URL.RawQuery = q.Encode()
+	addQueryParams(req, params)
 
 	var entities Entities
 	if err := c.get(req, &entities); err != nil {

--- a/lib/logs.go
+++ b/lib/logs.go
@@ -23,15 +23,6 @@ const (
 	endTimeParam   = "endtime"
 )
 
-// addQueryParams adds query parameters to a request URL.
-func addQueryParams(req *http.Request, params map[string]string) {
-	q := req.URL.Query()
-	for key, value := range params {
-		q.Add(key, value)
-	}
-	req.URL.RawQuery = q.Encode()
-}
-
 // addLogQueryParams adds optional pagination and date range params to a log request.
 func addLogQueryParams(req *http.Request, nextPage, startDate, endDate string) {
 	params := map[string]string{}

--- a/lib/repository.go
+++ b/lib/repository.go
@@ -136,26 +136,26 @@ func (c *Client) ListRepositories(namespace string, public, starred, popularity 
 		return nil, fmt.Errorf("failed to create list repositories request: %w", err)
 	}
 
-	q := req.URL.Query()
+	params := map[string]string{}
 	if namespace != "" {
-		q.Add("namespace", namespace)
+		params["namespace"] = namespace
 	}
 	if public {
-		q.Add("public", "true")
+		params["public"] = queryValueTrue
 	}
 	if starred {
-		q.Add("starred", "true")
+		params["starred"] = queryValueTrue
 	}
 	if popularity {
-		q.Add("popularity", "true")
+		params["popularity"] = queryValueTrue
 	}
 	if page > 0 {
-		q.Add("page", fmt.Sprintf("%d", page))
+		params["page"] = fmt.Sprintf("%d", page)
 	}
 	if limit > 0 {
-		q.Add("limit", fmt.Sprintf("%d", limit))
+		params["limit"] = fmt.Sprintf("%d", limit)
 	}
-	req.URL.RawQuery = q.Encode()
+	addQueryParams(req, params)
 
 	var repos RepositoryList
 	if err := c.get(req, &repos); err != nil {
@@ -191,14 +191,14 @@ func (c *Client) ListTags(namespace, repository string, limit int, onlyActive bo
 		return nil, fmt.Errorf("failed to create list tags request: %w", err)
 	}
 
-	q := req.URL.Query()
+	params := map[string]string{}
 	if limit > 0 {
-		q.Add("limit", fmt.Sprintf("%d", limit))
+		params["limit"] = fmt.Sprintf("%d", limit)
 	}
 	if onlyActive {
-		q.Add("onlyActiveTags", "true")
+		params["onlyActiveTags"] = queryValueTrue
 	}
-	req.URL.RawQuery = q.Encode()
+	addQueryParams(req, params)
 
 	var tags RepositoryTags
 	if err := c.get(req, &tags); err != nil {

--- a/lib/search.go
+++ b/lib/search.go
@@ -14,21 +14,20 @@ package lib
 
 import (
 	"fmt"
-	"net/url"
 )
 
 // SearchRepositories searches for repositories matching the query
 func (c *Client) SearchRepositories(query string, page int) (*SearchRepositoryResult, error) {
-	params := url.Values{}
-	params.Add("query", query)
-	if page > 0 {
-		params.Add("page", fmt.Sprintf("%d", page))
-	}
-
-	req, err := newRequest("GET", fmt.Sprintf("%s/find/repositories?%s", c.BaseURL, params.Encode()), nil)
+	req, err := newRequest("GET", c.BaseURL+"/find/repositories", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create search repositories request: %w", err)
 	}
+
+	params := map[string]string{"query": query}
+	if page > 0 {
+		params["page"] = fmt.Sprintf("%d", page)
+	}
+	addQueryParams(req, params)
 
 	var result SearchRepositoryResult
 	if err := c.get(req, &result); err != nil {
@@ -40,13 +39,12 @@ func (c *Client) SearchRepositories(query string, page int) (*SearchRepositoryRe
 
 // SearchAll searches for all entity types (repositories, users, organizations, teams, robots)
 func (c *Client) SearchAll(query string) (*SearchAllResult, error) {
-	params := url.Values{}
-	params.Add("query", query)
-
-	req, err := newRequest("GET", fmt.Sprintf("%s/find/all?%s", c.BaseURL, params.Encode()), nil)
+	req, err := newRequest("GET", c.BaseURL+"/find/all", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create search all request: %w", err)
 	}
+
+	addQueryParams(req, map[string]string{"query": query})
 
 	var result SearchAllResult
 	if err := c.get(req, &result); err != nil {

--- a/lib/secscan.go
+++ b/lib/secscan.go
@@ -17,16 +17,13 @@ import (
 
 // GetManifestSecurity retrieves security scan information for a specific manifest
 func (c *Client) GetManifestSecurity(namespace, repository, manifestRef string, vulnerabilities bool) (*SecurityScan, error) {
-	url := c.buildURL("/repository/%s/%s/manifest/%s/security", namespace, repository, manifestRef)
-
-	// Add query parameter to include vulnerabilities
-	if vulnerabilities {
-		url += "?vulnerabilities=true"
-	}
-
-	req, err := newRequest("GET", url, nil)
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/manifest/%s/security", namespace, repository, manifestRef), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest security request: %w", err)
+	}
+
+	if vulnerabilities {
+		addQueryParams(req, map[string]string{"vulnerabilities": queryValueTrue})
 	}
 
 	var securityScan SecurityScan

--- a/lib/trigger.go
+++ b/lib/trigger.go
@@ -132,9 +132,7 @@ func (c *Client) GetTriggerBuilds(namespace, repository, triggerUUID string, lim
 	}
 
 	if limit > 0 {
-		q := req.URL.Query()
-		q.Add("limit", fmt.Sprintf("%d", limit))
-		req.URL.RawQuery = q.Encode()
+		addQueryParams(req, map[string]string{"limit": fmt.Sprintf("%d", limit)})
 	}
 
 	var builds Builds


### PR DESCRIPTION
## Summary
- Move `addQueryParams` helper from `logs.go` to `client.go` for shared use
- Convert all 4 query parameter patterns to use `addQueryParams` consistently:
  - `secscan.go`: replace fragile string concatenation (`url += "?..."`)
  - `search.go`: replace `url.Values{}` pre-build pattern
  - `repository.go`, `trigger.go`, `discovery.go`: replace inline `req.URL.Query()` blocks
- Add `queryValueTrue` constant to satisfy goconst linter

Closes #136