### PR TITLE
refactor: replace manual flag checks with MarkFlagRequired

### DIFF
--- a/cmd/errortype.go
+++ b/cmd/errortype.go
@@ -24,10 +24,6 @@ var errorTypeCmd = &cobra.Command{
 
 This endpoint provides details about error types that can be returned by the Quay.io API.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if errorTypeName == "" {
-			return fmt.Errorf("--type is required")
-		}
-
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -44,4 +40,5 @@ This endpoint provides details about error types that can be returned by the Qua
 
 func init() {
 	errorTypeCmd.Flags().StringVar(&errorTypeName, "type", "", "Error type to look up (e.g., 'invalid_token')")
+	_ = errorTypeCmd.MarkFlagRequired("type")
 }

--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -63,10 +63,6 @@ var prototypeInfoCmd = &cobra.Command{
 	Short: "Get a specific prototype",
 	Long:  `Get detailed information about a specific permission prototype.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if prototypeUUID == "" {
-			return fmt.Errorf("--uuid is required")
-		}
-
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -97,16 +93,6 @@ Roles:
   - write: Pull and push images
   - admin: Full administrative access`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if prototypeDelegateName == "" {
-			return fmt.Errorf("--delegate-name is required")
-		}
-		if prototypeDelegateKind == "" {
-			return fmt.Errorf("--delegate-kind is required")
-		}
-		if prototypeRole == "" {
-			return fmt.Errorf("--role is required")
-		}
-
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -135,13 +121,6 @@ var prototypeUpdateCmd = &cobra.Command{
 	Short: "Update a prototype",
 	Long:  `Update an existing permission prototype's role.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if prototypeUUID == "" {
-			return fmt.Errorf("--uuid is required")
-		}
-		if prototypeRole == "" {
-			return fmt.Errorf("--role is required")
-		}
-
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -166,9 +145,6 @@ var prototypeDeleteCmd = &cobra.Command{
 	Short: "Delete a prototype",
 	Long:  `Delete a permission prototype from an organization.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if prototypeUUID == "" {
-			return fmt.Errorf("--uuid is required")
-		}
 		if !confirmProtoDelete {
 			return fmt.Errorf("--confirm is required to delete a prototype")
 		}
@@ -197,15 +173,20 @@ func setupPrototypeFlags() {
 	// UUID flags
 	for _, cmd := range []*cobra.Command{prototypeInfoCmd, prototypeUpdateCmd, prototypeDeleteCmd} {
 		cmd.Flags().StringVar(&prototypeUUID, "uuid", "", "Prototype UUID")
+		_ = cmd.MarkFlagRequired("uuid")
 	}
 
 	// Create flags
 	prototypeCreateCmd.Flags().StringVar(&prototypeDelegateName, "delegate-name", "", "Name of the delegate (user/team/robot)")
+	_ = prototypeCreateCmd.MarkFlagRequired("delegate-name")
 	prototypeCreateCmd.Flags().StringVar(&prototypeDelegateKind, "delegate-kind", "", "Kind of delegate (user, team, robot)")
+	_ = prototypeCreateCmd.MarkFlagRequired("delegate-kind")
 	prototypeCreateCmd.Flags().StringVar(&prototypeRole, "role", "", "Permission role (read, write, admin)")
+	_ = prototypeCreateCmd.MarkFlagRequired("role")
 
 	// Update flags
 	prototypeUpdateCmd.Flags().StringVar(&prototypeRole, "role", "", "New permission role (read, write, admin)")
+	_ = prototypeUpdateCmd.MarkFlagRequired("role")
 
 	// Delete flags
 	prototypeDeleteCmd.Flags().BoolVar(&confirmProtoDelete, "confirm", false, "Confirm deletion")

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -41,10 +41,6 @@ var repoInfoCmd = &cobra.Command{
 	Use:   subcmdInfo,
 	Short: "Get repository information from Quay.io",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if repository == "" {
-			return fmt.Errorf("--repository is required")
-		}
-
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -65,10 +61,6 @@ var repoCreateCmd = &cobra.Command{
 	Short: "Create a new repository",
 	Long:  `Create a new repository in the specified namespace with optional description and visibility settings.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if repository == "" {
-			return fmt.Errorf("--repository is required")
-		}
-
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -90,10 +82,6 @@ var repoUpdateCmd = &cobra.Command{
 	Short: "Update repository settings",
 	Long:  `Update repository description and/or visibility settings.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if repository == "" {
-			return fmt.Errorf("--repository is required")
-		}
-
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -115,10 +103,6 @@ var repoDeleteCmd = &cobra.Command{
 	Short: "Delete a repository",
 	Long:  `Delete a repository. This action is irreversible and will remove all images and tags.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if repository == "" {
-			return fmt.Errorf("--repository is required")
-		}
-
 		if !confirmDeletion {
 			return fmt.Errorf("are you sure you want to delete repository %s/%s? This action cannot be undone.\nUse --confirm to proceed with deletion", namespace, repository)
 		}
@@ -228,10 +212,6 @@ var repoChangeVisibilityCmd = &cobra.Command{
 	Short: "Change repository visibility",
 	Long:  `Change a repository's visibility between public and private.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if repository == "" {
-			return fmt.Errorf("--repository is required")
-		}
-
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -262,6 +242,9 @@ func init() {
 
 	// Mark global flags as required
 	_ = repositoryCmd.MarkPersistentFlagRequired("namespace")
+	for _, cmd := range []*cobra.Command{repoInfoCmd, repoCreateCmd, repoUpdateCmd, repoDeleteCmd, repoChangeVisibilityCmd} {
+		_ = cmd.MarkFlagRequired("repository")
+	}
 
 	// Create command specific flags
 	repoCreateCmd.Flags().StringVarP(&repoVisibility, "visibility", "v", "private", "Repository visibility (private/public)")

--- a/cmd/repotoken.go
+++ b/cmd/repotoken.go
@@ -64,10 +64,6 @@ var repotokenInfoCmd = &cobra.Command{
 	Short: "Get a specific token",
 	Long:  `Get detailed information about a specific repository token. (DEPRECATED - use robot accounts)`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if repoTokenCode == "" {
-			return fmt.Errorf("--code is required")
-		}
-
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -88,10 +84,6 @@ var repotokenCreateCmd = &cobra.Command{
 	Short: "Create a new token",
 	Long:  `Create a new repository token. (DEPRECATED - use robot accounts)`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if repoTokenName == "" {
-			return fmt.Errorf("--name is required")
-		}
-
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -116,13 +108,6 @@ var repotokenUpdateCmd = &cobra.Command{
 	Short: "Update a token",
 	Long:  `Update a repository token's role. (DEPRECATED - use robot accounts)`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if repoTokenCode == "" {
-			return fmt.Errorf("--code is required")
-		}
-		if repoTokenRole == "" {
-			return fmt.Errorf("--role is required")
-		}
-
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -147,9 +132,6 @@ var repotokenDeleteCmd = &cobra.Command{
 	Short: "Delete a token",
 	Long:  `Delete a repository token. (DEPRECATED - use robot accounts)`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if repoTokenCode == "" {
-			return fmt.Errorf("--code is required")
-		}
 		if !confirmTokenDelete {
 			return fmt.Errorf("--confirm is required to delete a token")
 		}
@@ -179,13 +161,16 @@ func setupRepoTokenFlags() {
 	// Code flags
 	for _, cmd := range []*cobra.Command{repotokenInfoCmd, repotokenUpdateCmd, repotokenDeleteCmd} {
 		cmd.Flags().StringVar(&repoTokenCode, "code", "", "Token code")
+		_ = cmd.MarkFlagRequired("code")
 	}
 
 	// Create flags
 	repotokenCreateCmd.Flags().StringVar(&repoTokenName, "name", "", "Friendly name for the token")
+	_ = repotokenCreateCmd.MarkFlagRequired("name")
 
 	// Update flags
 	repotokenUpdateCmd.Flags().StringVar(&repoTokenRole, "role", "", "New role (read, write, admin)")
+	_ = repotokenUpdateCmd.MarkFlagRequired("role")
 
 	// Delete flags
 	repotokenDeleteCmd.Flags().BoolVar(&confirmTokenDelete, "confirm", false, "Confirm deletion")

--- a/cmd/trigger.go
+++ b/cmd/trigger.go
@@ -64,10 +64,6 @@ var triggerInfoCmd = &cobra.Command{
 	Short: "Get details of a specific build trigger",
 	Long:  `Get detailed information about a specific build trigger by its UUID.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if triggerUUID == "" {
-			return fmt.Errorf("--uuid is required")
-		}
-
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -88,10 +84,6 @@ var triggerDeleteCmd = &cobra.Command{
 	Short: "Delete a build trigger",
 	Long:  `Delete a build trigger from a repository.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if triggerUUID == "" {
-			return fmt.Errorf("--uuid is required")
-		}
-
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -113,10 +105,6 @@ var triggerEnableCmd = &cobra.Command{
 	Short: "Enable a build trigger",
 	Long:  `Enable a build trigger for a repository.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if triggerUUID == "" {
-			return fmt.Errorf("--uuid is required")
-		}
-
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -137,10 +125,6 @@ var triggerDisableCmd = &cobra.Command{
 	Short: "Disable a build trigger",
 	Long:  `Disable a build trigger for a repository.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if triggerUUID == "" {
-			return fmt.Errorf("--uuid is required")
-		}
-
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -161,10 +145,6 @@ var triggerStartCmd = &cobra.Command{
 	Short: "Manually start a build from a trigger",
 	Long:  `Manually start a build using a configured trigger.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if triggerUUID == "" {
-			return fmt.Errorf("--uuid is required")
-		}
-
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -192,10 +172,6 @@ var triggerActivateCmd = &cobra.Command{
 	Short: "Activate a build trigger with configuration",
 	Long:  `Activate a build trigger with the specified configuration.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if triggerUUID == "" {
-			return fmt.Errorf("--uuid is required")
-		}
-
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -220,10 +196,6 @@ var triggerBuildsCmd = &cobra.Command{
 	Short: "List builds for a trigger",
 	Long:  `List builds that were started by a specific trigger.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if triggerUUID == "" {
-			return fmt.Errorf("--uuid is required")
-		}
-
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -248,6 +220,7 @@ func setupTriggerFlags() {
 	// UUID flags for subcommands that need it
 	for _, cmd := range []*cobra.Command{triggerInfoCmd, triggerDeleteCmd, triggerEnableCmd, triggerDisableCmd, triggerStartCmd, triggerActivateCmd, triggerBuildsCmd} {
 		cmd.Flags().StringVar(&triggerUUID, "uuid", "", "UUID of the build trigger")
+		_ = cmd.MarkFlagRequired("uuid")
 	}
 
 	// Start command specific flags


### PR DESCRIPTION
## Summary
- Replaces 25 manual `if flag == "" { return error }` checks with Cobra's `MarkFlagRequired()` across 5 cmd/ files
- Required flags now show `(required)` in help text and are validated by Cobra before `RunE` executes
- Keeps manual `--confirm` checks on delete commands (validates truthiness, not just presence)
- Files changed: `errortype.go`, `repotoken.go`, `prototype.go`, `repository.go`, `trigger.go`

Closes #123