### PR TITLE
ci: add govulncheck to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -58,6 +58,25 @@ jobs:
         name: api-coverage-report
         path: api-coverage-report.md
 
+  govulncheck:
+    name: Govulncheck
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+
+    - name: Set up Go
+      uses: actions/setup-go@v7
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Install govulncheck
+      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+    - name: Run govulncheck
+      run: govulncheck ./...
+
   benchmark-tests:
     name: Performance Benchmarks
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a dedicated govulncheck job to the nightly CI workflow
- Installs and runs govulncheck ./... to detect known vulnerabilities in dependencies
- Complements the existing gosec security scan with Go official vulnerability database

Closes #125