### PR TITLE
feat: add User-Agent header to all HTTP requests

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -9,7 +9,12 @@ import (
 
 // getClient creates a Quay client with the configured token and URL.
 func getClient() (*lib.Client, error) {
-	return lib.NewClientWithURL(token, quayURL)
+	client, err := lib.NewClientWithURL(token, quayURL)
+	if err != nil {
+		return nil, err
+	}
+	client.Version = rootCmd.Version
+	return client, nil
 }
 
 // printJSON marshals and prints data as formatted JSON

--- a/lib/client.go
+++ b/lib/client.go
@@ -44,6 +44,7 @@ const DefaultQuayURL = "https://quay.io/api/v1"
 type Client struct {
 	BearerToken string
 	BaseURL     string
+	Version     string
 	HTTPClient  *http.Client
 }
 
@@ -58,6 +59,7 @@ func NewClientWithURL(bearerToken, baseURL string) (*Client, error) {
 	return &Client{
 		BearerToken: bearerToken,
 		BaseURL:     baseURL,
+		Version:     "dev",
 		HTTPClient: &http.Client{
 			Timeout:   30 * time.Second,
 			Transport: transport,
@@ -86,6 +88,7 @@ func (c *Client) do(req *http.Request, v any, acceptedStatuses ...int) error {
 		req.Header.Set("Authorization", "Bearer "+c.BearerToken)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "go-quay/"+c.Version)
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -27,6 +27,10 @@ func TestNewClient(t *testing.T) {
 		t.Errorf("Expected base URL %s, got %s", DefaultQuayURL, client.BaseURL)
 	}
 
+	if client.Version != "dev" {
+		t.Errorf("Expected default version 'dev', got %s", client.Version)
+	}
+
 	if client.HTTPClient == nil {
 		t.Error("Expected HTTP client to be set, got nil")
 	}
@@ -84,6 +88,37 @@ func TestNewClientWithURLEmptyToken(t *testing.T) {
 
 	if client.BaseURL != "https://quay.example.com/api/v1" {
 		t.Errorf("Expected custom base URL, got %s", client.BaseURL)
+	}
+}
+
+func TestUserAgentHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ua := r.Header.Get("User-Agent")
+		if ua != "go-quay/1.2.3" {
+			t.Errorf("Expected User-Agent 'go-quay/1.2.3', got '%s'", ua)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL(testTokenValue, server.URL)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	client.Version = "1.2.3"
+
+	req, err := newRequest(httpMethodGet, server.URL+"/test", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	var result map[string]any
+	err = client.get(req, &result)
+	if err != nil {
+		t.Fatalf("get returned error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds a `Version` field to `lib.Client` (defaults to `dev`)
- Sets `User-Agent: go-quay/<version>` on every outgoing HTTP request
- Threads the build-time version from `main.go` through `cmd` to the client
- Adds tests for the default version and User-Agent header

Closes #127