### PR TITLE
refactor: replace os.Exit calls with error returns (RunE)

### DIFF
--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -20,133 +19,138 @@ var billingCmd = &cobra.Command{
 var orgBillingCmd = &cobra.Command{
 	Use:   "org-info",
 	Short: "Get billing information for an organization",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		billing, err := client.GetOrganizationBilling(billingOrgName)
 		if err != nil {
-			fmt.Printf("Error getting organization billing: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting organization billing: %w", err)
 		}
 
-		printJSON(billing)
+		return printJSON(billing)
 	},
 }
 
 var userBillingCmd = &cobra.Command{
 	Use:   "user-info",
 	Short: "Get billing information for the current user",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		billing, err := client.GetUserBilling()
 		if err != nil {
-			fmt.Printf("Error getting user billing: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting user billing: %w", err)
 		}
 
-		printJSON(billing)
+		return printJSON(billing)
 	},
 }
 
 var orgSubscriptionCmd = &cobra.Command{
 	Use:   "org-subscription",
 	Short: "Get subscription details for an organization",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		subscription, err := client.GetOrganizationSubscription(billingOrgName)
 		if err != nil {
-			fmt.Printf("Error getting organization subscription: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting organization subscription: %w", err)
 		}
 
-		printJSON(subscription)
+		return printJSON(subscription)
 	},
 }
 
 var userSubscriptionCmd = &cobra.Command{
 	Use:   "user-subscription",
 	Short: "Get subscription details for the current user",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		subscription, err := client.GetUserSubscription()
 		if err != nil {
-			fmt.Printf("Error getting user subscription: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting user subscription: %w", err)
 		}
 
-		printJSON(subscription)
+		return printJSON(subscription)
 	},
 }
 
 var orgInvoicesCmd = &cobra.Command{
 	Use:   "org-invoices",
 	Short: "Get invoices for an organization",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		invoices, err := client.GetOrganizationInvoices(billingOrgName)
 		if err != nil {
-			fmt.Printf("Error getting organization invoices: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting organization invoices: %w", err)
 		}
 
-		printJSON(invoices)
+		return printJSON(invoices)
 	},
 }
 
 var userInvoicesCmd = &cobra.Command{
 	Use:   "user-invoices",
 	Short: "Get invoices for the current user",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		invoices, err := client.GetUserInvoices()
 		if err != nil {
-			fmt.Printf("Error getting user invoices: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting user invoices: %w", err)
 		}
 
-		printJSON(invoices)
+		return printJSON(invoices)
 	},
 }
 
 var plansCmd = &cobra.Command{
 	Use:   "plans",
 	Short: "Get available subscription plans",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		plans, err := client.GetAvailablePlans()
 		if err != nil {
-			fmt.Printf("Error getting available plans: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting available plans: %w", err)
 		}
 
-		printJSON(plans)
+		return printJSON(plans)
 	},
 }
 
 func init() {
 	orgBillingCmd.PersistentFlags().StringVarP(&billingOrgName, "organization", "o", "", "Organization name")
-	if err := orgBillingCmd.MarkPersistentFlagRequired("organization"); err != nil {
-		fmt.Printf("Error marking organization flag required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = orgBillingCmd.MarkPersistentFlagRequired("organization")
 
 	orgSubscriptionCmd.PersistentFlags().StringVarP(&billingOrgName, "organization", "o", "", "Organization name")
-	if err := orgSubscriptionCmd.MarkPersistentFlagRequired("organization"); err != nil {
-		fmt.Printf("Error marking organization flag required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = orgSubscriptionCmd.MarkPersistentFlagRequired("organization")
 
 	orgInvoicesCmd.PersistentFlags().StringVarP(&billingOrgName, "organization", "o", "", "Organization name")
-	if err := orgInvoicesCmd.MarkPersistentFlagRequired("organization"); err != nil {
-		fmt.Printf("Error marking organization flag required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = orgInvoicesCmd.MarkPersistentFlagRequired("organization")
 
 	billingCmd.AddCommand(orgBillingCmd)
 	billingCmd.AddCommand(userBillingCmd)

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -42,17 +41,19 @@ var buildListCmd = &cobra.Command{
 	Use:   subcmdList,
 	Short: "List builds for a repository",
 	Long:  `List all builds for the specified repository.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		builds, err := client.GetBuilds(buildNamespace, buildRepository, buildLimit)
 		if err != nil {
-			fmt.Printf("Error getting builds: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting builds: %w", err)
 		}
 
 		fmt.Printf("Builds for %s/%s:\n", buildNamespace, buildRepository)
-		printJSON(builds)
+		return printJSON(builds)
 	},
 }
 
@@ -61,17 +62,19 @@ var buildInfoCmd = &cobra.Command{
 	Use:   subcmdInfo,
 	Short: "Get build details",
 	Long:  `Get detailed information about a specific build.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		build, err := client.GetBuild(buildNamespace, buildRepository, buildUUID)
 		if err != nil {
-			fmt.Printf("Error getting build: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting build: %w", err)
 		}
 
 		fmt.Printf("Build: %s\n", buildUUID)
-		printJSON(build)
+		return printJSON(build)
 	},
 }
 
@@ -80,17 +83,19 @@ var buildLogsCmd = &cobra.Command{
 	Use:   "logs",
 	Short: "Get build logs",
 	Long:  `Get the logs for a specific build.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		logs, err := client.GetBuildLogs(buildNamespace, buildRepository, buildUUID)
 		if err != nil {
-			fmt.Printf("Error getting build logs: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting build logs: %w", err)
 		}
 
 		fmt.Printf("Logs for build %s:\n", buildUUID)
-		printJSON(logs)
+		return printJSON(logs)
 	},
 }
 
@@ -101,8 +106,11 @@ var buildRequestCmd = &cobra.Command{
 	Long: `Request a new build from an archive URL.
 
 The archive should be a tar.gz file containing a Dockerfile and any necessary build context.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		buildReq := &lib.RequestBuildRequest{
 			ArchiveURL:     buildArchiveURL,
@@ -113,12 +121,11 @@ The archive should be a tar.gz file containing a Dockerfile and any necessary bu
 
 		build, err := client.RequestBuild(buildNamespace, buildRepository, buildReq)
 		if err != nil {
-			fmt.Printf("Error requesting build: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("requesting build: %w", err)
 		}
 
 		fmt.Printf("Build requested successfully!\n")
-		printJSON(build)
+		return printJSON(build)
 	},
 }
 
@@ -127,22 +134,23 @@ var buildCancelCmd = &cobra.Command{
 	Use:   "cancel",
 	Short: "Cancel an ongoing build",
 	Long:  `Cancel an ongoing build. This action cannot be undone.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirmBuildCancel {
-			fmt.Printf("Are you sure you want to cancel build '%s'? This action cannot be undone.\n", buildUUID)
-			fmt.Println("Use --confirm to proceed with cancellation.")
-			os.Exit(1)
+			return fmt.Errorf("are you sure you want to cancel build '%s'? This action cannot be undone.\nUse --confirm to proceed with cancellation", buildUUID)
 		}
 
-		client := mustGetClient()
-
-		err := client.CancelBuild(buildNamespace, buildRepository, buildUUID)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error canceling build: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.CancelBuild(buildNamespace, buildRepository, buildUUID)
+		if err != nil {
+			return fmt.Errorf("canceling build: %w", err)
 		}
 
 		fmt.Printf("Build '%s' canceled successfully.\n", buildUUID)
+		return nil
 	},
 }
 
@@ -150,17 +158,19 @@ var buildStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Get build status",
 	Long:  `Get the current status of a specific build.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		status, err := client.GetBuildStatus(buildNamespace, buildRepository, buildUUID)
 		if err != nil {
-			fmt.Printf("Error getting build status: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting build status: %w", err)
 		}
 
 		fmt.Printf("Status for build %s:\n", buildUUID)
-		printJSON(status)
+		return printJSON(status)
 	},
 }
 
@@ -176,8 +186,8 @@ func init() {
 	// Global build flags
 	buildCmd.PersistentFlags().StringVarP(&buildNamespace, "namespace", "n", "", "Repository namespace")
 	buildCmd.PersistentFlags().StringVarP(&buildRepository, "repository", "r", "", "Repository name")
-	markFlagRequired(buildCmd.MarkPersistentFlagRequired("namespace"))
-	markFlagRequired(buildCmd.MarkPersistentFlagRequired("repository"))
+	_ = buildCmd.MarkPersistentFlagRequired("namespace")
+	_ = buildCmd.MarkPersistentFlagRequired("repository")
 
 	initBuildListFlags()
 	initBuildInfoFlags()
@@ -188,7 +198,7 @@ func init() {
 
 func initBuildStatusFlags() {
 	buildStatusCmd.Flags().StringVarP(&buildUUID, "uuid", "u", "", "Build UUID")
-	markFlagRequired(buildStatusCmd.MarkFlagRequired("uuid"))
+	_ = buildStatusCmd.MarkFlagRequired("uuid")
 }
 
 func initBuildListFlags() {
@@ -197,7 +207,7 @@ func initBuildListFlags() {
 
 func initBuildInfoFlags() {
 	buildInfoCmd.Flags().StringVarP(&buildUUID, "uuid", "u", "", "Build UUID")
-	markFlagRequired(buildInfoCmd.MarkFlagRequired("uuid"))
+	_ = buildInfoCmd.MarkFlagRequired("uuid")
 }
 
 func initBuildRequestFlags() {
@@ -205,11 +215,11 @@ func initBuildRequestFlags() {
 	buildRequestCmd.Flags().StringVarP(&buildDockerfile, "dockerfile", "d", "", "Path to Dockerfile within archive")
 	buildRequestCmd.Flags().StringVarP(&buildSubdirectory, "subdirectory", "s", "", "Subdirectory containing build context")
 	buildRequestCmd.Flags().StringSliceVar(&buildTags, "tag", []string{"latest"}, "Tags for the built image")
-	markFlagRequired(buildRequestCmd.MarkFlagRequired("archive-url"))
+	_ = buildRequestCmd.MarkFlagRequired("archive-url")
 }
 
 func initBuildCancelFlags() {
 	buildCancelCmd.Flags().StringVarP(&buildUUID, "uuid", "u", "", "Build UUID")
 	buildCancelCmd.Flags().BoolVar(&confirmBuildCancel, "confirm", false, "Confirm build cancellation")
-	markFlagRequired(buildCancelCmd.MarkFlagRequired("uuid"))
+	_ = buildCancelCmd.MarkFlagRequired("uuid")
 }

--- a/cmd/discovery.go
+++ b/cmd/discovery.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -23,16 +22,18 @@ var discoveryAPICmd = &cobra.Command{
 	Use:   "api",
 	Short: "Get API discovery information",
 	Long:  `Get API discovery information from Quay.io including available endpoints and versions.`,
-	Run: func(_ *cobra.Command, _ []string) {
-		client := mustGetClient()
+	RunE: func(_ *cobra.Command, _ []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		discovery, err := client.GetDiscovery()
 		if err != nil {
-			fmt.Printf("Error getting discovery: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting discovery: %w", err)
 		}
 
-		printJSON(discovery)
+		return printJSON(discovery)
 	},
 }
 
@@ -40,16 +41,18 @@ var discoveryCapabilitiesCmd = &cobra.Command{
 	Use:   "capabilities",
 	Short: "Get registry capabilities",
 	Long:  `Get registry capabilities including sparse manifest support and available mirror architectures.`,
-	Run: func(_ *cobra.Command, _ []string) {
-		client := mustGetClient()
+	RunE: func(_ *cobra.Command, _ []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		capabilities, err := client.GetRegistryCapabilities()
 		if err != nil {
-			fmt.Printf("Error getting registry capabilities: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting registry capabilities: %w", err)
 		}
 
-		printJSON(capabilities)
+		return printJSON(capabilities)
 	},
 }
 
@@ -57,16 +60,18 @@ var discoveryAppInfoCmd = &cobra.Command{
 	Use:   "app-info",
 	Short: "Get application information by client ID",
 	Long:  `Get detailed information about an OAuth application by its client ID.`,
-	Run: func(_ *cobra.Command, _ []string) {
-		client := mustGetClient()
+	RunE: func(_ *cobra.Command, _ []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		app, err := client.GetAppInfo(discoveryClientID)
 		if err != nil {
-			fmt.Printf("Error getting app info: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting app info: %w", err)
 		}
 
-		printJSON(app)
+		return printJSON(app)
 	},
 }
 
@@ -74,16 +79,18 @@ var discoveryEntitiesCmd = &cobra.Command{
 	Use:   "entities",
 	Short: "Search for entities by prefix",
 	Long:  `Search for users, organizations, and teams by name prefix.`,
-	Run: func(_ *cobra.Command, _ []string) {
-		client := mustGetClient()
+	RunE: func(_ *cobra.Command, _ []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		entities, err := client.GetEntities(entityPrefix, includeOrgs, includeTeams)
 		if err != nil {
-			fmt.Printf("Error getting entities: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting entities: %w", err)
 		}
 
-		printJSON(entities)
+		return printJSON(entities)
 	},
 }
 
@@ -94,16 +101,10 @@ func init() {
 	discoveryCmd.AddCommand(discoveryEntitiesCmd)
 
 	discoveryAppInfoCmd.Flags().StringVar(&discoveryClientID, "client-id", "", "OAuth application client ID")
-	if err := discoveryAppInfoCmd.MarkFlagRequired("client-id"); err != nil {
-		fmt.Printf("Error marking client-id flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = discoveryAppInfoCmd.MarkFlagRequired("client-id")
 
 	discoveryEntitiesCmd.Flags().StringVar(&entityPrefix, "prefix", "", "Entity name prefix to search")
 	discoveryEntitiesCmd.Flags().BoolVar(&includeOrgs, "include-orgs", false, "Include organizations in results")
 	discoveryEntitiesCmd.Flags().BoolVar(&includeTeams, "include-teams", false, "Include teams in results")
-	if err := discoveryEntitiesCmd.MarkFlagRequired("prefix"); err != nil {
-		fmt.Printf("Error marking prefix flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = discoveryEntitiesCmd.MarkFlagRequired("prefix")
 }

--- a/cmd/errortype.go
+++ b/cmd/errortype.go
@@ -8,7 +8,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -24,21 +23,22 @@ var errorTypeCmd = &cobra.Command{
 	Long: `Get detailed information about a specific error type.
 
 This endpoint provides details about error types that can be returned by the Quay.io API.`,
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		if errorTypeName == "" {
-			fmt.Println("Error: --type is required")
-			os.Exit(1)
+			return fmt.Errorf("--type is required")
 		}
 
-		client := mustGetClient()
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		errType, err := client.GetErrorType(errorTypeName)
 		if err != nil {
-			fmt.Println("Error getting error type:", err)
-			os.Exit(1)
+			return fmt.Errorf("getting error type: %w", err)
 		}
 
-		printJSON(errType)
+		return printJSON(errType)
 	},
 }
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -3,35 +3,21 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 )
 
-func markFlagRequired(err error) {
-	if err != nil {
-		fmt.Printf("Error marking flag as required: %v\n", err)
-		os.Exit(1)
-	}
-}
-
-// mustGetClient creates a Quay client with the configured token and URL.
-// Exits with error message if client creation fails.
-func mustGetClient() *lib.Client {
-	client, err := lib.NewClientWithURL(token, quayURL)
-	if err != nil {
-		fmt.Printf("Error creating client: %v\n", err)
-		os.Exit(1)
-	}
-	return client
+// getClient creates a Quay client with the configured token and URL.
+func getClient() (*lib.Client, error) {
+	return lib.NewClientWithURL(token, quayURL)
 }
 
 // printJSON marshals and prints data as formatted JSON
-func printJSON(data interface{}) {
+func printJSON(data interface{}) error {
 	output, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
-		fmt.Printf("Error marshaling JSON: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("marshaling JSON: %w", err)
 	}
 	fmt.Println(string(output))
+	return nil
 }

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -31,16 +30,18 @@ var repoLogsCmd = &cobra.Command{
 	Use:   "repo-logs",
 	Short: "Get repository logs",
 	Long:  `Get action logs for a specific repository.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		logs, err := client.GetLogs(namespace, repository, nextPage, startdate, enddate)
 		if err != nil {
-			fmt.Printf("Error getting repository logs: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting repository logs: %w", err)
 		}
 
-		printJSON(logs)
+		return printJSON(logs)
 	},
 }
 
@@ -48,16 +49,18 @@ var repoAggregatedLogsCmd = &cobra.Command{
 	Use:   "repo-aggregated-logs",
 	Short: "Get aggregated repository logs",
 	Long:  `Get aggregated action logs for a specific repository.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		logs, err := client.GetAggregatedLogs(namespace, repository, startdate, enddate)
 		if err != nil {
-			fmt.Printf("Error getting repository aggregated logs: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting repository aggregated logs: %w", err)
 		}
 
-		printJSON(logs)
+		return printJSON(logs)
 	},
 }
 
@@ -65,16 +68,18 @@ var orgLogsCmd = &cobra.Command{
 	Use:   "org-logs",
 	Short: "Get organization logs",
 	Long:  `Get action logs for an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		logs, err := client.GetOrganizationLogs(orgName, nextPage, startdate, enddate)
 		if err != nil {
-			fmt.Printf("Error getting organization logs: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting organization logs: %w", err)
 		}
 
-		printJSON(logs)
+		return printJSON(logs)
 	},
 }
 
@@ -82,16 +87,18 @@ var orgAggregatedLogsCmd = &cobra.Command{
 	Use:   "org-aggregated-logs",
 	Short: "Get aggregated organization logs",
 	Long:  `Get aggregated action logs for an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		logs, err := client.GetOrganizationAggregatedLogs(orgName, startdate, enddate)
 		if err != nil {
-			fmt.Printf("Error getting organization aggregated logs: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting organization aggregated logs: %w", err)
 		}
 
-		printJSON(logs)
+		return printJSON(logs)
 	},
 }
 
@@ -99,16 +106,18 @@ var userLogsCmd = &cobra.Command{
 	Use:   "user-logs",
 	Short: "Get user logs",
 	Long:  `Get action logs for the current user.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		logs, err := client.GetUserLogs(nextPage, startdate, enddate)
 		if err != nil {
-			fmt.Printf("Error getting user logs: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting user logs: %w", err)
 		}
 
-		printJSON(logs)
+		return printJSON(logs)
 	},
 }
 
@@ -116,16 +125,18 @@ var userAggregatedLogsCmd = &cobra.Command{
 	Use:   "user-aggregated-logs",
 	Short: "Get aggregated user logs",
 	Long:  `Get aggregated action logs for the current user.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		logs, err := client.GetUserAggregatedLogs(startdate, enddate)
 		if err != nil {
-			fmt.Printf("Error getting user aggregated logs: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting user aggregated logs: %w", err)
 		}
 
-		printJSON(logs)
+		return printJSON(logs)
 	},
 }
 
@@ -133,21 +144,24 @@ var exportOrgLogsCmd = &cobra.Command{
 	Use:   "export-org-logs",
 	Short: "Export organization logs",
 	Long:  `Export action logs for an organization via callback URL or email.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
-		err := client.ExportOrganizationLogs(orgName, &lib.ExportLogsRequest{
+		err = client.ExportOrganizationLogs(orgName, &lib.ExportLogsRequest{
 			StartTime:   starttime,
 			EndTime:     endtime,
 			CallbackURL: callbackURL,
 			Email:       callbackEmail,
 		})
 		if err != nil {
-			fmt.Printf("Error exporting organization logs: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("exporting organization logs: %w", err)
 		}
 
 		fmt.Println("Organization logs export initiated successfully.")
+		return nil
 	},
 }
 
@@ -155,21 +169,24 @@ var exportUserLogsCmd = &cobra.Command{
 	Use:   "export-user-logs",
 	Short: "Export user logs",
 	Long:  `Export action logs for the current user via callback URL or email.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
-		err := client.ExportUserLogs(&lib.ExportLogsRequest{
+		err = client.ExportUserLogs(&lib.ExportLogsRequest{
 			StartTime:   starttime,
 			EndTime:     endtime,
 			CallbackURL: callbackURL,
 			Email:       callbackEmail,
 		})
 		if err != nil {
-			fmt.Printf("Error exporting user logs: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("exporting user logs: %w", err)
 		}
 
 		fmt.Println("User logs export initiated successfully.")
+		return nil
 	},
 }
 
@@ -177,21 +194,24 @@ var exportRepoLogsCmd = &cobra.Command{
 	Use:   "export-repo-logs",
 	Short: "Export repository logs",
 	Long:  `Export action logs for a repository via callback URL or email.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
-		err := client.ExportRepositoryLogs(namespace, repository, &lib.ExportLogsRequest{
+		err = client.ExportRepositoryLogs(namespace, repository, &lib.ExportLogsRequest{
 			StartTime:   starttime,
 			EndTime:     endtime,
 			CallbackURL: callbackURL,
 			Email:       callbackEmail,
 		})
 		if err != nil {
-			fmt.Printf("Error exporting repository logs: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("exporting repository logs: %w", err)
 		}
 
 		fmt.Println("Repository logs export initiated successfully.")
+		return nil
 	},
 }
 

--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -36,17 +35,19 @@ var manifestInfoCmd = &cobra.Command{
 	Use:   subcmdInfo,
 	Short: "Get detailed manifest information",
 	Long:  `Get detailed information about a specific manifest including layers, config, and metadata.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		manifest, err := client.GetManifest(namespace, repository, manifestRef)
 		if err != nil {
-			fmt.Printf("Error getting manifest information: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting manifest information: %w", err)
 		}
 
 		fmt.Printf("Manifest information for %s/%s@%s\n", namespace, repository, manifestRef)
-		printJSON(manifest)
+		return printJSON(manifest)
 	},
 }
 
@@ -55,22 +56,23 @@ var manifestDeleteCmd = &cobra.Command{
 	Use:   subcmdDelete,
 	Short: "Delete a manifest",
 	Long:  `Delete a specific manifest from the repository. This action cannot be undone.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirmManifestDeletion {
-			fmt.Printf("Are you sure you want to delete manifest %s/%s@%s? This action cannot be undone.\n", namespace, repository, manifestRef)
-			fmt.Print("Use --confirm to proceed with deletion.\n")
-			os.Exit(1)
+			return fmt.Errorf("are you sure you want to delete manifest %s/%s@%s? This action cannot be undone.\nUse --confirm to proceed with deletion", namespace, repository, manifestRef)
 		}
 
-		client := mustGetClient()
-
-		err := client.DeleteManifest(namespace, repository, manifestRef)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error deleting manifest: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.DeleteManifest(namespace, repository, manifestRef)
+		if err != nil {
+			return fmt.Errorf("deleting manifest: %w", err)
 		}
 
 		fmt.Printf("Successfully deleted manifest %s/%s@%s\n", namespace, repository, manifestRef)
+		return nil
 	},
 }
 
@@ -79,17 +81,19 @@ var manifestLabelsCmd = &cobra.Command{
 	Use:   "labels",
 	Short: "List manifest labels",
 	Long:  `List all labels associated with a specific manifest.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		labels, err := client.GetManifestLabels(namespace, repository, manifestRef)
 		if err != nil {
-			fmt.Printf("Error getting manifest labels: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting manifest labels: %w", err)
 		}
 
 		fmt.Printf("Labels for manifest %s/%s@%s\n", namespace, repository, manifestRef)
-		printJSON(labels)
+		return printJSON(labels)
 	},
 }
 
@@ -98,17 +102,19 @@ var manifestLabelCmd = &cobra.Command{
 	Use:   "label",
 	Short: "Get a specific manifest label",
 	Long:  `Get detailed information about a specific label on a manifest.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		label, err := client.GetManifestLabel(namespace, repository, manifestRef, labelID)
 		if err != nil {
-			fmt.Printf("Error getting manifest label: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting manifest label: %w", err)
 		}
 
 		fmt.Printf("Label %s for manifest %s/%s@%s\n", labelID, namespace, repository, manifestRef)
-		printJSON(label)
+		return printJSON(label)
 	},
 }
 
@@ -117,17 +123,19 @@ var manifestAddLabelCmd = &cobra.Command{
 	Use:   "add-label",
 	Short: "Add a label to a manifest",
 	Long:  `Add a new label with a key-value pair to a specific manifest.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		label, err := client.AddManifestLabel(namespace, repository, manifestRef, labelKey, labelValue, labelMediaType)
 		if err != nil {
-			fmt.Printf("Error adding manifest label: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("adding manifest label: %w", err)
 		}
 
 		fmt.Printf("Successfully added label to manifest %s/%s@%s\n", namespace, repository, manifestRef)
-		printJSON(label)
+		return printJSON(label)
 	},
 }
 
@@ -136,16 +144,19 @@ var manifestRemoveLabelCmd = &cobra.Command{
 	Use:   "remove-label",
 	Short: "Remove a label from a manifest",
 	Long:  `Remove a specific label from a manifest by its label ID.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-
-		err := client.DeleteManifestLabel(namespace, repository, manifestRef, labelID)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error removing manifest label: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.DeleteManifestLabel(namespace, repository, manifestRef, labelID)
+		if err != nil {
+			return fmt.Errorf("removing manifest label: %w", err)
 		}
 
 		fmt.Printf("Successfully removed label %s from manifest %s/%s@%s\n", labelID, namespace, repository, manifestRef)
+		return nil
 	},
 }
 
@@ -164,46 +175,25 @@ func init() {
 	manifestCmd.PersistentFlags().StringVarP(&manifestRef, "manifest", "m", "", "Manifest reference (digest like sha256:...)")
 
 	// Mark global flags as required
-	if err := manifestCmd.MarkPersistentFlagRequired("namespace"); err != nil {
-		fmt.Printf("Error marking namespace flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := manifestCmd.MarkPersistentFlagRequired("repository"); err != nil {
-		fmt.Printf("Error marking repository flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := manifestCmd.MarkPersistentFlagRequired("manifest"); err != nil {
-		fmt.Printf("Error marking manifest flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = manifestCmd.MarkPersistentFlagRequired("namespace")
+	_ = manifestCmd.MarkPersistentFlagRequired("repository")
+	_ = manifestCmd.MarkPersistentFlagRequired("manifest")
 
 	// Delete command specific flags
 	manifestDeleteCmd.Flags().BoolVar(&confirmManifestDeletion, "confirm", false, "Confirm manifest deletion")
 
 	// Label command specific flags (for getting a specific label)
 	manifestLabelCmd.Flags().StringVarP(&labelID, "label-id", "l", "", "Label ID")
-	if err := manifestLabelCmd.MarkFlagRequired("label-id"); err != nil {
-		fmt.Printf("Error marking label-id flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = manifestLabelCmd.MarkFlagRequired("label-id")
 
 	// Add label command specific flags
 	manifestAddLabelCmd.Flags().StringVarP(&labelKey, "key", "k", "", "Label key")
 	manifestAddLabelCmd.Flags().StringVarP(&labelValue, "value", "v", "", "Label value")
 	manifestAddLabelCmd.Flags().StringVar(&labelMediaType, "media-type", "", "Label media type (optional, defaults to text/plain)")
-	if err := manifestAddLabelCmd.MarkFlagRequired("key"); err != nil {
-		fmt.Printf("Error marking key flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := manifestAddLabelCmd.MarkFlagRequired("value"); err != nil {
-		fmt.Printf("Error marking value flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = manifestAddLabelCmd.MarkFlagRequired("key")
+	_ = manifestAddLabelCmd.MarkFlagRequired("value")
 
 	// Remove label command specific flags
 	manifestRemoveLabelCmd.Flags().StringVarP(&labelID, "label-id", "l", "", "Label ID to remove")
-	if err := manifestRemoveLabelCmd.MarkFlagRequired("label-id"); err != nil {
-		fmt.Printf("Error marking label-id flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = manifestRemoveLabelCmd.MarkFlagRequired("label-id")
 }

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -22,16 +21,18 @@ var messagesListCmd = &cobra.Command{
 	Use:   subcmdList,
 	Short: "Get system messages",
 	Long:  `Get system-wide messages including maintenance notifications and announcements.`,
-	Run: func(_ *cobra.Command, _ []string) {
-		client := mustGetClient()
+	RunE: func(_ *cobra.Command, _ []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		messages, err := client.GetMessages()
 		if err != nil {
-			fmt.Printf("Error getting messages: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting messages: %w", err)
 		}
 
-		printJSON(messages)
+		return printJSON(messages)
 	},
 }
 
@@ -39,17 +40,19 @@ var messagesCreateCmd = &cobra.Command{
 	Use:   subcmdCreate,
 	Short: "Create a system message",
 	Long:  `Create a new system-wide message.`,
-	Run: func(_ *cobra.Command, _ []string) {
-		client := mustGetClient()
+	RunE: func(_ *cobra.Command, _ []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		message, err := client.CreateMessage(messageContent, messageSeverity, messageMediaType)
 		if err != nil {
-			fmt.Printf("Error creating message: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating message: %w", err)
 		}
 
 		fmt.Println("Message created successfully!")
-		printJSON(message)
+		return printJSON(message)
 	},
 }
 
@@ -60,12 +63,6 @@ func init() {
 	messagesCreateCmd.Flags().StringVar(&messageContent, "content", "", "Message content")
 	messagesCreateCmd.Flags().StringVar(&messageSeverity, "severity", "", "Message severity (info, warning, error)")
 	messagesCreateCmd.Flags().StringVar(&messageMediaType, "media-type", "", "Media type for the message")
-	if err := messagesCreateCmd.MarkFlagRequired("content"); err != nil {
-		fmt.Printf("Error marking content flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := messagesCreateCmd.MarkFlagRequired("severity"); err != nil {
-		fmt.Printf("Error marking severity flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = messagesCreateCmd.MarkFlagRequired("content")
+	_ = messagesCreateCmd.MarkFlagRequired("severity")
 }

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -56,17 +55,19 @@ var notificationListCmd = &cobra.Command{
 	Use:   subcmdList,
 	Short: "List notifications for a repository",
 	Long:  `List all notifications (webhooks) for the specified repository.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		notifications, err := client.GetNotifications(notificationNamespace, notificationRepository)
 		if err != nil {
-			fmt.Printf("Error getting notifications: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting notifications: %w", err)
 		}
 
 		fmt.Printf("Notifications for %s/%s:\n", notificationNamespace, notificationRepository)
-		printJSON(notifications)
+		return printJSON(notifications)
 	},
 }
 
@@ -75,17 +76,19 @@ var notificationInfoCmd = &cobra.Command{
 	Use:   subcmdInfo,
 	Short: "Get notification details",
 	Long:  `Get detailed information about a specific notification.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		notification, err := client.GetNotification(notificationNamespace, notificationRepository, notificationUUID)
 		if err != nil {
-			fmt.Printf("Error getting notification: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting notification: %w", err)
 		}
 
 		fmt.Printf("Notification: %s\n", notificationUUID)
-		printJSON(notification)
+		return printJSON(notification)
 	},
 }
 
@@ -98,8 +101,11 @@ var notificationCreateCmd = &cobra.Command{
 For webhook method, provide the --url flag with the webhook endpoint.
 For email method, provide the --url flag with the email address.
 For slack method, provide the --url flag with the Slack webhook URL.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		config := map[string]interface{}{}
 		switch notificationMethod {
@@ -120,12 +126,11 @@ For slack method, provide the --url flag with the Slack webhook URL.`,
 
 		notification, err := client.CreateNotification(notificationNamespace, notificationRepository, notificationReq)
 		if err != nil {
-			fmt.Printf("Error creating notification: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating notification: %w", err)
 		}
 
 		fmt.Printf("Notification created successfully!\n")
-		printJSON(notification)
+		return printJSON(notification)
 	},
 }
 
@@ -134,22 +139,23 @@ var notificationDeleteCmd = &cobra.Command{
 	Use:   subcmdDelete,
 	Short: "Delete a notification",
 	Long:  `Delete a notification from the repository. This action cannot be undone.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirmNotificationDel {
-			fmt.Printf("Are you sure you want to delete notification '%s'? This action cannot be undone.\n", notificationUUID)
-			fmt.Println("Use --confirm to proceed with deletion.")
-			os.Exit(1)
+			return fmt.Errorf("are you sure you want to delete notification '%s'? This action cannot be undone.\nUse --confirm to proceed with deletion", notificationUUID)
 		}
 
-		client := mustGetClient()
-
-		err := client.DeleteNotification(notificationNamespace, notificationRepository, notificationUUID)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error deleting notification: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.DeleteNotification(notificationNamespace, notificationRepository, notificationUUID)
+		if err != nil {
+			return fmt.Errorf("deleting notification: %w", err)
 		}
 
 		fmt.Printf("Notification '%s' deleted successfully.\n", notificationUUID)
+		return nil
 	},
 }
 
@@ -158,16 +164,19 @@ var notificationTestCmd = &cobra.Command{
 	Use:   "test",
 	Short: "Test a notification",
 	Long:  `Send a test event to the notification endpoint.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-
-		err := client.TestNotification(notificationNamespace, notificationRepository, notificationUUID)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error testing notification: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.TestNotification(notificationNamespace, notificationRepository, notificationUUID)
+		if err != nil {
+			return fmt.Errorf("testing notification: %w", err)
 		}
 
 		fmt.Printf("Test event sent to notification '%s'.\n", notificationUUID)
+		return nil
 	},
 }
 
@@ -176,16 +185,19 @@ var notificationResetCmd = &cobra.Command{
 	Use:   "reset",
 	Short: "Reset notification failure count",
 	Long:  `Reset the failure count for a notification that has failed.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-
-		err := client.ResetNotification(notificationNamespace, notificationRepository, notificationUUID)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error resetting notification: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.ResetNotification(notificationNamespace, notificationRepository, notificationUUID)
+		if err != nil {
+			return fmt.Errorf("resetting notification: %w", err)
 		}
 
 		fmt.Printf("Notification '%s' failure count reset.\n", notificationUUID)
+		return nil
 	},
 }
 
@@ -193,8 +205,11 @@ var notificationUpdateCmd = &cobra.Command{
 	Use:   subcmdUpdate,
 	Short: "Update a notification",
 	Long:  `Update an existing notification (webhook) configuration.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		config := map[string]interface{}{}
 		switch notificationMethod {
@@ -215,12 +230,11 @@ var notificationUpdateCmd = &cobra.Command{
 
 		notification, err := client.UpdateNotification(notificationNamespace, notificationRepository, notificationUUID, notificationReq)
 		if err != nil {
-			fmt.Printf("Error updating notification: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("updating notification: %w", err)
 		}
 
 		fmt.Printf("Notification '%s' updated successfully!\n", notificationUUID)
-		printJSON(notification)
+		return printJSON(notification)
 	},
 }
 
@@ -237,8 +251,8 @@ func init() {
 	// Global notification flags
 	notificationCmd.PersistentFlags().StringVarP(&notificationNamespace, "namespace", "n", "", "Repository namespace")
 	notificationCmd.PersistentFlags().StringVarP(&notificationRepository, "repository", "r", "", "Repository name")
-	markFlagRequired(notificationCmd.MarkPersistentFlagRequired("namespace"))
-	markFlagRequired(notificationCmd.MarkPersistentFlagRequired("repository"))
+	_ = notificationCmd.MarkPersistentFlagRequired("namespace")
+	_ = notificationCmd.MarkPersistentFlagRequired("repository")
 
 	initNotificationInfoFlags()
 	initNotificationCreateFlags()
@@ -254,12 +268,12 @@ func initNotificationUpdateFlags() {
 	notificationUpdateCmd.Flags().StringVarP(&notificationMethod, "method", "m", "", "Method (webhook, email, slack)")
 	notificationUpdateCmd.Flags().StringVar(&notificationURL, "url", "", "Webhook URL or email address")
 	notificationUpdateCmd.Flags().StringVar(&notificationTitle, "title", "", "Notification title")
-	markFlagRequired(notificationUpdateCmd.MarkFlagRequired("uuid"))
+	_ = notificationUpdateCmd.MarkFlagRequired("uuid")
 }
 
 func initNotificationInfoFlags() {
 	notificationInfoCmd.Flags().StringVarP(&notificationUUID, "uuid", "u", "", "Notification UUID")
-	markFlagRequired(notificationInfoCmd.MarkFlagRequired("uuid"))
+	_ = notificationInfoCmd.MarkFlagRequired("uuid")
 }
 
 func initNotificationCreateFlags() {
@@ -267,23 +281,23 @@ func initNotificationCreateFlags() {
 	notificationCreateCmd.Flags().StringVarP(&notificationMethod, "method", "m", "", "Method (webhook, email, slack)")
 	notificationCreateCmd.Flags().StringVar(&notificationURL, "url", "", "Webhook URL or email address")
 	notificationCreateCmd.Flags().StringVar(&notificationTitle, "title", "", "Notification title")
-	markFlagRequired(notificationCreateCmd.MarkFlagRequired("event"))
-	markFlagRequired(notificationCreateCmd.MarkFlagRequired("method"))
-	markFlagRequired(notificationCreateCmd.MarkFlagRequired("url"))
+	_ = notificationCreateCmd.MarkFlagRequired("event")
+	_ = notificationCreateCmd.MarkFlagRequired("method")
+	_ = notificationCreateCmd.MarkFlagRequired("url")
 }
 
 func initNotificationDeleteFlags() {
 	notificationDeleteCmd.Flags().StringVarP(&notificationUUID, "uuid", "u", "", "Notification UUID")
 	notificationDeleteCmd.Flags().BoolVar(&confirmNotificationDel, "confirm", false, "Confirm notification deletion")
-	markFlagRequired(notificationDeleteCmd.MarkFlagRequired("uuid"))
+	_ = notificationDeleteCmd.MarkFlagRequired("uuid")
 }
 
 func initNotificationTestFlags() {
 	notificationTestCmd.Flags().StringVarP(&notificationUUID, "uuid", "u", "", "Notification UUID")
-	markFlagRequired(notificationTestCmd.MarkFlagRequired("uuid"))
+	_ = notificationTestCmd.MarkFlagRequired("uuid")
 }
 
 func initNotificationResetFlags() {
 	notificationResetCmd.Flags().StringVarP(&notificationUUID, "uuid", "u", "", "Notification UUID")
-	markFlagRequired(notificationResetCmd.MarkFlagRequired("uuid"))
+	_ = notificationResetCmd.MarkFlagRequired("uuid")
 }

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -57,14 +56,16 @@ var orgInfoCmd = &cobra.Command{
 	Use:   subcmdInfo,
 	Short: "Get organization information",
 	Long:  `Get detailed information about an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		org, err := client.GetOrganization(orgName)
 		if err != nil {
-			fmt.Printf("Error getting organization: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting organization: %w", err)
 		}
-		printJSON(org)
+		return printJSON(org)
 	},
 }
 
@@ -73,14 +74,16 @@ var orgMembersCmd = &cobra.Command{
 	Use:   "members",
 	Short: "Get organization members",
 	Long:  `Get list of all members in an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		members, err := client.GetOrganizationMembers(orgName)
 		if err != nil {
-			fmt.Printf("Error getting organization members: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting organization members: %w", err)
 		}
-		printJSON(members)
+		return printJSON(members)
 	},
 }
 
@@ -89,14 +92,16 @@ var orgTeamsCmd = &cobra.Command{
 	Use:   "teams",
 	Short: "Get organization teams",
 	Long:  `Get list of all teams in an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		teams, err := client.GetTeams(orgName)
 		if err != nil {
-			fmt.Printf("Error getting organization teams: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting organization teams: %w", err)
 		}
-		printJSON(teams)
+		return printJSON(teams)
 	},
 }
 
@@ -105,14 +110,16 @@ var teamInfoCmd = &cobra.Command{
 	Use:   "team",
 	Short: "Get team information",
 	Long:  `Get detailed information about a specific team.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		team, err := client.GetTeam(orgName, teamName)
 		if err != nil {
-			fmt.Printf("Error getting team: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting team: %w", err)
 		}
-		printJSON(team)
+		return printJSON(team)
 	},
 }
 
@@ -121,14 +128,16 @@ var teamMembersCmd = &cobra.Command{
 	Use:   "team-members",
 	Short: "Get team members",
 	Long:  `Get list of all members in a specific team.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		members, err := client.GetTeamMembers(orgName, teamName)
 		if err != nil {
-			fmt.Printf("Error getting team members: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting team members: %w", err)
 		}
-		printJSON(members)
+		return printJSON(members)
 	},
 }
 
@@ -137,14 +146,16 @@ var orgRobotsCmd = &cobra.Command{
 	Use:   "robots",
 	Short: "Get organization robots",
 	Long:  `Get list of all robot accounts in an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		robots, err := client.GetRobotAccounts(orgName)
 		if err != nil {
-			fmt.Printf("Error getting organization robots: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting organization robots: %w", err)
 		}
-		printJSON(robots)
+		return printJSON(robots)
 	},
 }
 
@@ -153,14 +164,16 @@ var orgQuotaCmd = &cobra.Command{
 	Use:   "quota",
 	Short: "Get organization quota",
 	Long:  `Get quota information for an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		quota, err := client.GetQuota(orgName)
 		if err != nil {
-			fmt.Printf("Error getting organization quota: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting organization quota: %w", err)
 		}
-		printJSON(quota)
+		return printJSON(quota)
 	},
 }
 
@@ -169,14 +182,16 @@ var autoPruneCmd = &cobra.Command{
 	Use:   "auto-prune",
 	Short: "Get auto-prune policies",
 	Long:  `Get list of auto-prune policies for an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		policies, err := client.GetAutoPrunePolicies(orgName)
 		if err != nil {
-			fmt.Printf("Error getting auto-prune policies: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting auto-prune policies: %w", err)
 		}
-		printJSON(policies)
+		return printJSON(policies)
 	},
 }
 
@@ -185,14 +200,16 @@ var orgApplicationsCmd = &cobra.Command{
 	Use:   "applications",
 	Short: "Get organization applications",
 	Long:  `Get list of OAuth applications for an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		applications, err := client.GetApplications(orgName)
 		if err != nil {
-			fmt.Printf("Error getting organization applications: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting organization applications: %w", err)
 		}
-		printJSON(applications)
+		return printJSON(applications)
 	},
 }
 
@@ -201,14 +218,16 @@ var createOrgCmd = &cobra.Command{
 	Use:   "create-org",
 	Short: "Create an organization",
 	Long:  `Create a new organization with the specified name and email.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		org, err := client.CreateOrganization(orgName, email)
 		if err != nil {
-			fmt.Printf("Error creating organization: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating organization: %w", err)
 		}
-		printJSON(org)
+		return printJSON(org)
 	},
 }
 
@@ -217,14 +236,16 @@ var updateOrgCmd = &cobra.Command{
 	Use:   "update-org",
 	Short: "Update an organization",
 	Long:  `Update an organization's email.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		org, err := client.UpdateOrganization(orgName, email)
 		if err != nil {
-			fmt.Printf("Error updating organization: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("updating organization: %w", err)
 		}
-		printJSON(org)
+		return printJSON(org)
 	},
 }
 
@@ -233,18 +254,20 @@ var deleteOrgCmd = &cobra.Command{
 	Use:   "delete-org",
 	Short: "Delete an organization",
 	Long:  `Delete an organization. Requires --confirm flag.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirm {
-			fmt.Println("Error: must pass --confirm to delete an organization")
-			os.Exit(1)
+			return fmt.Errorf("must pass --confirm to delete an organization")
 		}
-		client := mustGetClient()
-		err := client.DeleteOrganization(orgName)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error deleting organization: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+		err = client.DeleteOrganization(orgName)
+		if err != nil {
+			return fmt.Errorf("deleting organization: %w", err)
 		}
 		fmt.Println("Organization deleted successfully")
+		return nil
 	},
 }
 
@@ -253,14 +276,17 @@ var addMemberCmd = &cobra.Command{
 	Use:   "add-member",
 	Short: "Add a member to an organization",
 	Long:  `Add a member to an organization by member name.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-		err := client.AddOrganizationMember(orgName, memberName)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error adding organization member: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+		err = client.AddOrganizationMember(orgName, memberName)
+		if err != nil {
+			return fmt.Errorf("adding organization member: %w", err)
 		}
 		fmt.Println("Member added successfully")
+		return nil
 	},
 }
 
@@ -269,18 +295,20 @@ var removeMemberCmd = &cobra.Command{
 	Use:   "remove-member",
 	Short: "Remove a member from an organization",
 	Long:  `Remove a member from an organization. Requires --confirm flag.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirm {
-			fmt.Println("Error: must pass --confirm to remove a member")
-			os.Exit(1)
+			return fmt.Errorf("must pass --confirm to remove a member")
 		}
-		client := mustGetClient()
-		err := client.RemoveOrganizationMember(orgName, memberName)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error removing organization member: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+		err = client.RemoveOrganizationMember(orgName, memberName)
+		if err != nil {
+			return fmt.Errorf("removing organization member: %w", err)
 		}
 		fmt.Println("Member removed successfully")
+		return nil
 	},
 }
 
@@ -289,14 +317,16 @@ var getMemberCmd = &cobra.Command{
 	Use:   "member",
 	Short: "Get organization member information",
 	Long:  `Get detailed information about a specific organization member.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		member, err := client.GetOrganizationMember(orgName, memberName)
 		if err != nil {
-			fmt.Printf("Error getting organization member: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting organization member: %w", err)
 		}
-		printJSON(member)
+		return printJSON(member)
 	},
 }
 
@@ -305,14 +335,16 @@ var collaboratorsCmd = &cobra.Command{
 	Use:   "collaborators",
 	Short: "Get organization collaborators",
 	Long:  `Get list of collaborators for an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		collaborators, err := client.GetOrganizationCollaborators(orgName)
 		if err != nil {
-			fmt.Printf("Error getting organization collaborators: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting organization collaborators: %w", err)
 		}
-		printJSON(collaborators)
+		return printJSON(collaborators)
 	},
 }
 
@@ -321,14 +353,16 @@ var orgRepositoriesCmd = &cobra.Command{
 	Use:   "repositories",
 	Short: "Get organization repositories",
 	Long:  `Get list of repositories for an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		repos, err := client.GetOrganizationRepositories(orgName)
 		if err != nil {
-			fmt.Printf("Error getting organization repositories: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting organization repositories: %w", err)
 		}
-		printJSON(repos)
+		return printJSON(repos)
 	},
 }
 
@@ -337,14 +371,16 @@ var proxyCacheCmd = &cobra.Command{
 	Use:   "proxy-cache",
 	Short: "Get proxy cache configuration",
 	Long:  `Get proxy cache configuration for an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		config, err := client.GetProxyCacheConfig(orgName)
 		if err != nil {
-			fmt.Printf("Error getting proxy cache config: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting proxy cache config: %w", err)
 		}
-		printJSON(config)
+		return printJSON(config)
 	},
 }
 
@@ -353,14 +389,16 @@ var createProxyCacheCmd = &cobra.Command{
 	Use:   "create-proxy-cache",
 	Short: "Create proxy cache configuration",
 	Long:  `Create proxy cache configuration for an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		config, err := client.CreateProxyCacheConfig(orgName, upstreamRegistry, insecure, expiration)
 		if err != nil {
-			fmt.Printf("Error creating proxy cache config: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating proxy cache config: %w", err)
 		}
-		printJSON(config)
+		return printJSON(config)
 	},
 }
 
@@ -369,18 +407,20 @@ var deleteProxyCacheCmd = &cobra.Command{
 	Use:   "delete-proxy-cache",
 	Short: "Delete proxy cache configuration",
 	Long:  `Delete proxy cache configuration for an organization. Requires --confirm flag.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirm {
-			fmt.Println("Error: must pass --confirm to delete proxy cache config")
-			os.Exit(1)
+			return fmt.Errorf("must pass --confirm to delete proxy cache config")
 		}
-		client := mustGetClient()
-		err := client.DeleteProxyCacheConfig(orgName)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error deleting proxy cache config: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+		err = client.DeleteProxyCacheConfig(orgName)
+		if err != nil {
+			return fmt.Errorf("deleting proxy cache config: %w", err)
 		}
 		fmt.Println("Proxy cache config deleted successfully")
+		return nil
 	},
 }
 
@@ -389,14 +429,16 @@ var orgRobotCmd = &cobra.Command{
 	Use:   "robot",
 	Short: "Get robot account information",
 	Long:  `Get detailed information about a specific robot account.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		robot, err := client.GetRobotAccount(orgName, robotShortname)
 		if err != nil {
-			fmt.Printf("Error getting robot account: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting robot account: %w", err)
 		}
-		printJSON(robot)
+		return printJSON(robot)
 	},
 }
 
@@ -405,14 +447,16 @@ var createRobotCmd = &cobra.Command{
 	Use:   "create-robot",
 	Short: "Create a robot account",
 	Long:  `Create a new robot account in an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		robot, err := client.CreateRobotAccount(orgName, robotShortname, description, nil)
 		if err != nil {
-			fmt.Printf("Error creating robot account: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating robot account: %w", err)
 		}
-		printJSON(robot)
+		return printJSON(robot)
 	},
 }
 
@@ -421,18 +465,20 @@ var deleteRobotCmd = &cobra.Command{
 	Use:   "delete-robot",
 	Short: "Delete a robot account",
 	Long:  `Delete a robot account from an organization. Requires --confirm flag.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirm {
-			fmt.Println("Error: must pass --confirm to delete a robot account")
-			os.Exit(1)
+			return fmt.Errorf("must pass --confirm to delete a robot account")
 		}
-		client := mustGetClient()
-		err := client.DeleteRobotAccount(orgName, robotShortname)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error deleting robot account: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+		err = client.DeleteRobotAccount(orgName, robotShortname)
+		if err != nil {
+			return fmt.Errorf("deleting robot account: %w", err)
 		}
 		fmt.Println("Robot account deleted successfully")
+		return nil
 	},
 }
 
@@ -441,14 +487,16 @@ var regenerateRobotCmd = &cobra.Command{
 	Use:   "regenerate-robot",
 	Short: "Regenerate a robot account token",
 	Long:  `Regenerate the token for a robot account.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		robot, err := client.RegenerateRobotToken(orgName, robotShortname)
 		if err != nil {
-			fmt.Printf("Error regenerating robot token: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("regenerating robot token: %w", err)
 		}
-		printJSON(robot)
+		return printJSON(robot)
 	},
 }
 
@@ -457,14 +505,16 @@ var orgRobotPermissionsCmd = &cobra.Command{
 	Use:   "robot-permissions",
 	Short: "Get robot account permissions",
 	Long:  `Get permissions for a specific robot account.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		perms, err := client.GetRobotPermissions(orgName, robotShortname)
 		if err != nil {
-			fmt.Printf("Error getting robot permissions: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting robot permissions: %w", err)
 		}
-		printJSON(perms)
+		return printJSON(perms)
 	},
 }
 
@@ -473,14 +523,17 @@ var setRobotPermissionCmd = &cobra.Command{
 	Use:   "set-robot-permission",
 	Short: "Set robot repository permission",
 	Long:  `Set a robot account's permission on a repository.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-		err := client.SetRobotRepositoryPermission(orgName, robotShortname, repository, role)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error setting robot permission: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+		err = client.SetRobotRepositoryPermission(orgName, robotShortname, repository, role)
+		if err != nil {
+			return fmt.Errorf("setting robot permission: %w", err)
 		}
 		fmt.Println("Robot permission set successfully")
+		return nil
 	},
 }
 
@@ -489,18 +542,20 @@ var removeRobotPermissionCmd = &cobra.Command{
 	Use:   "remove-robot-permission",
 	Short: "Remove robot repository permission",
 	Long:  `Remove a robot account's permission on a repository. Requires --confirm flag.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirm {
-			fmt.Println("Error: must pass --confirm to remove a robot permission")
-			os.Exit(1)
+			return fmt.Errorf("must pass --confirm to remove a robot permission")
 		}
-		client := mustGetClient()
-		err := client.RemoveRobotRepositoryPermission(orgName, robotShortname, repository)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error removing robot permission: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+		err = client.RemoveRobotRepositoryPermission(orgName, robotShortname, repository)
+		if err != nil {
+			return fmt.Errorf("removing robot permission: %w", err)
 		}
 		fmt.Println("Robot permission removed successfully")
+		return nil
 	},
 }
 
@@ -508,16 +563,18 @@ var removeRobotPermissionCmd = &cobra.Command{
 var orgRobotFederationGetCmd = &cobra.Command{
 	Use:   "robot-federation-get",
 	Short: "Get organization robot federation configuration",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		federation, err := client.GetRobotFederation(orgName, robotShortname)
 		if err != nil {
-			fmt.Printf("Error getting robot federation: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting robot federation: %w", err)
 		}
 
-		printJSON(federation)
+		return printJSON(federation)
 	},
 }
 
@@ -525,20 +582,23 @@ var orgRobotFederationGetCmd = &cobra.Command{
 var orgRobotFederationCreateCmd = &cobra.Command{
 	Use:   "robot-federation-create",
 	Short: "Create or update organization robot federation configuration",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		configs := []lib.RobotFederationConfig{
 			{Issuer: federationIssuer, Subject: federationSubject},
 		}
 
-		err := client.CreateRobotFederation(orgName, robotShortname, configs)
+		err = client.CreateRobotFederation(orgName, robotShortname, configs)
 		if err != nil {
-			fmt.Printf("Error creating robot federation: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating robot federation: %w", err)
 		}
 
 		fmt.Printf("Successfully configured federation for robot %s in org %s\n", robotShortname, orgName)
+		return nil
 	},
 }
 
@@ -546,16 +606,19 @@ var orgRobotFederationCreateCmd = &cobra.Command{
 var orgRobotFederationDeleteCmd = &cobra.Command{
 	Use:   "robot-federation-delete",
 	Short: "Delete organization robot federation configuration",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-
-		err := client.DeleteRobotFederation(orgName, robotShortname)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error deleting robot federation: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.DeleteRobotFederation(orgName, robotShortname)
+		if err != nil {
+			return fmt.Errorf("deleting robot federation: %w", err)
 		}
 
 		fmt.Printf("Successfully deleted federation for robot %s in org %s\n", robotShortname, orgName)
+		return nil
 	},
 }
 
@@ -564,14 +627,16 @@ var applicationCmd = &cobra.Command{
 	Use:   "application",
 	Short: "Get application information",
 	Long:  `Get detailed information about a specific OAuth application.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		app, err := client.GetApplication(orgName, clientID)
 		if err != nil {
-			fmt.Printf("Error getting application: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting application: %w", err)
 		}
-		printJSON(app)
+		return printJSON(app)
 	},
 }
 
@@ -580,14 +645,16 @@ var createApplicationCmd = &cobra.Command{
 	Use:   "create-application",
 	Short: "Create an OAuth application",
 	Long:  `Create a new OAuth application for an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		app, err := client.CreateApplication(orgName, appName, description, applicationURI, redirectURI)
 		if err != nil {
-			fmt.Printf("Error creating application: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating application: %w", err)
 		}
-		printJSON(app)
+		return printJSON(app)
 	},
 }
 
@@ -596,14 +663,16 @@ var updateApplicationCmd = &cobra.Command{
 	Use:   "update-application",
 	Short: "Update an OAuth application",
 	Long:  `Update an existing OAuth application.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		app, err := client.UpdateApplication(orgName, clientID, appName, description, applicationURI, redirectURI)
 		if err != nil {
-			fmt.Printf("Error updating application: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("updating application: %w", err)
 		}
-		printJSON(app)
+		return printJSON(app)
 	},
 }
 
@@ -612,18 +681,20 @@ var deleteApplicationCmd = &cobra.Command{
 	Use:   "delete-application",
 	Short: "Delete an OAuth application",
 	Long:  `Delete an OAuth application. Requires --confirm flag.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirm {
-			fmt.Println("Error: must pass --confirm to delete an application")
-			os.Exit(1)
+			return fmt.Errorf("must pass --confirm to delete an application")
 		}
-		client := mustGetClient()
-		err := client.DeleteApplication(orgName, clientID)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error deleting application: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+		err = client.DeleteApplication(orgName, clientID)
+		if err != nil {
+			return fmt.Errorf("deleting application: %w", err)
 		}
 		fmt.Println("Application deleted successfully")
+		return nil
 	},
 }
 
@@ -632,14 +703,16 @@ var resetApplicationSecretCmd = &cobra.Command{
 	Use:   "reset-application-secret",
 	Short: "Reset application client secret",
 	Long:  `Reset the client secret for an OAuth application.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		app, err := client.ResetApplicationClientSecret(orgName, clientID)
 		if err != nil {
-			fmt.Printf("Error resetting application secret: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("resetting application secret: %w", err)
 		}
-		printJSON(app)
+		return printJSON(app)
 	},
 }
 
@@ -648,14 +721,16 @@ var marketplaceCmd = &cobra.Command{
 	Use:   "marketplace",
 	Short: "Get organization marketplace information",
 	Long:  `Get marketplace information for an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		marketplace, err := client.GetOrganizationMarketplace(orgName)
 		if err != nil {
-			fmt.Printf("Error getting marketplace info: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting marketplace info: %w", err)
 		}
-		printJSON(marketplace)
+		return printJSON(marketplace)
 	},
 }
 
@@ -664,14 +739,17 @@ var createMarketplaceSubscriptionCmd = &cobra.Command{
 	Use:   "create-marketplace-subscription",
 	Short: "Create a marketplace subscription",
 	Long:  `Create a marketplace subscription for an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-		err := client.CreateOrganizationMarketplaceSubscription(orgName, &lib.MarketplaceSubscriptionRequest{SKU: sku, Quantity: quantity})
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error creating marketplace subscription: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+		err = client.CreateOrganizationMarketplaceSubscription(orgName, &lib.MarketplaceSubscriptionRequest{SKU: sku, Quantity: quantity})
+		if err != nil {
+			return fmt.Errorf("creating marketplace subscription: %w", err)
 		}
 		fmt.Println("Marketplace subscription created successfully")
+		return nil
 	},
 }
 
@@ -680,18 +758,20 @@ var deleteMarketplaceSubscriptionCmd = &cobra.Command{
 	Use:   "delete-marketplace-subscription",
 	Short: "Delete a marketplace subscription",
 	Long:  `Delete a marketplace subscription. Requires --confirm flag.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirm {
-			fmt.Println("Error: must pass --confirm to delete a marketplace subscription")
-			os.Exit(1)
+			return fmt.Errorf("must pass --confirm to delete a marketplace subscription")
 		}
-		client := mustGetClient()
-		err := client.DeleteOrganizationMarketplaceSubscription(orgName, subscriptionID)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error deleting marketplace subscription: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+		err = client.DeleteOrganizationMarketplaceSubscription(orgName, subscriptionID)
+		if err != nil {
+			return fmt.Errorf("deleting marketplace subscription: %w", err)
 		}
 		fmt.Println("Marketplace subscription deleted successfully")
+		return nil
 	},
 }
 
@@ -700,18 +780,20 @@ var batchRemoveSubscriptionsCmd = &cobra.Command{
 	Use:   "batch-remove-subscriptions",
 	Short: "Batch remove marketplace subscriptions",
 	Long:  `Remove multiple marketplace subscriptions at once. Requires --confirm flag.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirm {
-			fmt.Println("Error: must pass --confirm to batch remove subscriptions")
-			os.Exit(1)
+			return fmt.Errorf("must pass --confirm to batch remove subscriptions")
 		}
-		client := mustGetClient()
-		err := client.BatchRemoveOrganizationMarketplaceSubscriptions(orgName, subscriptionIDs)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error batch removing subscriptions: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+		err = client.BatchRemoveOrganizationMarketplaceSubscriptions(orgName, subscriptionIDs)
+		if err != nil {
+			return fmt.Errorf("batch removing subscriptions: %w", err)
 		}
 		fmt.Println("Marketplace subscriptions removed successfully")
+		return nil
 	},
 }
 
@@ -720,14 +802,16 @@ var createQuotaCmd = &cobra.Command{
 	Use:   "create-quota",
 	Short: "Create organization quota",
 	Long:  `Create a quota for an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		quota, err := client.CreateQuota(orgName, limitBytes)
 		if err != nil {
-			fmt.Printf("Error creating quota: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating quota: %w", err)
 		}
-		printJSON(quota)
+		return printJSON(quota)
 	},
 }
 
@@ -736,14 +820,16 @@ var updateQuotaCmd = &cobra.Command{
 	Use:   "update-quota",
 	Short: "Update organization quota",
 	Long:  `Update the quota for an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		quota, err := client.UpdateQuota(orgName, limitBytes)
 		if err != nil {
-			fmt.Printf("Error updating quota: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("updating quota: %w", err)
 		}
-		printJSON(quota)
+		return printJSON(quota)
 	},
 }
 
@@ -752,18 +838,20 @@ var deleteQuotaCmd = &cobra.Command{
 	Use:   "delete-quota",
 	Short: "Delete organization quota",
 	Long:  `Delete the quota for an organization. Requires --confirm flag.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirm {
-			fmt.Println("Error: must pass --confirm to delete a quota")
-			os.Exit(1)
+			return fmt.Errorf("must pass --confirm to delete a quota")
 		}
-		client := mustGetClient()
-		err := client.DeleteQuota(orgName)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error deleting quota: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+		err = client.DeleteQuota(orgName)
+		if err != nil {
+			return fmt.Errorf("deleting quota: %w", err)
 		}
 		fmt.Println("Quota deleted successfully")
+		return nil
 	},
 }
 
@@ -772,14 +860,16 @@ var autoPrunePolicyCmd = &cobra.Command{
 	Use:   "auto-prune-policy",
 	Short: "Get a specific auto-prune policy",
 	Long:  `Get detailed information about a specific auto-prune policy.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		policy, err := client.GetAutoPrunePolicy(orgName, policyUUID)
 		if err != nil {
-			fmt.Printf("Error getting auto-prune policy: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting auto-prune policy: %w", err)
 		}
-		printJSON(policy)
+		return printJSON(policy)
 	},
 }
 
@@ -788,14 +878,16 @@ var createAutoPruneCmd = &cobra.Command{
 	Use:   "create-auto-prune",
 	Short: "Create an auto-prune policy",
 	Long:  `Create an auto-prune policy for an organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		policy, err := client.CreateAutoPrunePolicy(orgName, method, pruneValue, tagPattern)
 		if err != nil {
-			fmt.Printf("Error creating auto-prune policy: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating auto-prune policy: %w", err)
 		}
-		printJSON(policy)
+		return printJSON(policy)
 	},
 }
 
@@ -804,14 +896,16 @@ var updateAutoPruneCmd = &cobra.Command{
 	Use:   "update-auto-prune",
 	Short: "Update an auto-prune policy",
 	Long:  `Update an existing auto-prune policy.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 		policy, err := client.UpdateAutoPrunePolicy(orgName, policyUUID, method, pruneValue, tagPattern)
 		if err != nil {
-			fmt.Printf("Error updating auto-prune policy: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("updating auto-prune policy: %w", err)
 		}
-		printJSON(policy)
+		return printJSON(policy)
 	},
 }
 
@@ -820,18 +914,20 @@ var deleteAutoPruneCmd = &cobra.Command{
 	Use:   "delete-auto-prune",
 	Short: "Delete an auto-prune policy",
 	Long:  `Delete an auto-prune policy. Requires --confirm flag.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirm {
-			fmt.Println("Error: must pass --confirm to delete an auto-prune policy")
-			os.Exit(1)
+			return fmt.Errorf("must pass --confirm to delete an auto-prune policy")
 		}
-		client := mustGetClient()
-		err := client.DeleteAutoPrunePolicy(orgName, policyUUID)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error deleting auto-prune policy: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+		err = client.DeleteAutoPrunePolicy(orgName, policyUUID)
+		if err != nil {
+			return fmt.Errorf("deleting auto-prune policy: %w", err)
 		}
 		fmt.Println("Auto-prune policy deleted successfully")
+		return nil
 	},
 }
 
@@ -840,14 +936,17 @@ var inviteMemberCmd = &cobra.Command{
 	Use:   "invite-member",
 	Short: "Invite a member to a team",
 	Long:  `Invite a member to a team by email.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-		err := client.InviteTeamMember(orgName, teamName, email)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error inviting team member: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+		err = client.InviteTeamMember(orgName, teamName, email)
+		if err != nil {
+			return fmt.Errorf("inviting team member: %w", err)
 		}
 		fmt.Println("Team member invited successfully")
+		return nil
 	},
 }
 
@@ -856,18 +955,20 @@ var cancelInviteCmd = &cobra.Command{
 	Use:   "cancel-invite",
 	Short: "Cancel a team member invitation",
 	Long:  `Cancel a pending team member invitation. Requires --confirm flag.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirm {
-			fmt.Println("Error: must pass --confirm to cancel an invite")
-			os.Exit(1)
+			return fmt.Errorf("must pass --confirm to cancel an invite")
 		}
-		client := mustGetClient()
-		err := client.DeleteTeamInvite(orgName, teamName, email)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error canceling team invite: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+		err = client.DeleteTeamInvite(orgName, teamName, email)
+		if err != nil {
+			return fmt.Errorf("canceling team invite: %w", err)
 		}
 		fmt.Println("Team invite canceled successfully")
+		return nil
 	},
 }
 
@@ -936,332 +1037,171 @@ func init() {
 
 func initOrgPersistentFlags() {
 	organizationCmd.PersistentFlags().StringVarP(&orgName, "organization", "o", "", "Organization name")
-
-	if err := organizationCmd.MarkPersistentFlagRequired("organization"); err != nil {
-		fmt.Printf("Error marking organization flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = organizationCmd.MarkPersistentFlagRequired("organization")
 }
 
 func initOrgMemberFlags() {
-	// team info flags
 	teamInfoCmd.Flags().StringVarP(&teamName, "team", "T", "", "Team name")
-	if err := teamInfoCmd.MarkFlagRequired("team"); err != nil {
-		fmt.Printf("Error marking team flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = teamInfoCmd.MarkFlagRequired("team")
 
-	// team members flags
 	teamMembersCmd.Flags().StringVarP(&teamName, "team", "T", "", "Team name")
-	if err := teamMembersCmd.MarkFlagRequired("team"); err != nil {
-		fmt.Printf("Error marking team flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = teamMembersCmd.MarkFlagRequired("team")
 
-	// create-org flags
 	createOrgCmd.Flags().StringVar(&email, "email", "", "Email address")
-	if err := createOrgCmd.MarkFlagRequired("email"); err != nil {
-		fmt.Printf("Error marking email flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = createOrgCmd.MarkFlagRequired("email")
 
-	// update-org flags
 	updateOrgCmd.Flags().StringVar(&email, "email", "", "Email address")
-	if err := updateOrgCmd.MarkFlagRequired("email"); err != nil {
-		fmt.Printf("Error marking email flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = updateOrgCmd.MarkFlagRequired("email")
 
-	// delete-org flags
 	deleteOrgCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm deletion")
 
-	// add-member flags
 	addMemberCmd.Flags().StringVar(&memberName, "member", "", "Member name")
-	if err := addMemberCmd.MarkFlagRequired("member"); err != nil {
-		fmt.Printf("Error marking member flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = addMemberCmd.MarkFlagRequired("member")
 
-	// remove-member flags
 	removeMemberCmd.Flags().StringVar(&memberName, "member", "", "Member name")
-	if err := removeMemberCmd.MarkFlagRequired("member"); err != nil {
-		fmt.Printf("Error marking member flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = removeMemberCmd.MarkFlagRequired("member")
 	removeMemberCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm removal")
 
-	// member flags
 	getMemberCmd.Flags().StringVar(&memberName, "member", "", "Member name")
-	if err := getMemberCmd.MarkFlagRequired("member"); err != nil {
-		fmt.Printf("Error marking member flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = getMemberCmd.MarkFlagRequired("member")
 }
 
 func initOrgProxyCacheFlags() {
-	// create-proxy-cache flags
 	createProxyCacheCmd.Flags().StringVar(&upstreamRegistry, "upstream-registry", "", "Upstream registry URL")
-	if err := createProxyCacheCmd.MarkFlagRequired("upstream-registry"); err != nil {
-		fmt.Printf("Error marking upstream-registry flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = createProxyCacheCmd.MarkFlagRequired("upstream-registry")
 	createProxyCacheCmd.Flags().BoolVar(&insecure, "insecure", false, "Allow insecure connections")
 	createProxyCacheCmd.Flags().IntVar(&expiration, "expiration", 0, "Cache expiration in seconds")
 
-	// delete-proxy-cache flags
 	deleteProxyCacheCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm deletion")
 }
 
 func initOrgRobotFlags() {
-	// robot flags
 	orgRobotCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
-	if err := orgRobotCmd.MarkFlagRequired("robot"); err != nil {
-		fmt.Printf("Error marking robot flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = orgRobotCmd.MarkFlagRequired("robot")
 
-	// create-robot flags
 	createRobotCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
-	if err := createRobotCmd.MarkFlagRequired("robot"); err != nil {
-		fmt.Printf("Error marking robot flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = createRobotCmd.MarkFlagRequired("robot")
 	createRobotCmd.Flags().StringVar(&description, "description", "", "Robot description")
 
-	// delete-robot flags
 	deleteRobotCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
-	if err := deleteRobotCmd.MarkFlagRequired("robot"); err != nil {
-		fmt.Printf("Error marking robot flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = deleteRobotCmd.MarkFlagRequired("robot")
 	deleteRobotCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm deletion")
 
-	// regenerate-robot flags
 	regenerateRobotCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
-	if err := regenerateRobotCmd.MarkFlagRequired("robot"); err != nil {
-		fmt.Printf("Error marking robot flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = regenerateRobotCmd.MarkFlagRequired("robot")
 
-	// robot-permissions flags
 	orgRobotPermissionsCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
-	if err := orgRobotPermissionsCmd.MarkFlagRequired("robot"); err != nil {
-		fmt.Printf("Error marking robot flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = orgRobotPermissionsCmd.MarkFlagRequired("robot")
 
-	// set-robot-permission flags
 	setRobotPermissionCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
-	if err := setRobotPermissionCmd.MarkFlagRequired("robot"); err != nil {
-		fmt.Printf("Error marking robot flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = setRobotPermissionCmd.MarkFlagRequired("robot")
 	setRobotPermissionCmd.Flags().StringVar(&repository, "repository", "", "Repository name")
-	if err := setRobotPermissionCmd.MarkFlagRequired("repository"); err != nil {
-		fmt.Printf("Error marking repository flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = setRobotPermissionCmd.MarkFlagRequired("repository")
 	setRobotPermissionCmd.Flags().StringVar(&role, "role", "", "Permission role")
-	if err := setRobotPermissionCmd.MarkFlagRequired("role"); err != nil {
-		fmt.Printf("Error marking role flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = setRobotPermissionCmd.MarkFlagRequired("role")
 
-	// remove-robot-permission flags
 	removeRobotPermissionCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
-	if err := removeRobotPermissionCmd.MarkFlagRequired("robot"); err != nil {
-		fmt.Printf("Error marking robot flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = removeRobotPermissionCmd.MarkFlagRequired("robot")
 	removeRobotPermissionCmd.Flags().StringVar(&repository, "repository", "", "Repository name")
-	if err := removeRobotPermissionCmd.MarkFlagRequired("repository"); err != nil {
-		fmt.Printf("Error marking repository flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = removeRobotPermissionCmd.MarkFlagRequired("repository")
 	removeRobotPermissionCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm removal")
 
-	// robot-federation-get flags
 	orgRobotFederationGetCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
-	markFlagRequired(orgRobotFederationGetCmd.MarkFlagRequired("robot"))
+	_ = orgRobotFederationGetCmd.MarkFlagRequired("robot")
 
-	// robot-federation-create flags
 	orgRobotFederationCreateCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
 	orgRobotFederationCreateCmd.Flags().StringVar(&federationIssuer, "issuer", "", "Federation token issuer")
 	orgRobotFederationCreateCmd.Flags().StringVar(&federationSubject, "subject", "", "Federation token subject")
-	markFlagRequired(orgRobotFederationCreateCmd.MarkFlagRequired("robot"))
-	markFlagRequired(orgRobotFederationCreateCmd.MarkFlagRequired("issuer"))
-	markFlagRequired(orgRobotFederationCreateCmd.MarkFlagRequired("subject"))
+	_ = orgRobotFederationCreateCmd.MarkFlagRequired("robot")
+	_ = orgRobotFederationCreateCmd.MarkFlagRequired("issuer")
+	_ = orgRobotFederationCreateCmd.MarkFlagRequired("subject")
 
-	// robot-federation-delete flags
 	orgRobotFederationDeleteCmd.Flags().StringVar(&robotShortname, "robot", "", "Robot short name")
-	markFlagRequired(orgRobotFederationDeleteCmd.MarkFlagRequired("robot"))
+	_ = orgRobotFederationDeleteCmd.MarkFlagRequired("robot")
 }
 
 func initOrgApplicationFlags() {
-	// application flags
 	applicationCmd.Flags().StringVar(&clientID, "client-id", "", "Application client ID")
-	if err := applicationCmd.MarkFlagRequired("client-id"); err != nil {
-		fmt.Printf("Error marking client-id flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = applicationCmd.MarkFlagRequired("client-id")
 
-	// create-application flags
 	createApplicationCmd.Flags().StringVar(&appName, "name", "", "Application name")
-	if err := createApplicationCmd.MarkFlagRequired("name"); err != nil {
-		fmt.Printf("Error marking name flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = createApplicationCmd.MarkFlagRequired("name")
 	createApplicationCmd.Flags().StringVar(&description, "description", "", "Application description")
 	createApplicationCmd.Flags().StringVar(&applicationURI, "application-uri", "", "Application URI")
 	createApplicationCmd.Flags().StringVar(&redirectURI, "redirect-uri", "", "Redirect URI")
 
-	// update-application flags
 	updateApplicationCmd.Flags().StringVar(&clientID, "client-id", "", "Application client ID")
-	if err := updateApplicationCmd.MarkFlagRequired("client-id"); err != nil {
-		fmt.Printf("Error marking client-id flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = updateApplicationCmd.MarkFlagRequired("client-id")
 	updateApplicationCmd.Flags().StringVar(&appName, "name", "", "Application name")
-	if err := updateApplicationCmd.MarkFlagRequired("name"); err != nil {
-		fmt.Printf("Error marking name flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = updateApplicationCmd.MarkFlagRequired("name")
 	updateApplicationCmd.Flags().StringVar(&description, "description", "", "Application description")
 	updateApplicationCmd.Flags().StringVar(&applicationURI, "application-uri", "", "Application URI")
 	updateApplicationCmd.Flags().StringVar(&redirectURI, "redirect-uri", "", "Redirect URI")
 
-	// delete-application flags
 	deleteApplicationCmd.Flags().StringVar(&clientID, "client-id", "", "Application client ID")
-	if err := deleteApplicationCmd.MarkFlagRequired("client-id"); err != nil {
-		fmt.Printf("Error marking client-id flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = deleteApplicationCmd.MarkFlagRequired("client-id")
 	deleteApplicationCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm deletion")
 
-	// reset-application-secret flags
 	resetApplicationSecretCmd.Flags().StringVar(&clientID, "client-id", "", "Application client ID")
-	if err := resetApplicationSecretCmd.MarkFlagRequired("client-id"); err != nil {
-		fmt.Printf("Error marking client-id flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = resetApplicationSecretCmd.MarkFlagRequired("client-id")
 }
 
 func initOrgMarketplaceFlags() {
-	// create-marketplace-subscription flags
 	createMarketplaceSubscriptionCmd.Flags().StringVar(&sku, "sku", "", "Subscription SKU")
-	if err := createMarketplaceSubscriptionCmd.MarkFlagRequired("sku"); err != nil {
-		fmt.Printf("Error marking sku flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = createMarketplaceSubscriptionCmd.MarkFlagRequired("sku")
 	createMarketplaceSubscriptionCmd.Flags().IntVar(&quantity, "quantity", 0, "Subscription quantity")
 
-	// delete-marketplace-subscription flags
 	deleteMarketplaceSubscriptionCmd.Flags().StringVar(&subscriptionID, "subscription-id", "", "Subscription ID")
-	if err := deleteMarketplaceSubscriptionCmd.MarkFlagRequired("subscription-id"); err != nil {
-		fmt.Printf("Error marking subscription-id flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = deleteMarketplaceSubscriptionCmd.MarkFlagRequired("subscription-id")
 	deleteMarketplaceSubscriptionCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm deletion")
 
-	// batch-remove-subscriptions flags
 	batchRemoveSubscriptionsCmd.Flags().StringSliceVar(&subscriptionIDs, "subscription-ids", nil, "Comma-separated subscription IDs")
-	if err := batchRemoveSubscriptionsCmd.MarkFlagRequired("subscription-ids"); err != nil {
-		fmt.Printf("Error marking subscription-ids flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = batchRemoveSubscriptionsCmd.MarkFlagRequired("subscription-ids")
 	batchRemoveSubscriptionsCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm removal")
 }
 
 func initOrgQuotaFlags() {
-	// create-quota flags
 	createQuotaCmd.Flags().Int64Var(&limitBytes, "limit-bytes", 0, "Quota limit in bytes")
-	if err := createQuotaCmd.MarkFlagRequired("limit-bytes"); err != nil {
-		fmt.Printf("Error marking limit-bytes flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = createQuotaCmd.MarkFlagRequired("limit-bytes")
 
-	// update-quota flags
 	updateQuotaCmd.Flags().Int64Var(&limitBytes, "limit-bytes", 0, "Quota limit in bytes")
-	if err := updateQuotaCmd.MarkFlagRequired("limit-bytes"); err != nil {
-		fmt.Printf("Error marking limit-bytes flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = updateQuotaCmd.MarkFlagRequired("limit-bytes")
 
-	// delete-quota flags
 	deleteQuotaCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm deletion")
 }
 
 func initOrgAutoPruneFlags() {
-	// auto-prune-policy flags
 	autoPrunePolicyCmd.Flags().StringVar(&policyUUID, "policy-uuid", "", "Policy UUID")
-	if err := autoPrunePolicyCmd.MarkFlagRequired("policy-uuid"); err != nil {
-		fmt.Printf("Error marking policy-uuid flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = autoPrunePolicyCmd.MarkFlagRequired("policy-uuid")
 
-	// create-auto-prune flags
 	createAutoPruneCmd.Flags().StringVar(&method, "method", "", "Prune method")
-	if err := createAutoPruneCmd.MarkFlagRequired("method"); err != nil {
-		fmt.Printf("Error marking method flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = createAutoPruneCmd.MarkFlagRequired("method")
 	createAutoPruneCmd.Flags().IntVar(&pruneValue, "value", 0, "Prune value")
-	if err := createAutoPruneCmd.MarkFlagRequired("value"); err != nil {
-		fmt.Printf("Error marking value flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = createAutoPruneCmd.MarkFlagRequired("value")
 	createAutoPruneCmd.Flags().StringVar(&tagPattern, "tag-pattern", "", "Tag pattern to match")
 
-	// update-auto-prune flags
 	updateAutoPruneCmd.Flags().StringVar(&policyUUID, "policy-uuid", "", "Policy UUID")
-	if err := updateAutoPruneCmd.MarkFlagRequired("policy-uuid"); err != nil {
-		fmt.Printf("Error marking policy-uuid flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = updateAutoPruneCmd.MarkFlagRequired("policy-uuid")
 	updateAutoPruneCmd.Flags().StringVar(&method, "method", "", "Prune method")
-	if err := updateAutoPruneCmd.MarkFlagRequired("method"); err != nil {
-		fmt.Printf("Error marking method flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = updateAutoPruneCmd.MarkFlagRequired("method")
 	updateAutoPruneCmd.Flags().IntVar(&pruneValue, "value", 0, "Prune value")
-	if err := updateAutoPruneCmd.MarkFlagRequired("value"); err != nil {
-		fmt.Printf("Error marking value flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = updateAutoPruneCmd.MarkFlagRequired("value")
 	updateAutoPruneCmd.Flags().StringVar(&tagPattern, "tag-pattern", "", "Tag pattern to match")
 
-	// delete-auto-prune flags
 	deleteAutoPruneCmd.Flags().StringVar(&policyUUID, "policy-uuid", "", "Policy UUID")
-	if err := deleteAutoPruneCmd.MarkFlagRequired("policy-uuid"); err != nil {
-		fmt.Printf("Error marking policy-uuid flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = deleteAutoPruneCmd.MarkFlagRequired("policy-uuid")
 	deleteAutoPruneCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm deletion")
 }
 
 func initOrgInviteFlags() {
-	// invite-member flags
 	inviteMemberCmd.Flags().StringVarP(&teamName, "team", "T", "", "Team name")
-	if err := inviteMemberCmd.MarkFlagRequired("team"); err != nil {
-		fmt.Printf("Error marking team flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = inviteMemberCmd.MarkFlagRequired("team")
 	inviteMemberCmd.Flags().StringVar(&email, "email", "", "Email address")
-	if err := inviteMemberCmd.MarkFlagRequired("email"); err != nil {
-		fmt.Printf("Error marking email flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = inviteMemberCmd.MarkFlagRequired("email")
 
-	// cancel-invite flags
 	cancelInviteCmd.Flags().StringVarP(&teamName, "team", "T", "", "Team name")
-	if err := cancelInviteCmd.MarkFlagRequired("team"); err != nil {
-		fmt.Printf("Error marking team flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = cancelInviteCmd.MarkFlagRequired("team")
 	cancelInviteCmd.Flags().StringVar(&email, "email", "", "Email address")
-	if err := cancelInviteCmd.MarkFlagRequired("email"); err != nil {
-		fmt.Printf("Error marking email flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = cancelInviteCmd.MarkFlagRequired("email")
 	cancelInviteCmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm cancellation")
 }

--- a/cmd/permissions.go
+++ b/cmd/permissions.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -33,17 +32,19 @@ var permListCmd = &cobra.Command{
 	Use:   subcmdList,
 	Short: "List repository permissions",
 	Long:  `List all users and robots that have permissions on this repository.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		permissions, err := client.GetRepositoryPermissions(namespace, repository)
 		if err != nil {
-			fmt.Printf("Error getting repository permissions: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting repository permissions: %w", err)
 		}
 
 		fmt.Printf("Permissions for repository %s/%s:\n", namespace, repository)
-		printJSON(permissions)
+		return printJSON(permissions)
 	},
 }
 
@@ -52,17 +53,20 @@ var permSetCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Set permission for a user/robot",
 	Long:  `Set permission level for a user or robot account on this repository.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-
-		err := client.SetRepositoryPermission(namespace, repository, permissionUser, permissionRole)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error setting repository permission: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.SetRepositoryPermission(namespace, repository, permissionUser, permissionRole)
+		if err != nil {
+			return fmt.Errorf("setting repository permission: %w", err)
 		}
 
 		fmt.Printf("Successfully set %s permission for %s on repository %s/%s\n",
 			permissionRole, permissionUser, namespace, repository)
+		return nil
 	},
 }
 
@@ -71,179 +75,200 @@ var permRemoveCmd = &cobra.Command{
 	Use:   "remove",
 	Short: "Remove permission for a user/robot",
 	Long:  `Remove permission for a user or robot account from this repository.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-
-		err := client.RemoveRepositoryPermission(namespace, repository, permissionUser)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error removing repository permission: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.RemoveRepositoryPermission(namespace, repository, permissionUser)
+		if err != nil {
+			return fmt.Errorf("removing repository permission: %w", err)
 		}
 
 		fmt.Printf("Successfully removed permissions for %s from repository %s/%s\n",
 			permissionUser, namespace, repository)
+		return nil
 	},
 }
 
 var permUserPermissionsCmd = &cobra.Command{
 	Use:   "user-permissions",
 	Short: "List user permissions on repository",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		permissions, err := client.ListUserPermissions(namespace, repository)
 		if err != nil {
-			fmt.Printf("Error getting user permissions: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting user permissions: %w", err)
 		}
 
-		printJSON(permissions)
+		return printJSON(permissions)
 	},
 }
 
 var permUserPermissionCmd = &cobra.Command{
 	Use:   "user-permission",
 	Short: "Get specific user permission on repository",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		permission, err := client.GetUserPermission(namespace, repository, permissionUser)
 		if err != nil {
-			fmt.Printf("Error getting user permission: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting user permission: %w", err)
 		}
 
-		printJSON(permission)
+		return printJSON(permission)
 	},
 }
 
 var permSetUserPermCmd = &cobra.Command{
 	Use:   "set-user-permission",
 	Short: "Set user permission on repository",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-
-		err := client.SetUserPermission(namespace, repository, permissionUser, permissionRole)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error setting user permission: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.SetUserPermission(namespace, repository, permissionUser, permissionRole)
+		if err != nil {
+			return fmt.Errorf("setting user permission: %w", err)
 		}
 
 		fmt.Printf("Successfully set %s permission for user %s on %s/%s\n",
 			permissionRole, permissionUser, namespace, repository)
+		return nil
 	},
 }
 
 var permDeleteUserPermCmd = &cobra.Command{
 	Use:   "delete-user-permission",
 	Short: "Delete user permission from repository",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirmPermDeletion {
-			fmt.Printf("Are you sure you want to remove permission for user '%s' from %s/%s?\n",
+			return fmt.Errorf("are you sure you want to remove permission for user '%s' from %s/%s?\nUse --confirm to proceed with removal",
 				permissionUser, namespace, repository)
-			fmt.Println("Use --confirm to proceed with removal.")
-			os.Exit(1)
 		}
 
-		client := mustGetClient()
-
-		err := client.DeleteUserPermission(namespace, repository, permissionUser)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error deleting user permission: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.DeleteUserPermission(namespace, repository, permissionUser)
+		if err != nil {
+			return fmt.Errorf("deleting user permission: %w", err)
 		}
 
 		fmt.Printf("Successfully removed permission for user %s from %s/%s\n",
 			permissionUser, namespace, repository)
+		return nil
 	},
 }
 
 var permUserTransitiveCmd = &cobra.Command{
 	Use:   "user-transitive-permission",
 	Short: "Get user transitive permission on repository",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		permission, err := client.GetUserTransitivePermission(namespace, repository, permissionUser)
 		if err != nil {
-			fmt.Printf("Error getting user transitive permission: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting user transitive permission: %w", err)
 		}
 
-		printJSON(permission)
+		return printJSON(permission)
 	},
 }
 
 var permTeamPermissionsCmd = &cobra.Command{
 	Use:   "team-permissions",
 	Short: "List team permissions on repository",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		permissions, err := client.ListTeamPermissions(namespace, repository)
 		if err != nil {
-			fmt.Printf("Error getting team permissions: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting team permissions: %w", err)
 		}
 
-		printJSON(permissions)
+		return printJSON(permissions)
 	},
 }
 
 var permTeamPermissionCmd = &cobra.Command{
 	Use:   "team-permission",
 	Short: "Get specific team permission on repository",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		permission, err := client.GetTeamPermission(namespace, repository, permissionTeamName)
 		if err != nil {
-			fmt.Printf("Error getting team permission: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting team permission: %w", err)
 		}
 
-		printJSON(permission)
+		return printJSON(permission)
 	},
 }
 
 var permSetTeamPermCmd = &cobra.Command{
 	Use:   "set-team-permission",
 	Short: "Set team permission on repository",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-
-		err := client.SetTeamPermission(namespace, repository, permissionTeamName, permissionRole)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error setting team permission: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.SetTeamPermission(namespace, repository, permissionTeamName, permissionRole)
+		if err != nil {
+			return fmt.Errorf("setting team permission: %w", err)
 		}
 
 		fmt.Printf("Successfully set %s permission for team %s on %s/%s\n",
 			permissionRole, permissionTeamName, namespace, repository)
+		return nil
 	},
 }
 
 var permDeleteTeamPermCmd = &cobra.Command{
 	Use:   "delete-team-permission",
 	Short: "Delete team permission from repository",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirmPermDeletion {
-			fmt.Printf("Are you sure you want to remove permission for team '%s' from %s/%s?\n",
+			return fmt.Errorf("are you sure you want to remove permission for team '%s' from %s/%s?\nUse --confirm to proceed with removal",
 				permissionTeamName, namespace, repository)
-			fmt.Println("Use --confirm to proceed with removal.")
-			os.Exit(1)
 		}
 
-		client := mustGetClient()
-
-		err := client.DeleteTeamPermission(namespace, repository, permissionTeamName)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error deleting team permission: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.DeleteTeamPermission(namespace, repository, permissionTeamName)
+		if err != nil {
+			return fmt.Errorf("deleting team permission: %w", err)
 		}
 
 		fmt.Printf("Successfully removed permission for team %s from %s/%s\n",
 			permissionTeamName, namespace, repository)
+		return nil
 	},
 }
 
@@ -267,33 +292,18 @@ func init() {
 	permissionsCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
 
 	// Mark global flags as required
-	if err := permissionsCmd.MarkPersistentFlagRequired("namespace"); err != nil {
-		fmt.Printf("Error marking namespace flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := permissionsCmd.MarkPersistentFlagRequired("repository"); err != nil {
-		fmt.Printf("Error marking repository flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = permissionsCmd.MarkPersistentFlagRequired("namespace")
+	_ = permissionsCmd.MarkPersistentFlagRequired("repository")
 
 	// Set command specific flags
 	permSetCmd.Flags().StringVarP(&permissionUser, "user", "u", "", "Username or robot account")
 	permSetCmd.Flags().StringVarP(&permissionRole, "role", "R", "", "Permission role (read/write/admin)")
-	if err := permSetCmd.MarkFlagRequired("user"); err != nil {
-		fmt.Printf("Error marking user flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := permSetCmd.MarkFlagRequired("role"); err != nil {
-		fmt.Printf("Error marking role flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = permSetCmd.MarkFlagRequired("user")
+	_ = permSetCmd.MarkFlagRequired("role")
 
 	// Remove command specific flags
 	permRemoveCmd.Flags().StringVarP(&permissionUser, "user", "u", "", "Username or robot account")
-	if err := permRemoveCmd.MarkFlagRequired("user"); err != nil {
-		fmt.Printf("Error marking user flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = permRemoveCmd.MarkFlagRequired("user")
 
 	initPermUserFlags()
 	initPermTeamFlags()
@@ -301,31 +311,31 @@ func init() {
 
 func initPermUserFlags() {
 	permUserPermissionCmd.Flags().StringVarP(&permissionUser, "user", "u", "", "Username")
-	markFlagRequired(permUserPermissionCmd.MarkFlagRequired("user"))
+	_ = permUserPermissionCmd.MarkFlagRequired("user")
 
 	permSetUserPermCmd.Flags().StringVarP(&permissionUser, "user", "u", "", "Username")
 	permSetUserPermCmd.Flags().StringVarP(&permissionRole, "role", "R", "", "Permission role (read/write/admin)")
-	markFlagRequired(permSetUserPermCmd.MarkFlagRequired("user"))
-	markFlagRequired(permSetUserPermCmd.MarkFlagRequired("role"))
+	_ = permSetUserPermCmd.MarkFlagRequired("user")
+	_ = permSetUserPermCmd.MarkFlagRequired("role")
 
 	permDeleteUserPermCmd.Flags().StringVarP(&permissionUser, "user", "u", "", "Username")
 	permDeleteUserPermCmd.Flags().BoolVar(&confirmPermDeletion, "confirm", false, "Confirm permission removal")
-	markFlagRequired(permDeleteUserPermCmd.MarkFlagRequired("user"))
+	_ = permDeleteUserPermCmd.MarkFlagRequired("user")
 
 	permUserTransitiveCmd.Flags().StringVarP(&permissionUser, "user", "u", "", "Username")
-	markFlagRequired(permUserTransitiveCmd.MarkFlagRequired("user"))
+	_ = permUserTransitiveCmd.MarkFlagRequired("user")
 }
 
 func initPermTeamFlags() {
 	permTeamPermissionCmd.Flags().StringVar(&permissionTeamName, "team", "", "Team name")
-	markFlagRequired(permTeamPermissionCmd.MarkFlagRequired("team"))
+	_ = permTeamPermissionCmd.MarkFlagRequired("team")
 
 	permSetTeamPermCmd.Flags().StringVar(&permissionTeamName, "team", "", "Team name")
 	permSetTeamPermCmd.Flags().StringVarP(&permissionRole, "role", "R", "", "Permission role (read/write/admin)")
-	markFlagRequired(permSetTeamPermCmd.MarkFlagRequired("team"))
-	markFlagRequired(permSetTeamPermCmd.MarkFlagRequired("role"))
+	_ = permSetTeamPermCmd.MarkFlagRequired("team")
+	_ = permSetTeamPermCmd.MarkFlagRequired("role")
 
 	permDeleteTeamPermCmd.Flags().StringVar(&permissionTeamName, "team", "", "Team name")
 	permDeleteTeamPermCmd.Flags().BoolVar(&confirmPermDeletion, "confirm", false, "Confirm permission removal")
-	markFlagRequired(permDeleteTeamPermCmd.MarkFlagRequired("team"))
+	_ = permDeleteTeamPermCmd.MarkFlagRequired("team")
 }

--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -12,7 +12,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -43,16 +42,18 @@ var prototypeListCmd = &cobra.Command{
 	Use:   subcmdList,
 	Short: "List all permission prototypes",
 	Long:  `List all permission prototypes for an organization.`,
-	Run: func(_ *cobra.Command, _ []string) {
-		client := mustGetClient()
+	RunE: func(_ *cobra.Command, _ []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		prototypes, err := client.GetPrototypes(prototypeOrg)
 		if err != nil {
-			fmt.Println("Error getting prototypes:", err)
-			os.Exit(1)
+			return fmt.Errorf("getting prototypes: %w", err)
 		}
 
-		printJSON(prototypes)
+		return printJSON(prototypes)
 	},
 }
 
@@ -61,21 +62,22 @@ var prototypeInfoCmd = &cobra.Command{
 	Use:   subcmdInfo,
 	Short: "Get a specific prototype",
 	Long:  `Get detailed information about a specific permission prototype.`,
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		if prototypeUUID == "" {
-			fmt.Println("Error: --uuid is required")
-			os.Exit(1)
+			return fmt.Errorf("--uuid is required")
 		}
 
-		client := mustGetClient()
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		prototype, err := client.GetPrototype(prototypeOrg, prototypeUUID)
 		if err != nil {
-			fmt.Println("Error getting prototype:", err)
-			os.Exit(1)
+			return fmt.Errorf("getting prototype: %w", err)
 		}
 
-		printJSON(prototype)
+		return printJSON(prototype)
 	},
 }
 
@@ -87,28 +89,28 @@ var prototypeCreateCmd = &cobra.Command{
 
 Delegate kinds:
   - user: A specific user account
-  - team: A team within the organization  
+  - team: A team within the organization
   - robot: A robot account
 
 Roles:
   - read: Pull images
   - write: Pull and push images
   - admin: Full administrative access`,
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		if prototypeDelegateName == "" {
-			fmt.Println("Error: --delegate-name is required")
-			os.Exit(1)
+			return fmt.Errorf("--delegate-name is required")
 		}
 		if prototypeDelegateKind == "" {
-			fmt.Println("Error: --delegate-kind is required")
-			os.Exit(1)
+			return fmt.Errorf("--delegate-kind is required")
 		}
 		if prototypeRole == "" {
-			fmt.Println("Error: --role is required")
-			os.Exit(1)
+			return fmt.Errorf("--role is required")
 		}
 
-		client := mustGetClient()
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		createReq := &lib.CreatePrototypeRequest{
 			Delegate: lib.PrototypeDelegateRequest{
@@ -120,11 +122,10 @@ Roles:
 
 		prototype, err := client.CreatePrototype(prototypeOrg, createReq)
 		if err != nil {
-			fmt.Println("Error creating prototype:", err)
-			os.Exit(1)
+			return fmt.Errorf("creating prototype: %w", err)
 		}
 
-		printJSON(prototype)
+		return printJSON(prototype)
 	},
 }
 
@@ -133,17 +134,18 @@ var prototypeUpdateCmd = &cobra.Command{
 	Use:   subcmdUpdate,
 	Short: "Update a prototype",
 	Long:  `Update an existing permission prototype's role.`,
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		if prototypeUUID == "" {
-			fmt.Println("Error: --uuid is required")
-			os.Exit(1)
+			return fmt.Errorf("--uuid is required")
 		}
 		if prototypeRole == "" {
-			fmt.Println("Error: --role is required")
-			os.Exit(1)
+			return fmt.Errorf("--role is required")
 		}
 
-		client := mustGetClient()
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		updateReq := &lib.UpdatePrototypeRequest{
 			Role: prototypeRole,
@@ -151,11 +153,10 @@ var prototypeUpdateCmd = &cobra.Command{
 
 		prototype, err := client.UpdatePrototype(prototypeOrg, prototypeUUID, updateReq)
 		if err != nil {
-			fmt.Println("Error updating prototype:", err)
-			os.Exit(1)
+			return fmt.Errorf("updating prototype: %w", err)
 		}
 
-		printJSON(prototype)
+		return printJSON(prototype)
 	},
 }
 
@@ -164,25 +165,26 @@ var prototypeDeleteCmd = &cobra.Command{
 	Use:   subcmdDelete,
 	Short: "Delete a prototype",
 	Long:  `Delete a permission prototype from an organization.`,
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		if prototypeUUID == "" {
-			fmt.Println("Error: --uuid is required")
-			os.Exit(1)
+			return fmt.Errorf("--uuid is required")
 		}
 		if !confirmProtoDelete {
-			fmt.Println("Error: --confirm is required to delete a prototype")
-			os.Exit(1)
+			return fmt.Errorf("--confirm is required to delete a prototype")
 		}
 
-		client := mustGetClient()
-
-		err := client.DeletePrototype(prototypeOrg, prototypeUUID)
+		client, err := getClient()
 		if err != nil {
-			fmt.Println("Error deleting prototype:", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.DeletePrototype(prototypeOrg, prototypeUUID)
+		if err != nil {
+			return fmt.Errorf("deleting prototype: %w", err)
 		}
 
 		fmt.Printf("Prototype %s deleted successfully\n", prototypeUUID)
+		return nil
 	},
 }
 

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -40,21 +40,22 @@ Available commands:
 var repoInfoCmd = &cobra.Command{
 	Use:   subcmdInfo,
 	Short: "Get repository information from Quay.io",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if repository == "" {
-			fmt.Println("Error: --repository is required")
-			os.Exit(1)
+			return fmt.Errorf("--repository is required")
 		}
 
-		client := mustGetClient()
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		repo, err := client.GetRepository(namespace, repository)
 		if err != nil {
-			fmt.Printf("Error getting repository: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting repository: %w", err)
 		}
 
-		printJSON(repo)
+		return printJSON(repo)
 	},
 }
 
@@ -63,22 +64,23 @@ var repoCreateCmd = &cobra.Command{
 	Use:   subcmdCreate,
 	Short: "Create a new repository",
 	Long:  `Create a new repository in the specified namespace with optional description and visibility settings.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if repository == "" {
-			fmt.Println("Error: --repository is required")
-			os.Exit(1)
+			return fmt.Errorf("--repository is required")
 		}
 
-		client := mustGetClient()
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		repo, err := client.CreateRepository(namespace, repository, repoVisibility, repoDescription)
 		if err != nil {
-			fmt.Printf("Error creating repository: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating repository: %w", err)
 		}
 
 		fmt.Printf("Successfully created repository %s/%s\n", namespace, repository)
-		printJSON(repo)
+		return printJSON(repo)
 	},
 }
 
@@ -87,22 +89,23 @@ var repoUpdateCmd = &cobra.Command{
 	Use:   subcmdUpdate,
 	Short: "Update repository settings",
 	Long:  `Update repository description and/or visibility settings.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if repository == "" {
-			fmt.Println("Error: --repository is required")
-			os.Exit(1)
+			return fmt.Errorf("--repository is required")
 		}
 
-		client := mustGetClient()
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		repo, err := client.UpdateRepository(namespace, repository, repoDescription, repoVisibility)
 		if err != nil {
-			fmt.Printf("Error updating repository: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("updating repository: %w", err)
 		}
 
 		fmt.Printf("Successfully updated repository %s/%s\n", namespace, repository)
-		printJSON(repo)
+		return printJSON(repo)
 	},
 }
 
@@ -111,27 +114,27 @@ var repoDeleteCmd = &cobra.Command{
 	Use:   subcmdDelete,
 	Short: "Delete a repository",
 	Long:  `Delete a repository. This action is irreversible and will remove all images and tags.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if repository == "" {
-			fmt.Println("Error: --repository is required")
-			os.Exit(1)
+			return fmt.Errorf("--repository is required")
 		}
 
 		if !confirmDeletion {
-			fmt.Printf("Are you sure you want to delete repository %s/%s? This action cannot be undone.\n", namespace, repository)
-			fmt.Print("Use --confirm to proceed with deletion.\n")
-			os.Exit(1)
+			return fmt.Errorf("are you sure you want to delete repository %s/%s? This action cannot be undone.\nUse --confirm to proceed with deletion", namespace, repository)
 		}
 
-		client := mustGetClient()
-
-		err := client.DeleteRepository(namespace, repository)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error deleting repository: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.DeleteRepository(namespace, repository)
+		if err != nil {
+			return fmt.Errorf("deleting repository: %w", err)
 		}
 
 		fmt.Printf("Successfully deleted repository %s/%s\n", namespace, repository)
+		return nil
 	},
 }
 
@@ -150,18 +153,19 @@ Use --table with --popularity for an enriched dashboard sorted by pull count:
   kube-rbac-proxy             4052   0             1     v0.13.1     2026-03-13  no
   certsuite                   774    6             51    unstable    2026-06-15  yes
   collector                   32     4             46    unstable    2026-06-15  no`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		repos, err := client.ListRepositories(namespace, repoPublic, repoStarred, repoPopularity, repoPage, repoLimit)
 		if err != nil {
-			fmt.Printf("Error listing repositories: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("listing repositories: %w", err)
 		}
 
 		if !repoTable {
-			printJSON(repos)
-			return
+			return printJSON(repos)
 		}
 
 		sort.Slice(repos.Repositories, func(i, j int) bool {
@@ -213,9 +217,9 @@ Use --table with --popularity for an enriched dashboard sorted by pull count:
 		}
 
 		if err := w.Flush(); err != nil {
-			fmt.Printf("Error flushing table output: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("flushing table output: %w", err)
 		}
+		return nil
 	},
 }
 
@@ -223,21 +227,23 @@ var repoChangeVisibilityCmd = &cobra.Command{
 	Use:   "change-visibility",
 	Short: "Change repository visibility",
 	Long:  `Change a repository's visibility between public and private.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if repository == "" {
-			fmt.Println("Error: --repository is required")
-			os.Exit(1)
+			return fmt.Errorf("--repository is required")
 		}
 
-		client := mustGetClient()
-
-		err := client.ChangeRepositoryVisibility(namespace, repository, repoVisibility)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error changing repository visibility: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.ChangeRepositoryVisibility(namespace, repository, repoVisibility)
+		if err != nil {
+			return fmt.Errorf("changing repository visibility: %w", err)
 		}
 
 		fmt.Printf("Successfully changed visibility of %s/%s to %s\n", namespace, repository, repoVisibility)
+		return nil
 	},
 }
 
@@ -255,10 +261,7 @@ func init() {
 	repositoryCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
 
 	// Mark global flags as required
-	if err := repositoryCmd.MarkPersistentFlagRequired("namespace"); err != nil {
-		fmt.Printf("Error marking namespace flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = repositoryCmd.MarkPersistentFlagRequired("namespace")
 
 	// Create command specific flags
 	repoCreateCmd.Flags().StringVarP(&repoVisibility, "visibility", "v", "private", "Repository visibility (private/public)")
@@ -281,8 +284,5 @@ func init() {
 
 	// Change-visibility command specific flags
 	repoChangeVisibilityCmd.Flags().StringVarP(&repoVisibility, "visibility", "v", "", "New visibility (private/public)")
-	if err := repoChangeVisibilityCmd.MarkFlagRequired("visibility"); err != nil {
-		fmt.Printf("Error marking visibility flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = repoChangeVisibilityCmd.MarkFlagRequired("visibility")
 }

--- a/cmd/repotoken.go
+++ b/cmd/repotoken.go
@@ -14,7 +14,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -44,16 +43,18 @@ var repotokenListCmd = &cobra.Command{
 	Use:   subcmdList,
 	Short: "List all repository tokens",
 	Long:  `List all tokens for a repository. (DEPRECATED - use robot accounts)`,
-	Run: func(_ *cobra.Command, _ []string) {
-		client := mustGetClient()
+	RunE: func(_ *cobra.Command, _ []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		tokens, err := client.GetRepoTokens(repoTokenNamespace, repoTokenRepository) //nolint:staticcheck // Intentionally using deprecated API
 		if err != nil {
-			fmt.Println("Error getting tokens:", err)
-			os.Exit(1)
+			return fmt.Errorf("getting tokens: %w", err)
 		}
 
-		printJSON(tokens)
+		return printJSON(tokens)
 	},
 }
 
@@ -62,21 +63,22 @@ var repotokenInfoCmd = &cobra.Command{
 	Use:   subcmdInfo,
 	Short: "Get a specific token",
 	Long:  `Get detailed information about a specific repository token. (DEPRECATED - use robot accounts)`,
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		if repoTokenCode == "" {
-			fmt.Println("Error: --code is required")
-			os.Exit(1)
+			return fmt.Errorf("--code is required")
 		}
 
-		client := mustGetClient()
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		repoToken, err := client.GetRepoToken(repoTokenNamespace, repoTokenRepository, repoTokenCode) //nolint:staticcheck // Intentionally using deprecated API
 		if err != nil {
-			fmt.Println("Error getting token:", err)
-			os.Exit(1)
+			return fmt.Errorf("getting token: %w", err)
 		}
 
-		printJSON(repoToken)
+		return printJSON(repoToken)
 	},
 }
 
@@ -85,13 +87,15 @@ var repotokenCreateCmd = &cobra.Command{
 	Use:   subcmdCreate,
 	Short: "Create a new token",
 	Long:  `Create a new repository token. (DEPRECATED - use robot accounts)`,
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		if repoTokenName == "" {
-			fmt.Println("Error: --name is required")
-			os.Exit(1)
+			return fmt.Errorf("--name is required")
 		}
 
-		client := mustGetClient()
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		createReq := &lib.CreateRepoTokenRequest{
 			FriendlyName: repoTokenName,
@@ -99,11 +103,10 @@ var repotokenCreateCmd = &cobra.Command{
 
 		repoToken, err := client.CreateRepoToken(repoTokenNamespace, repoTokenRepository, createReq) //nolint:staticcheck // Intentionally using deprecated API
 		if err != nil {
-			fmt.Println("Error creating token:", err)
-			os.Exit(1)
+			return fmt.Errorf("creating token: %w", err)
 		}
 
-		printJSON(repoToken)
+		return printJSON(repoToken)
 	},
 }
 
@@ -112,17 +115,18 @@ var repotokenUpdateCmd = &cobra.Command{
 	Use:   subcmdUpdate,
 	Short: "Update a token",
 	Long:  `Update a repository token's role. (DEPRECATED - use robot accounts)`,
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		if repoTokenCode == "" {
-			fmt.Println("Error: --code is required")
-			os.Exit(1)
+			return fmt.Errorf("--code is required")
 		}
 		if repoTokenRole == "" {
-			fmt.Println("Error: --role is required")
-			os.Exit(1)
+			return fmt.Errorf("--role is required")
 		}
 
-		client := mustGetClient()
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		updateReq := &lib.UpdateRepoTokenRequest{
 			Role: repoTokenRole,
@@ -130,11 +134,10 @@ var repotokenUpdateCmd = &cobra.Command{
 
 		repoToken, err := client.UpdateRepoToken(repoTokenNamespace, repoTokenRepository, repoTokenCode, updateReq) //nolint:staticcheck // Intentionally using deprecated API
 		if err != nil {
-			fmt.Println("Error updating token:", err)
-			os.Exit(1)
+			return fmt.Errorf("updating token: %w", err)
 		}
 
-		printJSON(repoToken)
+		return printJSON(repoToken)
 	},
 }
 
@@ -143,25 +146,26 @@ var repotokenDeleteCmd = &cobra.Command{
 	Use:   subcmdDelete,
 	Short: "Delete a token",
 	Long:  `Delete a repository token. (DEPRECATED - use robot accounts)`,
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		if repoTokenCode == "" {
-			fmt.Println("Error: --code is required")
-			os.Exit(1)
+			return fmt.Errorf("--code is required")
 		}
 		if !confirmTokenDelete {
-			fmt.Println("Error: --confirm is required to delete a token")
-			os.Exit(1)
+			return fmt.Errorf("--confirm is required to delete a token")
 		}
 
-		client := mustGetClient()
-
-		err := client.DeleteRepoToken(repoTokenNamespace, repoTokenRepository, repoTokenCode) //nolint:staticcheck // Intentionally using deprecated API
+		client, err := getClient()
 		if err != nil {
-			fmt.Println("Error deleting token:", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.DeleteRepoToken(repoTokenNamespace, repoTokenRepository, repoTokenCode) //nolint:staticcheck // Intentionally using deprecated API
+		if err != nil {
+			return fmt.Errorf("deleting token: %w", err)
 		}
 
 		fmt.Printf("Token %s deleted successfully\n", repoTokenCode)
+		return nil
 	},
 }
 

--- a/cmd/robot.go
+++ b/cmd/robot.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -39,17 +38,19 @@ var robotListCmd = &cobra.Command{
 	Use:   subcmdList,
 	Short: "List all robot accounts",
 	Long:  `List all robot accounts associated with your user account.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		robots, err := client.GetUserRobotAccounts()
 		if err != nil {
-			fmt.Printf("Error getting robot accounts: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting robot accounts: %w", err)
 		}
 
 		fmt.Println("User robot accounts:")
-		printJSON(robots)
+		return printJSON(robots)
 	},
 }
 
@@ -58,17 +59,19 @@ var robotInfoCmd = &cobra.Command{
 	Use:   subcmdInfo,
 	Short: "Get robot account details",
 	Long:  `Get detailed information about a specific robot account including its token.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		robot, err := client.GetUserRobotAccount(robotShortname)
 		if err != nil {
-			fmt.Printf("Error getting robot account: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting robot account: %w", err)
 		}
 
 		fmt.Printf("Robot account: %s\n", robotShortname)
-		printJSON(robot)
+		return printJSON(robot)
 	},
 }
 
@@ -77,18 +80,20 @@ var robotCreateCmd = &cobra.Command{
 	Use:   subcmdCreate,
 	Short: "Create a new robot account",
 	Long:  `Create a new robot account with the specified name and description.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		robot, err := client.CreateUserRobotAccount(robotShortname, robotDescription, nil)
 		if err != nil {
-			fmt.Printf("Error creating robot account: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating robot account: %w", err)
 		}
 
 		fmt.Printf("Successfully created robot account: %s\n", robotShortname)
 		fmt.Println("IMPORTANT: Save the token below - it will not be shown again!")
-		printJSON(robot)
+		return printJSON(robot)
 	},
 }
 
@@ -97,22 +102,23 @@ var robotDeleteCmd = &cobra.Command{
 	Use:   subcmdDelete,
 	Short: "Delete a robot account",
 	Long:  `Delete a robot account. This action cannot be undone.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirmRobotDelete {
-			fmt.Printf("Are you sure you want to delete robot account '%s'? This action cannot be undone.\n", robotShortname)
-			fmt.Println("Use --confirm to proceed with deletion.")
-			os.Exit(1)
+			return fmt.Errorf("are you sure you want to delete robot account '%s'? This action cannot be undone.\nUse --confirm to proceed with deletion", robotShortname)
 		}
 
-		client := mustGetClient()
-
-		err := client.DeleteUserRobotAccount(robotShortname)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error deleting robot account: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.DeleteUserRobotAccount(robotShortname)
+		if err != nil {
+			return fmt.Errorf("deleting robot account: %w", err)
 		}
 
 		fmt.Printf("Successfully deleted robot account: %s\n", robotShortname)
+		return nil
 	},
 }
 
@@ -121,18 +127,20 @@ var robotRegenerateCmd = &cobra.Command{
 	Use:   "regenerate",
 	Short: "Regenerate robot token",
 	Long:  `Regenerate the token for a robot account. The old token will be invalidated.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		robot, err := client.RegenerateUserRobotToken(robotShortname)
 		if err != nil {
-			fmt.Printf("Error regenerating robot token: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("regenerating robot token: %w", err)
 		}
 
 		fmt.Printf("Successfully regenerated token for robot: %s\n", robotShortname)
 		fmt.Println("IMPORTANT: Save the new token below - it will not be shown again!")
-		printJSON(robot)
+		return printJSON(robot)
 	},
 }
 
@@ -141,17 +149,19 @@ var robotPermissionsCmd = &cobra.Command{
 	Use:   subcmdPermissions,
 	Short: "Get robot repository permissions",
 	Long:  `Get the repository permissions assigned to a robot account.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		permissions, err := client.GetUserRobotPermissions(robotShortname)
 		if err != nil {
-			fmt.Printf("Error getting robot permissions: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting robot permissions: %w", err)
 		}
 
 		fmt.Printf("Permissions for robot: %s\n", robotShortname)
-		printJSON(permissions)
+		return printJSON(permissions)
 	},
 }
 
@@ -159,16 +169,18 @@ var robotPermissionsCmd = &cobra.Command{
 var robotFederationGetCmd = &cobra.Command{
 	Use:   "federation-get",
 	Short: "Get robot federation configuration",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		federation, err := client.GetUserRobotFederation(robotShortname)
 		if err != nil {
-			fmt.Printf("Error getting robot federation: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting robot federation: %w", err)
 		}
 
-		printJSON(federation)
+		return printJSON(federation)
 	},
 }
 
@@ -176,20 +188,23 @@ var robotFederationGetCmd = &cobra.Command{
 var robotFederationCreateCmd = &cobra.Command{
 	Use:   "federation-create",
 	Short: "Create or update robot federation configuration",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		configs := []lib.RobotFederationConfig{
 			{Issuer: federationIssuer, Subject: federationSubject},
 		}
 
-		err := client.CreateUserRobotFederation(robotShortname, configs)
+		err = client.CreateUserRobotFederation(robotShortname, configs)
 		if err != nil {
-			fmt.Printf("Error creating robot federation: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating robot federation: %w", err)
 		}
 
 		fmt.Printf("Successfully configured federation for robot: %s\n", robotShortname)
+		return nil
 	},
 }
 
@@ -197,16 +212,19 @@ var robotFederationCreateCmd = &cobra.Command{
 var robotFederationDeleteCmd = &cobra.Command{
 	Use:   "federation-delete",
 	Short: "Delete robot federation configuration",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-
-		err := client.DeleteUserRobotFederation(robotShortname)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error deleting robot federation: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.DeleteUserRobotFederation(robotShortname)
+		if err != nil {
+			return fmt.Errorf("deleting robot federation: %w", err)
 		}
 
 		fmt.Printf("Successfully deleted federation for robot: %s\n", robotShortname)
+		return nil
 	},
 }
 
@@ -224,54 +242,39 @@ func init() {
 
 	// Info command flags
 	robotInfoCmd.Flags().StringVarP(&robotShortname, "name", "n", "", "Robot short name (without username prefix)")
-	if err := robotInfoCmd.MarkFlagRequired("name"); err != nil {
-		fmt.Printf("Error marking name flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = robotInfoCmd.MarkFlagRequired("name")
 
 	// Create command flags
 	robotCreateCmd.Flags().StringVarP(&robotShortname, "name", "n", "", "Robot short name (without username prefix)")
 	robotCreateCmd.Flags().StringVarP(&robotDescription, "description", "d", "", "Robot description")
-	if err := robotCreateCmd.MarkFlagRequired("name"); err != nil {
-		fmt.Printf("Error marking name flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = robotCreateCmd.MarkFlagRequired("name")
 
 	// Delete command flags
 	robotDeleteCmd.Flags().StringVarP(&robotShortname, "name", "n", "", "Robot short name (without username prefix)")
 	robotDeleteCmd.Flags().BoolVar(&confirmRobotDelete, "confirm", false, "Confirm robot deletion")
-	if err := robotDeleteCmd.MarkFlagRequired("name"); err != nil {
-		fmt.Printf("Error marking name flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = robotDeleteCmd.MarkFlagRequired("name")
 
 	// Regenerate command flags
 	robotRegenerateCmd.Flags().StringVarP(&robotShortname, "name", "n", "", "Robot short name (without username prefix)")
-	if err := robotRegenerateCmd.MarkFlagRequired("name"); err != nil {
-		fmt.Printf("Error marking name flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = robotRegenerateCmd.MarkFlagRequired("name")
 
 	// Permissions command flags
 	robotPermissionsCmd.Flags().StringVarP(&robotShortname, "name", "n", "", "Robot short name (without username prefix)")
-	if err := robotPermissionsCmd.MarkFlagRequired("name"); err != nil {
-		fmt.Printf("Error marking name flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = robotPermissionsCmd.MarkFlagRequired("name")
 
 	// Federation get command flags
 	robotFederationGetCmd.Flags().StringVarP(&robotShortname, "name", "n", "", "Robot short name")
-	markFlagRequired(robotFederationGetCmd.MarkFlagRequired("name"))
+	_ = robotFederationGetCmd.MarkFlagRequired("name")
 
 	// Federation create command flags
 	robotFederationCreateCmd.Flags().StringVarP(&robotShortname, "name", "n", "", "Robot short name")
 	robotFederationCreateCmd.Flags().StringVar(&federationIssuer, "issuer", "", "Federation token issuer")
 	robotFederationCreateCmd.Flags().StringVar(&federationSubject, "subject", "", "Federation token subject")
-	markFlagRequired(robotFederationCreateCmd.MarkFlagRequired("name"))
-	markFlagRequired(robotFederationCreateCmd.MarkFlagRequired("issuer"))
-	markFlagRequired(robotFederationCreateCmd.MarkFlagRequired("subject"))
+	_ = robotFederationCreateCmd.MarkFlagRequired("name")
+	_ = robotFederationCreateCmd.MarkFlagRequired("issuer")
+	_ = robotFederationCreateCmd.MarkFlagRequired("subject")
 
 	// Federation delete command flags
 	robotFederationDeleteCmd.Flags().StringVarP(&robotShortname, "name", "n", "", "Robot short name")
-	markFlagRequired(robotFederationDeleteCmd.MarkFlagRequired("name"))
+	_ = robotFederationDeleteCmd.MarkFlagRequired("name")
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -28,17 +27,19 @@ var searchReposCmd = &cobra.Command{
 	Use:   "repositories",
 	Short: "Search for repositories",
 	Long:  `Search for repositories on Quay.io by name or description.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		result, err := client.SearchRepositories(searchQuery, searchPage)
 		if err != nil {
-			fmt.Printf("Error searching repositories: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("searching repositories: %w", err)
 		}
 
 		fmt.Printf("Repository search results for: %s\n", searchQuery)
-		printJSON(result)
+		return printJSON(result)
 	},
 }
 
@@ -54,17 +55,19 @@ Results include a 'kind' field indicating the entity type:
   - organization: Organization
   - team: Team within an organization
   - robot: Robot account`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		result, err := client.SearchAll(searchQuery)
 		if err != nil {
-			fmt.Printf("Error searching: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("searching: %w", err)
 		}
 
 		fmt.Printf("Search results for: %s\n", searchQuery)
-		printJSON(result)
+		return printJSON(result)
 	},
 }
 
@@ -75,10 +78,7 @@ func init() {
 
 	// Global search flags
 	searchCmd.PersistentFlags().StringVarP(&searchQuery, "query", "q", "", "Search query")
-	if err := searchCmd.MarkPersistentFlagRequired("query"); err != nil {
-		fmt.Printf("Error marking query flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = searchCmd.MarkPersistentFlagRequired("query")
 
 	// Repositories command specific flags
 	searchReposCmd.Flags().IntVarP(&searchPage, "page", "p", 0, "Page number for pagination (starts at 1)")

--- a/cmd/secscan.go
+++ b/cmd/secscan.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -37,17 +36,19 @@ The scan status can be:
   - scanning: Scan is currently in progress
   - unsupported: Image type is not supported for scanning
   - failed: Scan failed`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		security, err := client.GetManifestSecurity(namespace, repository, secScanManifestRef, includeVulnerabilities)
 		if err != nil {
-			fmt.Printf("Error getting security scan: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting security scan: %w", err)
 		}
 
 		fmt.Printf("Security scan for %s/%s@%s\n", namespace, repository, secScanManifestRef)
-		printJSON(security)
+		return printJSON(security)
 	},
 }
 
@@ -61,18 +62,9 @@ func init() {
 	secscanCmd.PersistentFlags().StringVarP(&secScanManifestRef, "manifest", "m", "", "Manifest reference (digest like sha256:...)")
 
 	// Mark global flags as required
-	if err := secscanCmd.MarkPersistentFlagRequired("namespace"); err != nil {
-		fmt.Printf("Error marking namespace flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := secscanCmd.MarkPersistentFlagRequired("repository"); err != nil {
-		fmt.Printf("Error marking repository flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := secscanCmd.MarkPersistentFlagRequired("manifest"); err != nil {
-		fmt.Printf("Error marking manifest flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = secscanCmd.MarkPersistentFlagRequired("namespace")
+	_ = secscanCmd.MarkPersistentFlagRequired("repository")
+	_ = secscanCmd.MarkPersistentFlagRequired("manifest")
 
 	// Info command specific flags
 	secscanInfoCmd.Flags().BoolVarP(&includeVulnerabilities, "vulnerabilities", "V", true, "Include vulnerability details in the response")

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -33,17 +32,19 @@ var tagInfoCmd = &cobra.Command{
 	Use:   subcmdInfo,
 	Short: "Get detailed tag information",
 	Long:  `Get detailed information about a specific tag including metadata, manifest digest, and size.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		tag, err := client.GetTag(namespace, repository, tagName)
 		if err != nil {
-			fmt.Printf("Error getting tag information: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting tag information: %w", err)
 		}
 
 		fmt.Printf("Tag information for %s/%s:%s\n", namespace, repository, tagName)
-		printJSON(tag)
+		return printJSON(tag)
 	},
 }
 
@@ -52,17 +53,19 @@ var tagUpdateCmd = &cobra.Command{
 	Use:   subcmdUpdate,
 	Short: "Update tag metadata",
 	Long:  `Update tag metadata such as expiration date.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		tag, err := client.UpdateTag(namespace, repository, tagName, tagExpiration)
 		if err != nil {
-			fmt.Printf("Error updating tag: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("updating tag: %w", err)
 		}
 
 		fmt.Printf("Successfully updated tag %s/%s:%s\n", namespace, repository, tagName)
-		printJSON(tag)
+		return printJSON(tag)
 	},
 }
 
@@ -71,22 +74,23 @@ var tagDeleteCmd = &cobra.Command{
 	Use:   subcmdDelete,
 	Short: "Delete a tag",
 	Long:  `Delete a specific tag from the repository. This action cannot be undone.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirmTagDeletion {
-			fmt.Printf("Are you sure you want to delete tag %s/%s:%s? This action cannot be undone.\n", namespace, repository, tagName)
-			fmt.Print("Use --confirm to proceed with deletion.\n")
-			os.Exit(1)
+			return fmt.Errorf("are you sure you want to delete tag %s/%s:%s? This action cannot be undone.\nUse --confirm to proceed with deletion", namespace, repository, tagName)
 		}
 
-		client := mustGetClient()
-
-		err := client.DeleteTag(namespace, repository, tagName)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error deleting tag: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.DeleteTag(namespace, repository, tagName)
+		if err != nil {
+			return fmt.Errorf("deleting tag: %w", err)
 		}
 
 		fmt.Printf("Successfully deleted tag %s/%s:%s\n", namespace, repository, tagName)
+		return nil
 	},
 }
 
@@ -95,17 +99,19 @@ var tagHistoryCmd = &cobra.Command{
 	Use:   "history",
 	Short: "Get tag history",
 	Long:  `Get the history of changes for a specific tag, including previous versions and modifications.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		history, err := client.GetTagHistory(namespace, repository, tagName)
 		if err != nil {
-			fmt.Printf("Error getting tag history: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting tag history: %w", err)
 		}
 
 		fmt.Printf("History for tag %s/%s:%s\n", namespace, repository, tagName)
-		printJSON(history)
+		return printJSON(history)
 	},
 }
 
@@ -114,17 +120,19 @@ var tagRevertCmd = &cobra.Command{
 	Use:   "revert",
 	Short: "Revert tag to a previous state",
 	Long:  `Revert a tag to a previous state using its manifest digest.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		tag, err := client.RevertTag(namespace, repository, tagName, manifestDigest)
 		if err != nil {
-			fmt.Printf("Error reverting tag: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("reverting tag: %w", err)
 		}
 
 		fmt.Printf("Successfully reverted tag %s/%s:%s to manifest %s\n", namespace, repository, tagName, manifestDigest)
-		printJSON(tag)
+		return printJSON(tag)
 	},
 }
 
@@ -132,16 +140,19 @@ var tagRestoreCmd = &cobra.Command{
 	Use:   "restore",
 	Short: "Restore a tag from a previous state",
 	Long:  `Restore a previously deleted or modified tag using its manifest digest.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-
-		err := client.RestoreTag(namespace, repository, tagName, manifestDigest)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error restoring tag: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.RestoreTag(namespace, repository, tagName, manifestDigest)
+		if err != nil {
+			return fmt.Errorf("restoring tag: %w", err)
 		}
 
 		fmt.Printf("Successfully restored tag %s/%s:%s from manifest %s\n", namespace, repository, tagName, manifestDigest)
+		return nil
 	},
 }
 
@@ -160,18 +171,9 @@ func init() {
 	tagCmd.PersistentFlags().StringVarP(&tagName, "tag", "T", "", "Name of the tag")
 
 	// Mark global flags as required
-	if err := tagCmd.MarkPersistentFlagRequired("namespace"); err != nil {
-		fmt.Printf("Error marking namespace flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := tagCmd.MarkPersistentFlagRequired("repository"); err != nil {
-		fmt.Printf("Error marking repository flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := tagCmd.MarkPersistentFlagRequired("tag"); err != nil {
-		fmt.Printf("Error marking tag flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = tagCmd.MarkPersistentFlagRequired("namespace")
+	_ = tagCmd.MarkPersistentFlagRequired("repository")
+	_ = tagCmd.MarkPersistentFlagRequired("tag")
 
 	// Update command specific flags
 	tagUpdateCmd.Flags().StringVarP(&tagExpiration, "expiration", "e", "", "Tag expiration date (ISO format)")
@@ -181,15 +183,9 @@ func init() {
 
 	// Revert command specific flags
 	tagRevertCmd.Flags().StringVarP(&manifestDigest, "manifest", "m", "", "Manifest digest to revert to")
-	if err := tagRevertCmd.MarkFlagRequired("manifest"); err != nil {
-		fmt.Printf("Error marking manifest flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = tagRevertCmd.MarkFlagRequired("manifest")
 
 	// Restore command specific flags
 	tagRestoreCmd.Flags().StringVarP(&manifestDigest, "manifest", "m", "", "Manifest digest to restore")
-	if err := tagRestoreCmd.MarkFlagRequired("manifest"); err != nil {
-		fmt.Printf("Error marking manifest flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = tagRestoreCmd.MarkFlagRequired("manifest")
 }

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -47,17 +46,19 @@ var teamListCmd = &cobra.Command{
 	Use:   subcmdList,
 	Short: "List all teams in an organization",
 	Long:  `List all teams within the specified organization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		teams, err := client.GetTeams(teamCmdOrgname)
 		if err != nil {
-			fmt.Printf("Error getting teams: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting teams: %w", err)
 		}
 
 		fmt.Printf("Teams in organization '%s':\n", teamCmdOrgname)
-		printJSON(teams)
+		return printJSON(teams)
 	},
 }
 
@@ -66,17 +67,19 @@ var teamCmdInfoCmd = &cobra.Command{
 	Use:   subcmdInfo,
 	Short: "Get team details",
 	Long:  `Get detailed information about a specific team.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		team, err := client.GetTeam(teamCmdOrgname, teamCmdName)
 		if err != nil {
-			fmt.Printf("Error getting team: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting team: %w", err)
 		}
 
 		fmt.Printf("Team: %s/%s\n", teamCmdOrgname, teamCmdName)
-		printJSON(team)
+		return printJSON(team)
 	},
 }
 
@@ -90,17 +93,19 @@ Roles:
   - member: Inherits default permissions
   - creator: Can create new repositories
   - admin: Full administrative access`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		team, err := client.CreateTeam(teamCmdOrgname, teamCmdName, teamCmdDescription, teamCmdRole)
 		if err != nil {
-			fmt.Printf("Error creating team: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating team: %w", err)
 		}
 
 		fmt.Printf("Successfully created team: %s/%s\n", teamCmdOrgname, teamCmdName)
-		printJSON(team)
+		return printJSON(team)
 	},
 }
 
@@ -109,17 +114,19 @@ var teamUpdateCmd = &cobra.Command{
 	Use:   subcmdUpdate,
 	Short: "Update team settings",
 	Long:  `Update team description and role.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		team, err := client.UpdateTeam(teamCmdOrgname, teamCmdName, teamCmdDescription, teamCmdRole)
 		if err != nil {
-			fmt.Printf("Error updating team: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("updating team: %w", err)
 		}
 
 		fmt.Printf("Successfully updated team: %s/%s\n", teamCmdOrgname, teamCmdName)
-		printJSON(team)
+		return printJSON(team)
 	},
 }
 
@@ -128,22 +135,23 @@ var teamDeleteCmd = &cobra.Command{
 	Use:   subcmdDelete,
 	Short: "Delete a team",
 	Long:  `Delete a team from an organization. This action cannot be undone.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirmTeamDelete {
-			fmt.Printf("Are you sure you want to delete team '%s/%s'? This action cannot be undone.\n", teamCmdOrgname, teamCmdName)
-			fmt.Println("Use --confirm to proceed with deletion.")
-			os.Exit(1)
+			return fmt.Errorf("are you sure you want to delete team '%s/%s'? This action cannot be undone.\nUse --confirm to proceed with deletion", teamCmdOrgname, teamCmdName)
 		}
 
-		client := mustGetClient()
-
-		err := client.DeleteTeam(teamCmdOrgname, teamCmdName)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error deleting team: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.DeleteTeam(teamCmdOrgname, teamCmdName)
+		if err != nil {
+			return fmt.Errorf("deleting team: %w", err)
 		}
 
 		fmt.Printf("Successfully deleted team: %s/%s\n", teamCmdOrgname, teamCmdName)
+		return nil
 	},
 }
 
@@ -152,17 +160,19 @@ var teamCmdMembersCmd = &cobra.Command{
 	Use:   "members",
 	Short: "List team members",
 	Long:  `List all members of a specific team.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		members, err := client.GetTeamMembers(teamCmdOrgname, teamCmdName)
 		if err != nil {
-			fmt.Printf("Error getting team members: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting team members: %w", err)
 		}
 
 		fmt.Printf("Members of team '%s/%s':\n", teamCmdOrgname, teamCmdName)
-		printJSON(members)
+		return printJSON(members)
 	},
 }
 
@@ -171,16 +181,19 @@ var teamAddMemberCmd = &cobra.Command{
 	Use:   "add-member",
 	Short: "Add a member to a team",
 	Long:  `Add a user or robot account to a team.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-
-		err := client.AddTeamMember(teamCmdOrgname, teamCmdName, teamCmdMemberName)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error adding team member: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.AddTeamMember(teamCmdOrgname, teamCmdName, teamCmdMemberName)
+		if err != nil {
+			return fmt.Errorf("adding team member: %w", err)
 		}
 
 		fmt.Printf("Successfully added '%s' to team '%s/%s'\n", teamCmdMemberName, teamCmdOrgname, teamCmdName)
+		return nil
 	},
 }
 
@@ -189,22 +202,23 @@ var teamRemoveMemberCmd = &cobra.Command{
 	Use:   "remove-member",
 	Short: "Remove a member from a team",
 	Long:  `Remove a user or robot account from a team.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirmTeamMemberDel {
-			fmt.Printf("Are you sure you want to remove '%s' from team '%s/%s'?\n", teamCmdMemberName, teamCmdOrgname, teamCmdName)
-			fmt.Println("Use --confirm to proceed with removal.")
-			os.Exit(1)
+			return fmt.Errorf("are you sure you want to remove '%s' from team '%s/%s'?\nUse --confirm to proceed with removal", teamCmdMemberName, teamCmdOrgname, teamCmdName)
 		}
 
-		client := mustGetClient()
-
-		err := client.RemoveTeamMember(teamCmdOrgname, teamCmdName, teamCmdMemberName)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error removing team member: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.RemoveTeamMember(teamCmdOrgname, teamCmdName, teamCmdMemberName)
+		if err != nil {
+			return fmt.Errorf("removing team member: %w", err)
 		}
 
 		fmt.Printf("Successfully removed '%s' from team '%s/%s'\n", teamCmdMemberName, teamCmdOrgname, teamCmdName)
+		return nil
 	},
 }
 
@@ -213,17 +227,19 @@ var teamPermissionsCmd = &cobra.Command{
 	Use:   subcmdPermissions,
 	Short: "List team repository permissions",
 	Long:  `List all repository permissions for a team.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		permissions, err := client.GetTeamPermissions(teamCmdOrgname, teamCmdName)
 		if err != nil {
-			fmt.Printf("Error getting team permissions: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting team permissions: %w", err)
 		}
 
 		fmt.Printf("Repository permissions for team '%s/%s':\n", teamCmdOrgname, teamCmdName)
-		printJSON(permissions)
+		return printJSON(permissions)
 	},
 }
 
@@ -237,17 +253,20 @@ Permission roles:
   - read: Pull images
   - write: Pull and push images
   - admin: Full administrative access`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-
-		err := client.SetTeamRepositoryPermission(teamCmdOrgname, teamCmdName, teamCmdRepository, teamCmdPermissionRole)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error setting team permission: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.SetTeamRepositoryPermission(teamCmdOrgname, teamCmdName, teamCmdRepository, teamCmdPermissionRole)
+		if err != nil {
+			return fmt.Errorf("setting team permission: %w", err)
 		}
 
 		fmt.Printf("Successfully set '%s' permission for team '%s/%s' on repository '%s'\n",
 			teamCmdPermissionRole, teamCmdOrgname, teamCmdName, teamCmdRepository)
+		return nil
 	},
 }
 
@@ -256,24 +275,25 @@ var teamRemovePermissionCmd = &cobra.Command{
 	Use:   "remove-permission",
 	Short: "Remove repository permission from team",
 	Long:  `Remove repository permission from a team.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if !confirmTeamPermDel {
-			fmt.Printf("Are you sure you want to remove permissions for team '%s/%s' on repository '%s'?\n",
+			return fmt.Errorf("are you sure you want to remove permissions for team '%s/%s' on repository '%s'?\nUse --confirm to proceed with removal",
 				teamCmdOrgname, teamCmdName, teamCmdRepository)
-			fmt.Println("Use --confirm to proceed with removal.")
-			os.Exit(1)
 		}
 
-		client := mustGetClient()
-
-		err := client.RemoveTeamRepositoryPermission(teamCmdOrgname, teamCmdName, teamCmdRepository)
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error removing team permission: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.RemoveTeamRepositoryPermission(teamCmdOrgname, teamCmdName, teamCmdRepository)
+		if err != nil {
+			return fmt.Errorf("removing team permission: %w", err)
 		}
 
 		fmt.Printf("Successfully removed permissions for team '%s/%s' on repository '%s'\n",
 			teamCmdOrgname, teamCmdName, teamCmdRepository)
+		return nil
 	},
 }
 
@@ -299,68 +319,68 @@ func init() {
 
 func initTeamGlobalFlags() {
 	teamCmd.PersistentFlags().StringVarP(&teamCmdOrgname, "organization", "o", "", "Organization name")
-	markFlagRequired(teamCmd.MarkPersistentFlagRequired("organization"))
+	_ = teamCmd.MarkPersistentFlagRequired("organization")
 }
 
 func initTeamCmdFlags() {
 	// Info command flags
 	teamCmdInfoCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
-	markFlagRequired(teamCmdInfoCmd.MarkFlagRequired("name"))
+	_ = teamCmdInfoCmd.MarkFlagRequired("name")
 
 	// Create command flags
 	teamCreateCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
 	teamCreateCmd.Flags().StringVarP(&teamCmdDescription, "description", "d", "", "Team description")
 	teamCreateCmd.Flags().StringVarP(&teamCmdRole, "role", "r", "member", "Team role (member, creator, admin)")
-	markFlagRequired(teamCreateCmd.MarkFlagRequired("name"))
+	_ = teamCreateCmd.MarkFlagRequired("name")
 
 	// Update command flags
 	teamUpdateCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
 	teamUpdateCmd.Flags().StringVarP(&teamCmdDescription, "description", "d", "", "Team description")
 	teamUpdateCmd.Flags().StringVarP(&teamCmdRole, "role", "r", "", "Team role (member, creator, admin)")
-	markFlagRequired(teamUpdateCmd.MarkFlagRequired("name"))
+	_ = teamUpdateCmd.MarkFlagRequired("name")
 
 	// Delete command flags
 	teamDeleteCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
 	teamDeleteCmd.Flags().BoolVar(&confirmTeamDelete, "confirm", false, "Confirm team deletion")
-	markFlagRequired(teamDeleteCmd.MarkFlagRequired("name"))
+	_ = teamDeleteCmd.MarkFlagRequired("name")
 }
 
 func initTeamMemberCmdFlags() {
 	// Members command flags
 	teamCmdMembersCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
-	markFlagRequired(teamCmdMembersCmd.MarkFlagRequired("name"))
+	_ = teamCmdMembersCmd.MarkFlagRequired("name")
 
 	// Add member command flags
 	teamAddMemberCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
 	teamAddMemberCmd.Flags().StringVarP(&teamCmdMemberName, "member", "m", "", "Member name (username or robot)")
-	markFlagRequired(teamAddMemberCmd.MarkFlagRequired("name"))
-	markFlagRequired(teamAddMemberCmd.MarkFlagRequired("member"))
+	_ = teamAddMemberCmd.MarkFlagRequired("name")
+	_ = teamAddMemberCmd.MarkFlagRequired("member")
 
 	// Remove member command flags
 	teamRemoveMemberCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
 	teamRemoveMemberCmd.Flags().StringVarP(&teamCmdMemberName, "member", "m", "", "Member name (username or robot)")
 	teamRemoveMemberCmd.Flags().BoolVar(&confirmTeamMemberDel, "confirm", false, "Confirm member removal")
-	markFlagRequired(teamRemoveMemberCmd.MarkFlagRequired("name"))
-	markFlagRequired(teamRemoveMemberCmd.MarkFlagRequired("member"))
+	_ = teamRemoveMemberCmd.MarkFlagRequired("name")
+	_ = teamRemoveMemberCmd.MarkFlagRequired("member")
 }
 
 func initTeamPermissionCmdFlags() {
 	// Permissions command flags
 	teamPermissionsCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
-	markFlagRequired(teamPermissionsCmd.MarkFlagRequired("name"))
+	_ = teamPermissionsCmd.MarkFlagRequired("name")
 
 	// Set permission command flags
 	teamSetPermissionCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
 	teamSetPermissionCmd.Flags().StringVarP(&teamCmdRepository, "repository", "R", "", "Repository name")
 	teamSetPermissionCmd.Flags().StringVarP(&teamCmdPermissionRole, "role", "r", "", "Permission role (read, write, admin)")
-	markFlagRequired(teamSetPermissionCmd.MarkFlagRequired("name"))
-	markFlagRequired(teamSetPermissionCmd.MarkFlagRequired("repository"))
-	markFlagRequired(teamSetPermissionCmd.MarkFlagRequired("role"))
+	_ = teamSetPermissionCmd.MarkFlagRequired("name")
+	_ = teamSetPermissionCmd.MarkFlagRequired("repository")
+	_ = teamSetPermissionCmd.MarkFlagRequired("role")
 
 	// Remove permission command flags
 	teamRemovePermissionCmd.Flags().StringVarP(&teamCmdName, "name", "n", "", "Team name")
 	teamRemovePermissionCmd.Flags().StringVarP(&teamCmdRepository, "repository", "R", "", "Repository name")
 	teamRemovePermissionCmd.Flags().BoolVar(&confirmTeamPermDel, "confirm", false, "Confirm permission removal")
-	markFlagRequired(teamRemovePermissionCmd.MarkFlagRequired("name"))
-	markFlagRequired(teamRemovePermissionCmd.MarkFlagRequired("repository"))
+	_ = teamRemovePermissionCmd.MarkFlagRequired("name")
+	_ = teamRemovePermissionCmd.MarkFlagRequired("repository")
 }

--- a/cmd/trigger.go
+++ b/cmd/trigger.go
@@ -14,7 +14,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -35,7 +34,7 @@ var triggerCmd = &cobra.Command{
 	Short: "Manage repository build triggers",
 	Long: `Manage build triggers for repositories.
 
-Build triggers allow automated image builds when code is pushed to 
+Build triggers allow automated image builds when code is pushed to
 connected source repositories like GitHub, GitLab, or Bitbucket.`,
 }
 
@@ -44,16 +43,18 @@ var triggerListCmd = &cobra.Command{
 	Use:   subcmdList,
 	Short: "List all build triggers for a repository",
 	Long:  `List all build triggers configured for a repository.`,
-	Run: func(_ *cobra.Command, _ []string) {
-		client := mustGetClient()
+	RunE: func(_ *cobra.Command, _ []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		triggers, err := client.GetTriggers(triggerNamespace, triggerRepository)
 		if err != nil {
-			fmt.Println("Error getting triggers:", err)
-			os.Exit(1)
+			return fmt.Errorf("getting triggers: %w", err)
 		}
 
-		printJSON(triggers)
+		return printJSON(triggers)
 	},
 }
 
@@ -62,21 +63,22 @@ var triggerInfoCmd = &cobra.Command{
 	Use:   subcmdInfo,
 	Short: "Get details of a specific build trigger",
 	Long:  `Get detailed information about a specific build trigger by its UUID.`,
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		if triggerUUID == "" {
-			fmt.Println("Error: --uuid is required")
-			os.Exit(1)
+			return fmt.Errorf("--uuid is required")
 		}
 
-		client := mustGetClient()
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		trigger, err := client.GetTrigger(triggerNamespace, triggerRepository, triggerUUID)
 		if err != nil {
-			fmt.Println("Error getting trigger:", err)
-			os.Exit(1)
+			return fmt.Errorf("getting trigger: %w", err)
 		}
 
-		printJSON(trigger)
+		return printJSON(trigger)
 	},
 }
 
@@ -85,21 +87,23 @@ var triggerDeleteCmd = &cobra.Command{
 	Use:   subcmdDelete,
 	Short: "Delete a build trigger",
 	Long:  `Delete a build trigger from a repository.`,
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		if triggerUUID == "" {
-			fmt.Println("Error: --uuid is required")
-			os.Exit(1)
+			return fmt.Errorf("--uuid is required")
 		}
 
-		client := mustGetClient()
-
-		err := client.DeleteTrigger(triggerNamespace, triggerRepository, triggerUUID)
+		client, err := getClient()
 		if err != nil {
-			fmt.Println("Error deleting trigger:", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.DeleteTrigger(triggerNamespace, triggerRepository, triggerUUID)
+		if err != nil {
+			return fmt.Errorf("deleting trigger: %w", err)
 		}
 
 		fmt.Printf("Trigger %s deleted successfully\n", triggerUUID)
+		return nil
 	},
 }
 
@@ -108,21 +112,22 @@ var triggerEnableCmd = &cobra.Command{
 	Use:   "enable",
 	Short: "Enable a build trigger",
 	Long:  `Enable a build trigger for a repository.`,
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		if triggerUUID == "" {
-			fmt.Println("Error: --uuid is required")
-			os.Exit(1)
+			return fmt.Errorf("--uuid is required")
 		}
 
-		client := mustGetClient()
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		trigger, err := client.UpdateTrigger(triggerNamespace, triggerRepository, triggerUUID, true)
 		if err != nil {
-			fmt.Println("Error enabling trigger:", err)
-			os.Exit(1)
+			return fmt.Errorf("enabling trigger: %w", err)
 		}
 
-		printJSON(trigger)
+		return printJSON(trigger)
 	},
 }
 
@@ -131,21 +136,22 @@ var triggerDisableCmd = &cobra.Command{
 	Use:   "disable",
 	Short: "Disable a build trigger",
 	Long:  `Disable a build trigger for a repository.`,
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		if triggerUUID == "" {
-			fmt.Println("Error: --uuid is required")
-			os.Exit(1)
+			return fmt.Errorf("--uuid is required")
 		}
 
-		client := mustGetClient()
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		trigger, err := client.UpdateTrigger(triggerNamespace, triggerRepository, triggerUUID, false)
 		if err != nil {
-			fmt.Println("Error disabling trigger:", err)
-			os.Exit(1)
+			return fmt.Errorf("disabling trigger: %w", err)
 		}
 
-		printJSON(trigger)
+		return printJSON(trigger)
 	},
 }
 
@@ -154,13 +160,15 @@ var triggerStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Manually start a build from a trigger",
 	Long:  `Manually start a build using a configured trigger.`,
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		if triggerUUID == "" {
-			fmt.Println("Error: --uuid is required")
-			os.Exit(1)
+			return fmt.Errorf("--uuid is required")
 		}
 
-		client := mustGetClient()
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		var triggerReq *lib.ManualTriggerRequest
 		if triggerCommitSHA != "" {
@@ -171,11 +179,10 @@ var triggerStartCmd = &cobra.Command{
 
 		build, err := client.StartTriggerBuild(triggerNamespace, triggerRepository, triggerUUID, triggerReq)
 		if err != nil {
-			fmt.Println("Error starting trigger build:", err)
-			os.Exit(1)
+			return fmt.Errorf("starting trigger build: %w", err)
 		}
 
-		printJSON(build)
+		return printJSON(build)
 	},
 }
 
@@ -184,13 +191,15 @@ var triggerActivateCmd = &cobra.Command{
 	Use:   "activate",
 	Short: "Activate a build trigger with configuration",
 	Long:  `Activate a build trigger with the specified configuration.`,
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		if triggerUUID == "" {
-			fmt.Println("Error: --uuid is required")
-			os.Exit(1)
+			return fmt.Errorf("--uuid is required")
 		}
 
-		client := mustGetClient()
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		activateReq := &lib.ActivateTriggerRequest{}
 		if triggerPullRobot != "" {
@@ -199,11 +208,10 @@ var triggerActivateCmd = &cobra.Command{
 
 		trigger, err := client.ActivateTrigger(triggerNamespace, triggerRepository, triggerUUID, activateReq)
 		if err != nil {
-			fmt.Println("Error activating trigger:", err)
-			os.Exit(1)
+			return fmt.Errorf("activating trigger: %w", err)
 		}
 
-		printJSON(trigger)
+		return printJSON(trigger)
 	},
 }
 
@@ -211,21 +219,22 @@ var triggerBuildsCmd = &cobra.Command{
 	Use:   "builds",
 	Short: "List builds for a trigger",
 	Long:  `List builds that were started by a specific trigger.`,
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		if triggerUUID == "" {
-			fmt.Println("Error: --uuid is required")
-			os.Exit(1)
+			return fmt.Errorf("--uuid is required")
 		}
 
-		client := mustGetClient()
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		builds, err := client.GetTriggerBuilds(triggerNamespace, triggerRepository, triggerUUID, triggerBuildLimit)
 		if err != nil {
-			fmt.Println("Error getting trigger builds:", err)
-			os.Exit(1)
+			return fmt.Errorf("getting trigger builds: %w", err)
 		}
 
-		printJSON(builds)
+		return printJSON(builds)
 	},
 }
 

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -27,17 +26,19 @@ var userInfoCmd = &cobra.Command{
 	Use:   subcmdInfo,
 	Short: "Get current user information",
 	Long:  `Get detailed information about the currently authenticated user account.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		user, err := client.GetUser()
 		if err != nil {
-			fmt.Printf("Error getting user information: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting user information: %w", err)
 		}
 
 		fmt.Printf("User information for %s:\n", user.Username)
-		printJSON(user)
+		return printJSON(user)
 	},
 }
 
@@ -46,17 +47,19 @@ var userStarredCmd = &cobra.Command{
 	Use:   "starred",
 	Short: "List starred repositories",
 	Long:  `List all repositories starred by the current user.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		starred, err := client.GetStarredRepositories()
 		if err != nil {
-			fmt.Printf("Error getting starred repositories: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting starred repositories: %w", err)
 		}
 
 		fmt.Println("Starred repositories:")
-		printJSON(starred)
+		return printJSON(starred)
 	},
 }
 
@@ -65,16 +68,19 @@ var starRepoCmd = &cobra.Command{
 	Use:   "star",
 	Short: "Star a repository",
 	Long:  `Add a repository to your starred list for easy discovery.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-
-		err := client.StarRepository(namespace, repository)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error starring repository: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.StarRepository(namespace, repository)
+		if err != nil {
+			return fmt.Errorf("starring repository: %w", err)
 		}
 
 		fmt.Printf("Successfully starred repository %s/%s\n", namespace, repository)
+		return nil
 	},
 }
 
@@ -83,16 +89,19 @@ var unstarRepoCmd = &cobra.Command{
 	Use:   "unstar",
 	Short: "Unstar a repository",
 	Long:  `Remove a repository from your starred list.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
-
-		err := client.UnstarRepository(namespace, repository)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
 		if err != nil {
-			fmt.Printf("Error unstarring repository: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.UnstarRepository(namespace, repository)
+		if err != nil {
+			return fmt.Errorf("unstarring repository: %w", err)
 		}
 
 		fmt.Printf("Successfully unstarred repository %s/%s\n", namespace, repository)
+		return nil
 	},
 }
 
@@ -102,16 +111,18 @@ var userLookupCmd = &cobra.Command{
 	Use:   "lookup",
 	Short: "Look up a user by username",
 	Long:  `Get information about a specific user by their username.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		user, err := client.GetUserByUsername(lookupUsername)
 		if err != nil {
-			fmt.Printf("Error looking up user: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("looking up user: %w", err)
 		}
 
-		printJSON(user)
+		return printJSON(user)
 	},
 }
 
@@ -119,16 +130,18 @@ var userMarketplaceCmd = &cobra.Command{
 	Use:   "marketplace",
 	Short: "Get user marketplace information",
 	Long:  `Get marketplace subscription information for the current user.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := mustGetClient()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
 
 		marketplace, err := client.GetUserMarketplace()
 		if err != nil {
-			fmt.Printf("Error getting user marketplace info: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("getting user marketplace info: %w", err)
 		}
 
-		printJSON(marketplace)
+		return printJSON(marketplace)
 	},
 }
 
@@ -143,32 +156,16 @@ func init() {
 	// Star command specific flags (requires repository context)
 	starRepoCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
 	starRepoCmd.Flags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
-	if err := starRepoCmd.MarkFlagRequired("namespace"); err != nil {
-		fmt.Printf("Error marking namespace flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := starRepoCmd.MarkFlagRequired("repository"); err != nil {
-		fmt.Printf("Error marking repository flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = starRepoCmd.MarkFlagRequired("namespace")
+	_ = starRepoCmd.MarkFlagRequired("repository")
 
 	// Unstar command specific flags (requires repository context)
 	unstarRepoCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
 	unstarRepoCmd.Flags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
-	if err := unstarRepoCmd.MarkFlagRequired("namespace"); err != nil {
-		fmt.Printf("Error marking namespace flag as required: %v\n", err)
-		os.Exit(1)
-	}
-	if err := unstarRepoCmd.MarkFlagRequired("repository"); err != nil {
-		fmt.Printf("Error marking repository flag as required: %v\n", err)
-		os.Exit(1)
-	}
+	_ = unstarRepoCmd.MarkFlagRequired("namespace")
+	_ = unstarRepoCmd.MarkFlagRequired("repository")
 
 	// Lookup command flags
 	userLookupCmd.Flags().StringVarP(&lookupUsername, "username", "u", "", "Username to look up")
-	if err := userLookupCmd.MarkFlagRequired("username"); err != nil {
-		fmt.Printf("Error marking username flag as required: %v\n", err)
-		os.Exit(1)
-	}
-
+	_ = userLookupCmd.MarkFlagRequired("username")
 }


### PR DESCRIPTION
## Summary
- Convert all `Run:` command handlers to `RunE:` returning errors instead of calling `os.Exit(1)`
- Convert `mustGetClient()` to `getClient()` returning `(*Client, error)`
- Convert `printJSON()` to return `error`
- Replace all `fmt.Print + os.Exit(1)` patterns with `return fmt.Errorf`
- Simplify `init()` flag registration to `_ = cmd.MarkFlagRequired()`
- 21 files modified, zero `os.Exit` calls remaining in command code

This enables proper testability of error conditions and lets Cobra handle error display and exit codes.

Closes #144