### PR TITLE
feat: add tag change CLI command for creating/moving tags

### DIFF
--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -136,6 +136,27 @@ var tagRevertCmd = &cobra.Command{
 	},
 }
 
+// Tag Change (create/move)
+var tagChangeCmd = &cobra.Command{
+	Use:   "change",
+	Short: "Create or move a tag to a manifest",
+	Long:  `Create a new tag or move an existing tag to point at a specific manifest digest.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		err = client.ChangeTag(namespace, repository, tagName, manifestDigest)
+		if err != nil {
+			return fmt.Errorf("changing tag: %w", err)
+		}
+
+		fmt.Printf("Successfully changed tag %s/%s:%s to manifest %s\n", namespace, repository, tagName, manifestDigest)
+		return nil
+	},
+}
+
 var tagRestoreCmd = &cobra.Command{
 	Use:   "restore",
 	Short: "Restore a tag from a previous state",
@@ -164,6 +185,7 @@ func init() {
 	tagCmd.AddCommand(tagHistoryCmd)
 	tagCmd.AddCommand(tagRevertCmd)
 	tagCmd.AddCommand(tagRestoreCmd)
+	tagCmd.AddCommand(tagChangeCmd)
 
 	// Global tag flags (repository context)
 	tagCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
@@ -188,4 +210,8 @@ func init() {
 	// Restore command specific flags
 	tagRestoreCmd.Flags().StringVarP(&manifestDigest, "manifest", "m", "", "Manifest digest to restore")
 	_ = tagRestoreCmd.MarkFlagRequired("manifest")
+
+	// Change command specific flags
+	tagChangeCmd.Flags().StringVarP(&manifestDigest, "manifest", "m", "", "Manifest digest to assign to the tag")
+	_ = tagChangeCmd.MarkFlagRequired("manifest")
 }

--- a/lib/tag.go
+++ b/lib/tag.go
@@ -6,6 +6,7 @@ This file covers ENHANCED TAG operations:
 Tag Management:
   - GET    /api/v1/repository/{namespace}/{repository}/tag/{tag}                 - GetTag()
   - PUT    /api/v1/repository/{namespace}/{repository}/tag/{tag}                 - UpdateTag()
+  - PUT    /api/v1/repository/{namespace}/{repository}/tag/{tag}                 - ChangeTag()
   - DELETE /api/v1/repository/{namespace}/{repository}/tag/{tag}                 - DeleteTag()
   - GET    /api/v1/repository/{namespace}/{repository}/tag/{tag}/history         - GetTagHistory()
 
@@ -98,6 +99,25 @@ func (c *Client) RevertTag(namespace, repository, tag, manifestDigest string) (*
 	}
 
 	return &tagInfo, nil
+}
+
+// ChangeTag creates or moves a tag to point at a specific manifest digest
+func (c *Client) ChangeTag(namespace, repository, tag, manifestDigest string) error {
+	body := struct {
+		ManifestDigest string `json:"manifest_digest"`
+	}{
+		ManifestDigest: manifestDigest,
+	}
+	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), body)
+	if err != nil {
+		return fmt.Errorf("failed to create change tag request: %w", err)
+	}
+
+	if err := c.put(req, nil); err != nil {
+		return fmt.Errorf("failed to change tag: %w", err)
+	}
+
+	return nil
 }
 
 // RestoreTag restores a tag to a previous image

--- a/lib/tag_test.go
+++ b/lib/tag_test.go
@@ -245,6 +245,40 @@ func TestRevertTag(t *testing.T) {
 	}
 }
 
+func TestChangeTag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpMethodPut {
+			t.Errorf("Expected PUT request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/tag/" + testTagNameLatest
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		var req map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("Failed to decode request body: %v", err)
+		}
+
+		if req["manifest_digest"] != testManifestDigest {
+			t.Errorf("Expected manifest_digest '%s', got '%v'", testManifestDigest, req["manifest_digest"])
+		}
+
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL("test-token", server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.ChangeTag(testNamespace, testRepository, testTagNameLatest, testManifestDigest)
+	if err != nil {
+		t.Fatalf("ChangeTag returned error: %v", err)
+	}
+}
+
 func TestRestoreTag(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != httpMethodPost {
@@ -320,6 +354,12 @@ func TestTagErrorHandling(t *testing.T) {
 	_, err = client.RevertTag(testNamespace, testRepository, "nonexistent", testDigestSHA256)
 	if err == nil {
 		t.Error("Expected error for non-existent tag, got nil")
+	}
+
+	// Test ChangeTag error
+	err = client.ChangeTag(testNamespace, testRepository, "nonexistent", testDigestSHA256)
+	if err == nil {
+		t.Error("Expected error from ChangeTag, got nil")
 	}
 
 	// Test RestoreTag error


### PR DESCRIPTION
## Summary
- Adds `ChangeTag` lib method (PUT `/repository/{ns}/{repo}/tag/{tag}` with `manifest_digest` body)
- Adds `quay get tag change` CLI command with `--manifest/-m` required flag
- Distinct from existing `UpdateTag` which only handles expiration
- Includes unit tests for both success and error paths

Closes #176