### PR TITLE
refactor: add consistent error wrapping across domain files

### DIFF
--- a/lib/billing.go
+++ b/lib/billing.go
@@ -28,12 +28,12 @@ func (c *Client) GetOrganizationBilling(orgname string) (*BillingInfo, error) {
 	// Get new request
 	req, err := newRequest("GET", c.buildURL("/organization/%s/plan", orgname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get organization billing request: %w", err)
 	}
 
 	var billing BillingInfo
 	if err := c.get(req, &billing); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get organization billing: %w", err)
 	}
 
 	return &billing, nil
@@ -44,12 +44,12 @@ func (c *Client) GetUserBilling() (*BillingInfo, error) {
 	// Get new request
 	req, err := newRequest("GET", c.BaseURL+"/user/plan", nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get user billing request: %w", err)
 	}
 
 	var billing BillingInfo
 	if err := c.get(req, &billing); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get user billing: %w", err)
 	}
 
 	return &billing, nil
@@ -60,12 +60,12 @@ func (c *Client) GetOrganizationSubscription(orgname string) (*Subscription, err
 	// Get new request
 	req, err := newRequest("GET", c.buildURL("/organization/%s/plan", orgname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get organization subscription request: %w", err)
 	}
 
 	var subscription Subscription
 	if err := c.get(req, &subscription); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get organization subscription: %w", err)
 	}
 
 	return &subscription, nil
@@ -76,12 +76,12 @@ func (c *Client) GetUserSubscription() (*Subscription, error) {
 	// Get new request
 	req, err := newRequest("GET", c.BaseURL+"/user/plan", nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get user subscription request: %w", err)
 	}
 
 	var subscription Subscription
 	if err := c.get(req, &subscription); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get user subscription: %w", err)
 	}
 
 	return &subscription, nil
@@ -92,14 +92,14 @@ func (c *Client) GetOrganizationInvoices(orgname string) ([]Invoice, error) {
 	// Get new request
 	req, err := newRequest("GET", c.buildURL("/organization/%s/invoices", orgname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get organization invoices request: %w", err)
 	}
 
 	var invoicesResp struct {
 		Invoices []Invoice `json:"invoices"`
 	}
 	if err := c.get(req, &invoicesResp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get organization invoices: %w", err)
 	}
 
 	return invoicesResp.Invoices, nil
@@ -115,14 +115,14 @@ func (c *Client) GetAvailablePlans() ([]Subscription, error) {
 	// Get new request
 	req, err := newRequest("GET", c.BaseURL+"/plans", nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get available plans request: %w", err)
 	}
 
 	var plansResp struct {
 		Plans []Subscription `json:"plans"`
 	}
 	if err := c.get(req, &plansResp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get available plans: %w", err)
 	}
 
 	return plansResp.Plans, nil

--- a/lib/logs.go
+++ b/lib/logs.go
@@ -15,6 +15,7 @@ All log endpoints support pagination via next_page parameter.
 package lib
 
 import (
+	"fmt"
 	"net/http"
 )
 
@@ -45,7 +46,7 @@ func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate str
 	// Get new request
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/aggregatelogs", namespace, repository), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get repository aggregate logs request: %w", err)
 	}
 
 	// Set query parameters
@@ -56,7 +57,7 @@ func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate str
 
 	var logs AggregatedLogs
 	if err := c.get(req, &logs); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get repository aggregate logs: %w", err)
 	}
 
 	return &logs, nil
@@ -66,14 +67,14 @@ func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate str
 func (c *Client) GetLogs(namespace, repository, nextPage, startDate, endDate string) (*Logs, error) {
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/logs", namespace, repository), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get repository logs request: %w", err)
 	}
 
 	addLogQueryParams(req, nextPage, startDate, endDate)
 
 	var logs Logs
 	if err := c.get(req, &logs); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get repository logs: %w", err)
 	}
 
 	return &logs, nil
@@ -83,14 +84,14 @@ func (c *Client) GetLogs(namespace, repository, nextPage, startDate, endDate str
 func (c *Client) GetOrganizationLogs(orgname, nextPage, startDate, endDate string) (*Logs, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/logs", orgname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get organization logs request: %w", err)
 	}
 
 	addLogQueryParams(req, nextPage, startDate, endDate)
 
 	var logs Logs
 	if err := c.get(req, &logs); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get organization logs: %w", err)
 	}
 
 	return &logs, nil
@@ -100,7 +101,7 @@ func (c *Client) GetOrganizationLogs(orgname, nextPage, startDate, endDate strin
 func (c *Client) GetOrganizationAggregatedLogs(orgname, startDate, endDate string) (*AggregatedLogs, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/aggregatelogs", orgname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get organization aggregate logs request: %w", err)
 	}
 
 	addQueryParams(req, map[string]string{
@@ -110,7 +111,7 @@ func (c *Client) GetOrganizationAggregatedLogs(orgname, startDate, endDate strin
 
 	var logs AggregatedLogs
 	if err := c.get(req, &logs); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get organization aggregate logs: %w", err)
 	}
 
 	return &logs, nil
@@ -120,11 +121,11 @@ func (c *Client) GetOrganizationAggregatedLogs(orgname, startDate, endDate strin
 func (c *Client) ExportOrganizationLogs(orgname string, request *ExportLogsRequest) error {
 	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/exportlogs", orgname), request)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create export organization logs request: %w", err)
 	}
 
 	if err := c.post(req, nil); err != nil {
-		return err
+		return fmt.Errorf("failed to export organization logs: %w", err)
 	}
 
 	return nil
@@ -134,14 +135,14 @@ func (c *Client) ExportOrganizationLogs(orgname string, request *ExportLogsReque
 func (c *Client) GetUserLogs(nextPage, startDate, endDate string) (*Logs, error) {
 	req, err := newRequest("GET", c.buildURL("/user/logs"), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get user logs request: %w", err)
 	}
 
 	addLogQueryParams(req, nextPage, startDate, endDate)
 
 	var logs Logs
 	if err := c.get(req, &logs); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get user logs: %w", err)
 	}
 
 	return &logs, nil
@@ -151,7 +152,7 @@ func (c *Client) GetUserLogs(nextPage, startDate, endDate string) (*Logs, error)
 func (c *Client) GetUserAggregatedLogs(startDate, endDate string) (*AggregatedLogs, error) {
 	req, err := newRequest("GET", c.buildURL("/user/aggregatelogs"), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get user aggregate logs request: %w", err)
 	}
 
 	addQueryParams(req, map[string]string{
@@ -161,7 +162,7 @@ func (c *Client) GetUserAggregatedLogs(startDate, endDate string) (*AggregatedLo
 
 	var logs AggregatedLogs
 	if err := c.get(req, &logs); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get user aggregate logs: %w", err)
 	}
 
 	return &logs, nil
@@ -171,11 +172,11 @@ func (c *Client) GetUserAggregatedLogs(startDate, endDate string) (*AggregatedLo
 func (c *Client) ExportUserLogs(request *ExportLogsRequest) error {
 	req, err := newRequestWithBody("POST", c.buildURL("/user/exportlogs"), request)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create export user logs request: %w", err)
 	}
 
 	if err := c.post(req, nil); err != nil {
-		return err
+		return fmt.Errorf("failed to export user logs: %w", err)
 	}
 
 	return nil
@@ -185,11 +186,11 @@ func (c *Client) ExportUserLogs(request *ExportLogsRequest) error {
 func (c *Client) ExportRepositoryLogs(namespace, repository string, request *ExportLogsRequest) error {
 	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/exportlogs", namespace, repository), request)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create export repository logs request: %w", err)
 	}
 
 	if err := c.post(req, nil); err != nil {
-		return err
+		return fmt.Errorf("failed to export repository logs: %w", err)
 	}
 
 	return nil

--- a/lib/organization.go
+++ b/lib/organization.go
@@ -97,12 +97,12 @@ func (c *Client) CreateOrganization(name, email string) (*Organization, error) {
 		Email: email,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create organization request: %w", err)
 	}
 
 	var org Organization
 	if err := c.post(req, &org); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create organization: %w", err)
 	}
 
 	return &org, nil
@@ -112,12 +112,12 @@ func (c *Client) CreateOrganization(name, email string) (*Organization, error) {
 func (c *Client) GetOrganization(orgname string) (*Organization, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s", orgname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get organization request: %w", err)
 	}
 
 	var org Organization
 	if err := c.get(req, &org); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get organization: %w", err)
 	}
 
 	return &org, nil
@@ -127,10 +127,14 @@ func (c *Client) GetOrganization(orgname string) (*Organization, error) {
 func (c *Client) DeleteOrganization(orgname string) error {
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s", orgname), nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create delete organization request: %w", err)
 	}
 
-	return c.delete(req)
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to delete organization: %w", err)
+	}
+
+	return nil
 }
 
 // UpdateOrganization updates organization settings
@@ -139,12 +143,12 @@ func (c *Client) UpdateOrganization(orgname, email string) (*Organization, error
 		"email": email,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create update organization request: %w", err)
 	}
 
 	var org Organization
 	if err := c.put(req, &org); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to update organization: %w", err)
 	}
 
 	return &org, nil
@@ -156,12 +160,12 @@ func (c *Client) UpdateOrganization(orgname, email string) (*Organization, error
 func (c *Client) GetOrganizationMembers(orgname string) (*OrganizationMembers, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/members", orgname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get organization members request: %w", err)
 	}
 
 	var members OrganizationMembers
 	if err := c.get(req, &members); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get organization members: %w", err)
 	}
 
 	return &members, nil
@@ -171,20 +175,28 @@ func (c *Client) GetOrganizationMembers(orgname string) (*OrganizationMembers, e
 func (c *Client) AddOrganizationMember(orgname, membername string) error {
 	req, err := newRequest("PUT", c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create add organization member request: %w", err)
 	}
 
-	return c.put(req, nil)
+	if err := c.put(req, nil); err != nil {
+		return fmt.Errorf("failed to add organization member: %w", err)
+	}
+
+	return nil
 }
 
 // RemoveOrganizationMember removes a member from an organization
 func (c *Client) RemoveOrganizationMember(orgname, membername string) error {
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create remove organization member request: %w", err)
 	}
 
-	return c.delete(req)
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to remove organization member: %w", err)
+	}
+
+	return nil
 }
 
 // Organization Repositories
@@ -193,12 +205,12 @@ func (c *Client) RemoveOrganizationMember(orgname, membername string) error {
 func (c *Client) GetOrganizationRepositories(orgname string) (*OrganizationRepositories, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/repositories", orgname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get organization repositories request: %w", err)
 	}
 
 	var repos OrganizationRepositories
 	if err := c.get(req, &repos); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get organization repositories: %w", err)
 	}
 
 	return &repos, nil
@@ -210,12 +222,12 @@ func (c *Client) GetOrganizationRepositories(orgname string) (*OrganizationRepos
 func (c *Client) GetProxyCacheConfig(orgname string) (*ProxyCacheConfig, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/proxycache", orgname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get proxy cache config request: %w", err)
 	}
 
 	var config ProxyCacheConfig
 	if err := c.get(req, &config); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get proxy cache config: %w", err)
 	}
 
 	return &config, nil
@@ -229,12 +241,12 @@ func (c *Client) CreateProxyCacheConfig(orgname, upstreamRegistry string, insecu
 		"expiration":        expiration,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create proxy cache config request: %w", err)
 	}
 
 	var config ProxyCacheConfig
 	if err := c.post(req, &config); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create proxy cache config: %w", err)
 	}
 
 	return &config, nil
@@ -244,10 +256,14 @@ func (c *Client) CreateProxyCacheConfig(orgname, upstreamRegistry string, insecu
 func (c *Client) DeleteProxyCacheConfig(orgname string) error {
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/proxycache", orgname), nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create delete proxy cache config request: %w", err)
 	}
 
-	return c.delete(req)
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to delete proxy cache config: %w", err)
+	}
+
+	return nil
 }
 
 // Team Management
@@ -256,14 +272,14 @@ func (c *Client) DeleteProxyCacheConfig(orgname string) error {
 func (c *Client) GetTeams(orgname string) ([]Team, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/teams", orgname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get teams request: %w", err)
 	}
 
 	var response struct {
 		Teams []Team `json:"teams"`
 	}
 	if err := c.get(req, &response); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get teams: %w", err)
 	}
 
 	return response.Teams, nil
@@ -277,12 +293,12 @@ func (c *Client) CreateTeam(orgname, teamname, description, role string) (*Team,
 		Role:        role,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create team request: %w", err)
 	}
 
 	var team Team
 	if err := c.put(req, &team); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create team: %w", err)
 	}
 
 	return &team, nil
@@ -292,12 +308,12 @@ func (c *Client) CreateTeam(orgname, teamname, description, role string) (*Team,
 func (c *Client) GetTeam(orgname, teamname string) (*Team, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/team/%s", orgname, teamname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get team request: %w", err)
 	}
 
 	var team Team
 	if err := c.get(req, &team); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get team: %w", err)
 	}
 
 	return &team, nil
@@ -307,10 +323,14 @@ func (c *Client) GetTeam(orgname, teamname string) (*Team, error) {
 func (c *Client) DeleteTeam(orgname, teamname string) error {
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/team/%s", orgname, teamname), nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create delete team request: %w", err)
 	}
 
-	return c.delete(req)
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to delete team: %w", err)
+	}
+
+	return nil
 }
 
 // UpdateTeam updates team settings
@@ -320,12 +340,12 @@ func (c *Client) UpdateTeam(orgname, teamname, description, role string) (*Team,
 		fieldRole:     role,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create update team request: %w", err)
 	}
 
 	var team Team
 	if err := c.put(req, &team); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to update team: %w", err)
 	}
 
 	return &team, nil
@@ -337,12 +357,12 @@ func (c *Client) UpdateTeam(orgname, teamname, description, role string) (*Team,
 func (c *Client) GetTeamMembers(orgname, teamname string) (*TeamMembers, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/team/%s/members", orgname, teamname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get team members request: %w", err)
 	}
 
 	var members TeamMembers
 	if err := c.get(req, &members); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get team members: %w", err)
 	}
 
 	return &members, nil
@@ -352,20 +372,28 @@ func (c *Client) GetTeamMembers(orgname, teamname string) (*TeamMembers, error) 
 func (c *Client) AddTeamMember(orgname, teamname, membername string) error {
 	req, err := newRequest("PUT", c.buildURL("/organization/%s/team/%s/members/%s", orgname, teamname, membername), nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create add team member request: %w", err)
 	}
 
-	return c.put(req, nil)
+	if err := c.put(req, nil); err != nil {
+		return fmt.Errorf("failed to add team member: %w", err)
+	}
+
+	return nil
 }
 
 // RemoveTeamMember removes a member from a team
 func (c *Client) RemoveTeamMember(orgname, teamname, membername string) error {
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/team/%s/members/%s", orgname, teamname, membername), nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create remove team member request: %w", err)
 	}
 
-	return c.delete(req)
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to remove team member: %w", err)
+	}
+
+	return nil
 }
 
 // Team Permissions Management
@@ -374,12 +402,12 @@ func (c *Client) RemoveTeamMember(orgname, teamname, membername string) error {
 func (c *Client) GetTeamPermissions(orgname, teamname string) (*TeamPermissions, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/team/%s/permissions", orgname, teamname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get team permissions request: %w", err)
 	}
 
 	var perms TeamPermissions
 	if err := c.get(req, &perms); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get team permissions: %w", err)
 	}
 
 	return &perms, nil
@@ -391,20 +419,28 @@ func (c *Client) SetTeamRepositoryPermission(orgname, teamname, repository, role
 		fieldRole: role,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create set team repository permission request: %w", err)
 	}
 
-	return c.put(req, nil)
+	if err := c.put(req, nil); err != nil {
+		return fmt.Errorf("failed to set team repository permission: %w", err)
+	}
+
+	return nil
 }
 
 // RemoveTeamRepositoryPermission removes repository permission for a team
 func (c *Client) RemoveTeamRepositoryPermission(orgname, teamname, repository string) error {
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/team/%s/permissions/%s", orgname, teamname, repository), nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create remove team repository permission request: %w", err)
 	}
 
-	return c.delete(req)
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to remove team repository permission: %w", err)
+	}
+
+	return nil
 }
 
 // Robot Account Management
@@ -413,12 +449,12 @@ func (c *Client) RemoveTeamRepositoryPermission(orgname, teamname, repository st
 func (c *Client) GetRobotAccounts(orgname string) (*RobotAccounts, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/robots", orgname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get robot accounts request: %w", err)
 	}
 
 	var robots RobotAccounts
 	if err := c.get(req, &robots); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get robot accounts: %w", err)
 	}
 
 	return &robots, nil
@@ -431,12 +467,12 @@ func (c *Client) CreateRobotAccount(orgname, robotShortname, description string,
 		Unstructured: unstructured,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create robot account request: %w", err)
 	}
 
 	var robot RobotAccount
 	if err := c.put(req, &robot); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create robot account: %w", err)
 	}
 
 	return &robot, nil
@@ -446,12 +482,12 @@ func (c *Client) CreateRobotAccount(orgname, robotShortname, description string,
 func (c *Client) GetRobotAccount(orgname, robotShortname string) (*RobotAccount, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get robot account request: %w", err)
 	}
 
 	var robot RobotAccount
 	if err := c.get(req, &robot); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get robot account: %w", err)
 	}
 
 	return &robot, nil
@@ -461,22 +497,26 @@ func (c *Client) GetRobotAccount(orgname, robotShortname string) (*RobotAccount,
 func (c *Client) DeleteRobotAccount(orgname, robotShortname string) error {
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create delete robot account request: %w", err)
 	}
 
-	return c.delete(req)
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to delete robot account: %w", err)
+	}
+
+	return nil
 }
 
 // RegenerateRobotToken regenerates the token for a robot account
 func (c *Client) RegenerateRobotToken(orgname, robotShortname string) (*RobotAccount, error) {
 	req, err := newRequest("POST", c.buildURL("/organization/%s/robots/%s/regenerate", orgname, robotShortname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create regenerate robot token request: %w", err)
 	}
 
 	var robot RobotAccount
 	if err := c.post(req, &robot); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to regenerate robot token: %w", err)
 	}
 
 	return &robot, nil
@@ -486,12 +526,12 @@ func (c *Client) RegenerateRobotToken(orgname, robotShortname string) (*RobotAcc
 func (c *Client) GetRobotPermissions(orgname, robotShortname string) (*RobotPermissions, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/robots/%s/permissions", orgname, robotShortname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get robot permissions request: %w", err)
 	}
 
 	var perms RobotPermissions
 	if err := c.get(req, &perms); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get robot permissions: %w", err)
 	}
 
 	return &perms, nil
@@ -503,20 +543,28 @@ func (c *Client) SetRobotRepositoryPermission(orgname, robotShortname, repositor
 		fieldRole: role,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create set robot repository permission request: %w", err)
 	}
 
-	return c.put(req, nil)
+	if err := c.put(req, nil); err != nil {
+		return fmt.Errorf("failed to set robot repository permission: %w", err)
+	}
+
+	return nil
 }
 
 // RemoveRobotRepositoryPermission removes repository permission for a robot account
 func (c *Client) RemoveRobotRepositoryPermission(orgname, robotShortname, repository string) error {
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/robots/%s/permissions/%s", orgname, robotShortname, repository), nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create remove robot repository permission request: %w", err)
 	}
 
-	return c.delete(req)
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to remove robot repository permission: %w", err)
+	}
+
+	return nil
 }
 
 // Robot Federation
@@ -570,12 +618,12 @@ func (c *Client) DeleteRobotFederation(orgname, robotShortname string) error {
 func (c *Client) GetQuota(orgname string) (*Quota, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/quota", orgname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get quota request: %w", err)
 	}
 
 	var quota Quota
 	if err := c.get(req, &quota); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get quota: %w", err)
 	}
 
 	return &quota, nil
@@ -587,12 +635,12 @@ func (c *Client) CreateQuota(orgname string, limitBytes int64) (*Quota, error) {
 		LimitBytes: limitBytes,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create quota request: %w", err)
 	}
 
 	var quota Quota
 	if err := c.post(req, &quota); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create quota: %w", err)
 	}
 
 	return &quota, nil
@@ -604,12 +652,12 @@ func (c *Client) UpdateQuota(orgname string, limitBytes int64) (*Quota, error) {
 		LimitBytes: limitBytes,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create update quota request: %w", err)
 	}
 
 	var quota Quota
 	if err := c.put(req, &quota); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to update quota: %w", err)
 	}
 
 	return &quota, nil
@@ -619,10 +667,14 @@ func (c *Client) UpdateQuota(orgname string, limitBytes int64) (*Quota, error) {
 func (c *Client) DeleteQuota(orgname string) error {
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/quota", orgname), nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create delete quota request: %w", err)
 	}
 
-	return c.delete(req)
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to delete quota: %w", err)
+	}
+
+	return nil
 }
 
 // Auto-Prune Policy Management
@@ -631,12 +683,12 @@ func (c *Client) DeleteQuota(orgname string) error {
 func (c *Client) GetAutoPrunePolicies(orgname string) (*AutoPrunePolicies, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/autoprunepolicy", orgname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get auto-prune policies request: %w", err)
 	}
 
 	var policies AutoPrunePolicies
 	if err := c.get(req, &policies); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get auto-prune policies: %w", err)
 	}
 
 	return &policies, nil
@@ -650,12 +702,12 @@ func (c *Client) CreateAutoPrunePolicy(orgname, method string, value int, tagPat
 		TagPattern: tagPattern,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create auto-prune policy request: %w", err)
 	}
 
 	var policy AutoPrunePolicy
 	if err := c.post(req, &policy); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create auto-prune policy: %w", err)
 	}
 
 	return &policy, nil
@@ -665,12 +717,12 @@ func (c *Client) CreateAutoPrunePolicy(orgname, method string, value int, tagPat
 func (c *Client) GetAutoPrunePolicy(orgname, policyUUID string) (*AutoPrunePolicy, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get auto-prune policy request: %w", err)
 	}
 
 	var policy AutoPrunePolicy
 	if err := c.get(req, &policy); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get auto-prune policy: %w", err)
 	}
 
 	return &policy, nil
@@ -684,12 +736,12 @@ func (c *Client) UpdateAutoPrunePolicy(orgname, policyUUID, method string, value
 		TagPattern: tagPattern,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create update auto-prune policy request: %w", err)
 	}
 
 	var policy AutoPrunePolicy
 	if err := c.put(req, &policy); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to update auto-prune policy: %w", err)
 	}
 
 	return &policy, nil
@@ -699,10 +751,14 @@ func (c *Client) UpdateAutoPrunePolicy(orgname, policyUUID, method string, value
 func (c *Client) DeleteAutoPrunePolicy(orgname, policyUUID string) error {
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create delete auto-prune policy request: %w", err)
 	}
 
-	return c.delete(req)
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to delete auto-prune policy: %w", err)
+	}
+
+	return nil
 }
 
 // Applications Management
@@ -711,12 +767,12 @@ func (c *Client) DeleteAutoPrunePolicy(orgname, policyUUID string) error {
 func (c *Client) GetApplications(orgname string) (*Applications, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/applications", orgname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get applications request: %w", err)
 	}
 
 	var apps Applications
 	if err := c.get(req, &apps); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get applications: %w", err)
 	}
 
 	return &apps, nil
@@ -731,12 +787,12 @@ func (c *Client) CreateApplication(orgname, name, description, applicationURI, r
 		RedirectURI:    redirectURI,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create application request: %w", err)
 	}
 
 	var app Application
 	if err := c.post(req, &app); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create application: %w", err)
 	}
 
 	return &app, nil
@@ -746,12 +802,12 @@ func (c *Client) CreateApplication(orgname, name, description, applicationURI, r
 func (c *Client) GetApplication(orgname, clientID string) (*Application, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/applications/%s", orgname, clientID), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get application request: %w", err)
 	}
 
 	var app Application
 	if err := c.get(req, &app); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get application: %w", err)
 	}
 
 	return &app, nil
@@ -766,12 +822,12 @@ func (c *Client) UpdateApplication(orgname, clientID, name, description, applica
 		RedirectURI:    redirectURI,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create update application request: %w", err)
 	}
 
 	var app Application
 	if err := c.put(req, &app); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to update application: %w", err)
 	}
 
 	return &app, nil
@@ -781,22 +837,26 @@ func (c *Client) UpdateApplication(orgname, clientID, name, description, applica
 func (c *Client) DeleteApplication(orgname, clientID string) error {
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/applications/%s", orgname, clientID), nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create delete application request: %w", err)
 	}
 
-	return c.delete(req)
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to delete application: %w", err)
+	}
+
+	return nil
 }
 
 // ResetApplicationClientSecret resets the client secret for an application
 func (c *Client) ResetApplicationClientSecret(orgname, clientID string) (*Application, error) {
 	req, err := newRequest("POST", c.buildURL("/organization/%s/applications/%s/resetclientsecret", orgname, clientID), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create reset application client secret request: %w", err)
 	}
 
 	var app Application
 	if err := c.post(req, &app); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to reset application client secret: %w", err)
 	}
 
 	return &app, nil
@@ -806,12 +866,12 @@ func (c *Client) ResetApplicationClientSecret(orgname, clientID string) (*Applic
 func (c *Client) GetOrganizationCollaborators(orgname string) (*Collaborators, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/collaborators", orgname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get organization collaborators request: %w", err)
 	}
 
 	var collaborators Collaborators
 	if err := c.get(req, &collaborators); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get organization collaborators: %w", err)
 	}
 
 	return &collaborators, nil
@@ -821,12 +881,12 @@ func (c *Client) GetOrganizationCollaborators(orgname string) (*Collaborators, e
 func (c *Client) GetOrganizationMember(orgname, membername string) (*OrganizationMember, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get organization member request: %w", err)
 	}
 
 	var member OrganizationMember
 	if err := c.get(req, &member); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get organization member: %w", err)
 	}
 
 	return &member, nil
@@ -836,12 +896,12 @@ func (c *Client) GetOrganizationMember(orgname, membername string) (*Organizatio
 func (c *Client) GetOrganizationMarketplace(orgname string) (*MarketplaceInfo, error) {
 	req, err := newRequest("GET", c.buildURL("/organization/%s/marketplace", orgname), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create get organization marketplace request: %w", err)
 	}
 
 	var marketplace MarketplaceInfo
 	if err := c.get(req, &marketplace); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get organization marketplace: %w", err)
 	}
 
 	return &marketplace, nil
@@ -851,10 +911,14 @@ func (c *Client) GetOrganizationMarketplace(orgname string) (*MarketplaceInfo, e
 func (c *Client) CreateOrganizationMarketplaceSubscription(orgname string, subscription *MarketplaceSubscriptionRequest) error {
 	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/marketplace", orgname), subscription)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create marketplace subscription request: %w", err)
 	}
 
-	return c.post(req, nil)
+	if err := c.post(req, nil); err != nil {
+		return fmt.Errorf("failed to create marketplace subscription: %w", err)
+	}
+
+	return nil
 }
 
 // BatchRemoveOrganizationMarketplaceSubscriptions removes multiple marketplace subscriptions
@@ -866,38 +930,54 @@ func (c *Client) BatchRemoveOrganizationMarketplaceSubscriptions(orgname string,
 	}
 	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/marketplace/batchremove", orgname), body)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create batch remove marketplace subscriptions request: %w", err)
 	}
 
-	return c.post(req, nil)
+	if err := c.post(req, nil); err != nil {
+		return fmt.Errorf("failed to batch remove marketplace subscriptions: %w", err)
+	}
+
+	return nil
 }
 
 // DeleteOrganizationMarketplaceSubscription removes a specific marketplace subscription
 func (c *Client) DeleteOrganizationMarketplaceSubscription(orgname, subscriptionID string) error {
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/marketplace/%s", orgname, subscriptionID), nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create delete marketplace subscription request: %w", err)
 	}
 
-	return c.delete(req)
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to delete marketplace subscription: %w", err)
+	}
+
+	return nil
 }
 
 // InviteTeamMember invites a member to a team via email
 func (c *Client) InviteTeamMember(orgname, teamname, email string) error {
 	req, err := newRequest("PUT", c.buildURL("/organization/%s/team/%s/invite/%s", orgname, teamname, email), nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create invite team member request: %w", err)
 	}
 
-	return c.put(req, nil)
+	if err := c.put(req, nil); err != nil {
+		return fmt.Errorf("failed to invite team member: %w", err)
+	}
+
+	return nil
 }
 
 // DeleteTeamInvite deletes a pending team invitation
 func (c *Client) DeleteTeamInvite(orgname, teamname, email string) error {
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/team/%s/invite/%s", orgname, teamname, email), nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create delete team invite request: %w", err)
 	}
 
-	return c.delete(req)
+	if err := c.delete(req); err != nil {
+		return fmt.Errorf("failed to delete team invite: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary
- Wrap all bare `return nil, err` and `return err` with descriptive `fmt.Errorf("failed to ...: %w", err)` messages
- `lib/organization.go`: ~90 instances wrapped across 46 functions
- `lib/billing.go`: ~12 instances wrapped across 6 functions
- `lib/logs.go`: ~12 instances wrapped across 9 functions
- Follows the pattern already established in `lib/user.go`

Closes #140