### PR TITLE
feat: use QuayError struct for structured API error responses

### DIFF
--- a/lib/client.go
+++ b/lib/client.go
@@ -105,6 +105,13 @@ func (c *Client) do(req *http.Request, v any, acceptedStatuses ...int) error {
 	}
 	if !accepted {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
+
+		var quayErr QuayError
+		if json.Unmarshal(body, &quayErr) == nil && quayErr.Message != "" {
+			quayErr.Status = resp.StatusCode
+			return &quayErr
+		}
+
 		return fmt.Errorf("unexpected status code: %d, response: %s", resp.StatusCode, string(body))
 	}
 

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -174,6 +175,82 @@ func TestGetRequest(t *testing.T) {
 
 	if result.Value != 42 {
 		t.Errorf("Expected value 42, got %d", result.Value)
+	}
+}
+
+func TestQuayErrorParsing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"status":404,"error":"not_found","detail":"Repository not found","error_type":"not_found"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL(testTokenValue, server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	req, err := newRequest(httpMethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	var result map[string]string
+	err = client.get(req, &result)
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	var quayErr *QuayError
+	if !errors.As(err, &quayErr) {
+		t.Fatalf("Expected QuayError, got %T: %v", err, err)
+	}
+
+	if quayErr.StatusCode() != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", quayErr.StatusCode())
+	}
+
+	if quayErr.Message != "not_found" {
+		t.Errorf("Expected message 'not_found', got '%s'", quayErr.Message)
+	}
+
+	if quayErr.Detail != "Repository not found" {
+		t.Errorf("Expected detail 'Repository not found', got '%s'", quayErr.Detail)
+	}
+
+	expectedErrStr := "quay API error (status 404): not_found — Repository not found"
+	if quayErr.Error() != expectedErrStr {
+		t.Errorf("Expected error string '%s', got '%s'", expectedErrStr, quayErr.Error())
+	}
+}
+
+func TestQuayErrorFallbackToRawError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`not json at all`))
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL(testTokenValue, server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	req, err := newRequest(httpMethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	var result map[string]string
+	err = client.get(req, &result)
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	var quayErr *QuayError
+	if errors.As(err, &quayErr) {
+		t.Error("Expected raw error for non-JSON response, got QuayError")
 	}
 }
 

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -60,6 +60,8 @@ All structs include appropriate JSON tags for API serialization/deserialization.
 */
 package lib
 
+import "fmt"
+
 // ResolvedIP represents resolved IP details.
 type ResolvedIP struct {
 	Provider       string `json:"provider,omitempty"`
@@ -821,13 +823,24 @@ type TestNotificationResponse struct {
 
 // Error Response Structure
 
-// QuayError represents a Quay API error response
+// QuayError represents a Quay API error response and implements the error interface.
 type QuayError struct {
 	Status      int            `json:"status,omitempty"`
-	Error       string         `json:"error,omitempty"`
+	Message     string         `json:"error,omitempty"`
 	ErrorType   string         `json:"error_type,omitempty"`
 	Detail      string         `json:"detail,omitempty"`
 	ErrorDetail map[string]any `json:"error_detail,omitempty"`
+}
+
+func (e *QuayError) Error() string {
+	if e.Detail != "" {
+		return fmt.Sprintf("quay API error (status %d): %s — %s", e.Status, e.Message, e.Detail)
+	}
+	return fmt.Sprintf("quay API error (status %d): %s", e.Status, e.Message)
+}
+
+func (e *QuayError) StatusCode() int {
+	return e.Status
 }
 
 // Registry Capabilities Structures


### PR DESCRIPTION
## Summary
- Implements `Error()` and `StatusCode()` methods on the existing `QuayError` struct
- Parses Quay API JSON error responses into `*QuayError` in the HTTP client
- Enables `errors.As(err, &quayErr)` for type-safe error handling
- Falls back to raw error strings for non-JSON responses
- Renames `QuayError.Error` field to `Message` to avoid conflict with the `error` interface

Closes #129