### PR TITLE
refactor: write informational output to stderr instead of stdout

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -52,7 +53,7 @@ var buildListCmd = &cobra.Command{
 			return fmt.Errorf("getting builds: %w", err)
 		}
 
-		fmt.Printf("Builds for %s/%s:\n", buildNamespace, buildRepository)
+		fmt.Fprintf(os.Stderr, "Builds for %s/%s:\n", buildNamespace, buildRepository)
 		return printJSON(builds)
 	},
 }
@@ -73,7 +74,7 @@ var buildInfoCmd = &cobra.Command{
 			return fmt.Errorf("getting build: %w", err)
 		}
 
-		fmt.Printf("Build: %s\n", buildUUID)
+		fmt.Fprintf(os.Stderr, "Build: %s\n", buildUUID)
 		return printJSON(build)
 	},
 }
@@ -94,7 +95,7 @@ var buildLogsCmd = &cobra.Command{
 			return fmt.Errorf("getting build logs: %w", err)
 		}
 
-		fmt.Printf("Logs for build %s:\n", buildUUID)
+		fmt.Fprintf(os.Stderr, "Logs for build %s:\n", buildUUID)
 		return printJSON(logs)
 	},
 }
@@ -124,7 +125,7 @@ The archive should be a tar.gz file containing a Dockerfile and any necessary bu
 			return fmt.Errorf("requesting build: %w", err)
 		}
 
-		fmt.Printf("Build requested successfully!\n")
+		fmt.Fprintf(os.Stderr, "Build requested successfully!\n")
 		return printJSON(build)
 	},
 }
@@ -149,7 +150,7 @@ var buildCancelCmd = &cobra.Command{
 			return fmt.Errorf("canceling build: %w", err)
 		}
 
-		fmt.Printf("Build '%s' canceled successfully.\n", buildUUID)
+		fmt.Fprintf(os.Stderr, "Build '%s' canceled successfully.\n", buildUUID)
 		return nil
 	},
 }
@@ -169,7 +170,7 @@ var buildStatusCmd = &cobra.Command{
 			return fmt.Errorf("getting build status: %w", err)
 		}
 
-		fmt.Printf("Status for build %s:\n", buildUUID)
+		fmt.Fprintf(os.Stderr, "Status for build %s:\n", buildUUID)
 		return printJSON(status)
 	},
 }

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -160,7 +161,7 @@ var exportOrgLogsCmd = &cobra.Command{
 			return fmt.Errorf("exporting organization logs: %w", err)
 		}
 
-		fmt.Println("Organization logs export initiated successfully.")
+		fmt.Fprintln(os.Stderr, "Organization logs export initiated successfully.")
 		return nil
 	},
 }
@@ -185,7 +186,7 @@ var exportUserLogsCmd = &cobra.Command{
 			return fmt.Errorf("exporting user logs: %w", err)
 		}
 
-		fmt.Println("User logs export initiated successfully.")
+		fmt.Fprintln(os.Stderr, "User logs export initiated successfully.")
 		return nil
 	},
 }
@@ -210,7 +211,7 @@ var exportRepoLogsCmd = &cobra.Command{
 			return fmt.Errorf("exporting repository logs: %w", err)
 		}
 
-		fmt.Println("Repository logs export initiated successfully.")
+		fmt.Fprintln(os.Stderr, "Repository logs export initiated successfully.")
 		return nil
 	},
 }

--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -46,7 +47,7 @@ var manifestInfoCmd = &cobra.Command{
 			return fmt.Errorf("getting manifest information: %w", err)
 		}
 
-		fmt.Printf("Manifest information for %s/%s@%s\n", namespace, repository, manifestRef)
+		fmt.Fprintf(os.Stderr, "Manifest information for %s/%s@%s\n", namespace, repository, manifestRef)
 		return printJSON(manifest)
 	},
 }
@@ -71,7 +72,7 @@ var manifestDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting manifest: %w", err)
 		}
 
-		fmt.Printf("Successfully deleted manifest %s/%s@%s\n", namespace, repository, manifestRef)
+		fmt.Fprintf(os.Stderr, "Successfully deleted manifest %s/%s@%s\n", namespace, repository, manifestRef)
 		return nil
 	},
 }
@@ -92,7 +93,7 @@ var manifestLabelsCmd = &cobra.Command{
 			return fmt.Errorf("getting manifest labels: %w", err)
 		}
 
-		fmt.Printf("Labels for manifest %s/%s@%s\n", namespace, repository, manifestRef)
+		fmt.Fprintf(os.Stderr, "Labels for manifest %s/%s@%s\n", namespace, repository, manifestRef)
 		return printJSON(labels)
 	},
 }
@@ -113,7 +114,7 @@ var manifestLabelCmd = &cobra.Command{
 			return fmt.Errorf("getting manifest label: %w", err)
 		}
 
-		fmt.Printf("Label %s for manifest %s/%s@%s\n", labelID, namespace, repository, manifestRef)
+		fmt.Fprintf(os.Stderr, "Label %s for manifest %s/%s@%s\n", labelID, namespace, repository, manifestRef)
 		return printJSON(label)
 	},
 }
@@ -134,7 +135,7 @@ var manifestAddLabelCmd = &cobra.Command{
 			return fmt.Errorf("adding manifest label: %w", err)
 		}
 
-		fmt.Printf("Successfully added label to manifest %s/%s@%s\n", namespace, repository, manifestRef)
+		fmt.Fprintf(os.Stderr, "Successfully added label to manifest %s/%s@%s\n", namespace, repository, manifestRef)
 		return printJSON(label)
 	},
 }
@@ -155,7 +156,7 @@ var manifestRemoveLabelCmd = &cobra.Command{
 			return fmt.Errorf("removing manifest label: %w", err)
 		}
 
-		fmt.Printf("Successfully removed label %s from manifest %s/%s@%s\n", labelID, namespace, repository, manifestRef)
+		fmt.Fprintf(os.Stderr, "Successfully removed label %s from manifest %s/%s@%s\n", labelID, namespace, repository, manifestRef)
 		return nil
 	},
 }

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -51,7 +52,7 @@ var messagesCreateCmd = &cobra.Command{
 			return fmt.Errorf("creating message: %w", err)
 		}
 
-		fmt.Println("Message created successfully!")
+		fmt.Fprintln(os.Stderr, "Message created successfully!")
 		return printJSON(message)
 	},
 }

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -66,7 +67,7 @@ var notificationListCmd = &cobra.Command{
 			return fmt.Errorf("getting notifications: %w", err)
 		}
 
-		fmt.Printf("Notifications for %s/%s:\n", notificationNamespace, notificationRepository)
+		fmt.Fprintf(os.Stderr, "Notifications for %s/%s:\n", notificationNamespace, notificationRepository)
 		return printJSON(notifications)
 	},
 }
@@ -87,7 +88,7 @@ var notificationInfoCmd = &cobra.Command{
 			return fmt.Errorf("getting notification: %w", err)
 		}
 
-		fmt.Printf("Notification: %s\n", notificationUUID)
+		fmt.Fprintf(os.Stderr, "Notification: %s\n", notificationUUID)
 		return printJSON(notification)
 	},
 }
@@ -129,7 +130,7 @@ For slack method, provide the --url flag with the Slack webhook URL.`,
 			return fmt.Errorf("creating notification: %w", err)
 		}
 
-		fmt.Printf("Notification created successfully!\n")
+		fmt.Fprintf(os.Stderr, "Notification created successfully!\n")
 		return printJSON(notification)
 	},
 }
@@ -154,7 +155,7 @@ var notificationDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting notification: %w", err)
 		}
 
-		fmt.Printf("Notification '%s' deleted successfully.\n", notificationUUID)
+		fmt.Fprintf(os.Stderr, "Notification '%s' deleted successfully.\n", notificationUUID)
 		return nil
 	},
 }
@@ -175,7 +176,7 @@ var notificationTestCmd = &cobra.Command{
 			return fmt.Errorf("testing notification: %w", err)
 		}
 
-		fmt.Printf("Test event sent to notification '%s'.\n", notificationUUID)
+		fmt.Fprintf(os.Stderr, "Test event sent to notification '%s'.\n", notificationUUID)
 		return nil
 	},
 }
@@ -196,7 +197,7 @@ var notificationResetCmd = &cobra.Command{
 			return fmt.Errorf("resetting notification: %w", err)
 		}
 
-		fmt.Printf("Notification '%s' failure count reset.\n", notificationUUID)
+		fmt.Fprintf(os.Stderr, "Notification '%s' failure count reset.\n", notificationUUID)
 		return nil
 	},
 }
@@ -233,7 +234,7 @@ var notificationUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating notification: %w", err)
 		}
 
-		fmt.Printf("Notification '%s' updated successfully!\n", notificationUUID)
+		fmt.Fprintf(os.Stderr, "Notification '%s' updated successfully!\n", notificationUUID)
 		return printJSON(notification)
 	},
 }

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -266,7 +267,7 @@ var deleteOrgCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting organization: %w", err)
 		}
-		fmt.Println("Organization deleted successfully")
+		fmt.Fprintln(os.Stderr, "Organization deleted successfully")
 		return nil
 	},
 }
@@ -285,7 +286,7 @@ var addMemberCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("adding organization member: %w", err)
 		}
-		fmt.Println("Member added successfully")
+		fmt.Fprintln(os.Stderr, "Member added successfully")
 		return nil
 	},
 }
@@ -307,7 +308,7 @@ var removeMemberCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("removing organization member: %w", err)
 		}
-		fmt.Println("Member removed successfully")
+		fmt.Fprintln(os.Stderr, "Member removed successfully")
 		return nil
 	},
 }
@@ -419,7 +420,7 @@ var deleteProxyCacheCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting proxy cache config: %w", err)
 		}
-		fmt.Println("Proxy cache config deleted successfully")
+		fmt.Fprintln(os.Stderr, "Proxy cache config deleted successfully")
 		return nil
 	},
 }
@@ -477,7 +478,7 @@ var deleteRobotCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting robot account: %w", err)
 		}
-		fmt.Println("Robot account deleted successfully")
+		fmt.Fprintln(os.Stderr, "Robot account deleted successfully")
 		return nil
 	},
 }
@@ -532,7 +533,7 @@ var setRobotPermissionCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("setting robot permission: %w", err)
 		}
-		fmt.Println("Robot permission set successfully")
+		fmt.Fprintln(os.Stderr, "Robot permission set successfully")
 		return nil
 	},
 }
@@ -554,7 +555,7 @@ var removeRobotPermissionCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("removing robot permission: %w", err)
 		}
-		fmt.Println("Robot permission removed successfully")
+		fmt.Fprintln(os.Stderr, "Robot permission removed successfully")
 		return nil
 	},
 }
@@ -597,7 +598,7 @@ var orgRobotFederationCreateCmd = &cobra.Command{
 			return fmt.Errorf("creating robot federation: %w", err)
 		}
 
-		fmt.Printf("Successfully configured federation for robot %s in org %s\n", robotShortname, orgName)
+		fmt.Fprintf(os.Stderr, "Successfully configured federation for robot %s in org %s\n", robotShortname, orgName)
 		return nil
 	},
 }
@@ -617,7 +618,7 @@ var orgRobotFederationDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting robot federation: %w", err)
 		}
 
-		fmt.Printf("Successfully deleted federation for robot %s in org %s\n", robotShortname, orgName)
+		fmt.Fprintf(os.Stderr, "Successfully deleted federation for robot %s in org %s\n", robotShortname, orgName)
 		return nil
 	},
 }
@@ -693,7 +694,7 @@ var deleteApplicationCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting application: %w", err)
 		}
-		fmt.Println("Application deleted successfully")
+		fmt.Fprintln(os.Stderr, "Application deleted successfully")
 		return nil
 	},
 }
@@ -748,7 +749,7 @@ var createMarketplaceSubscriptionCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating marketplace subscription: %w", err)
 		}
-		fmt.Println("Marketplace subscription created successfully")
+		fmt.Fprintln(os.Stderr, "Marketplace subscription created successfully")
 		return nil
 	},
 }
@@ -770,7 +771,7 @@ var deleteMarketplaceSubscriptionCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting marketplace subscription: %w", err)
 		}
-		fmt.Println("Marketplace subscription deleted successfully")
+		fmt.Fprintln(os.Stderr, "Marketplace subscription deleted successfully")
 		return nil
 	},
 }
@@ -792,7 +793,7 @@ var batchRemoveSubscriptionsCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("batch removing subscriptions: %w", err)
 		}
-		fmt.Println("Marketplace subscriptions removed successfully")
+		fmt.Fprintln(os.Stderr, "Marketplace subscriptions removed successfully")
 		return nil
 	},
 }
@@ -850,7 +851,7 @@ var deleteQuotaCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting quota: %w", err)
 		}
-		fmt.Println("Quota deleted successfully")
+		fmt.Fprintln(os.Stderr, "Quota deleted successfully")
 		return nil
 	},
 }
@@ -926,7 +927,7 @@ var deleteAutoPruneCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting auto-prune policy: %w", err)
 		}
-		fmt.Println("Auto-prune policy deleted successfully")
+		fmt.Fprintln(os.Stderr, "Auto-prune policy deleted successfully")
 		return nil
 	},
 }
@@ -945,7 +946,7 @@ var inviteMemberCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("inviting team member: %w", err)
 		}
-		fmt.Println("Team member invited successfully")
+		fmt.Fprintln(os.Stderr, "Team member invited successfully")
 		return nil
 	},
 }
@@ -967,7 +968,7 @@ var cancelInviteCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("canceling team invite: %w", err)
 		}
-		fmt.Println("Team invite canceled successfully")
+		fmt.Fprintln(os.Stderr, "Team invite canceled successfully")
 		return nil
 	},
 }

--- a/cmd/permissions.go
+++ b/cmd/permissions.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -43,7 +44,7 @@ var permListCmd = &cobra.Command{
 			return fmt.Errorf("getting repository permissions: %w", err)
 		}
 
-		fmt.Printf("Permissions for repository %s/%s:\n", namespace, repository)
+		fmt.Fprintf(os.Stderr, "Permissions for repository %s/%s:\n", namespace, repository)
 		return printJSON(permissions)
 	},
 }
@@ -64,7 +65,7 @@ var permSetCmd = &cobra.Command{
 			return fmt.Errorf("setting repository permission: %w", err)
 		}
 
-		fmt.Printf("Successfully set %s permission for %s on repository %s/%s\n",
+		fmt.Fprintf(os.Stderr, "Successfully set %s permission for %s on repository %s/%s\n",
 			permissionRole, permissionUser, namespace, repository)
 		return nil
 	},
@@ -86,7 +87,7 @@ var permRemoveCmd = &cobra.Command{
 			return fmt.Errorf("removing repository permission: %w", err)
 		}
 
-		fmt.Printf("Successfully removed permissions for %s from repository %s/%s\n",
+		fmt.Fprintf(os.Stderr, "Successfully removed permissions for %s from repository %s/%s\n",
 			permissionUser, namespace, repository)
 		return nil
 	},
@@ -142,7 +143,7 @@ var permSetUserPermCmd = &cobra.Command{
 			return fmt.Errorf("setting user permission: %w", err)
 		}
 
-		fmt.Printf("Successfully set %s permission for user %s on %s/%s\n",
+		fmt.Fprintf(os.Stderr, "Successfully set %s permission for user %s on %s/%s\n",
 			permissionRole, permissionUser, namespace, repository)
 		return nil
 	},
@@ -167,7 +168,7 @@ var permDeleteUserPermCmd = &cobra.Command{
 			return fmt.Errorf("deleting user permission: %w", err)
 		}
 
-		fmt.Printf("Successfully removed permission for user %s from %s/%s\n",
+		fmt.Fprintf(os.Stderr, "Successfully removed permission for user %s from %s/%s\n",
 			permissionUser, namespace, repository)
 		return nil
 	},
@@ -241,7 +242,7 @@ var permSetTeamPermCmd = &cobra.Command{
 			return fmt.Errorf("setting team permission: %w", err)
 		}
 
-		fmt.Printf("Successfully set %s permission for team %s on %s/%s\n",
+		fmt.Fprintf(os.Stderr, "Successfully set %s permission for team %s on %s/%s\n",
 			permissionRole, permissionTeamName, namespace, repository)
 		return nil
 	},
@@ -266,7 +267,7 @@ var permDeleteTeamPermCmd = &cobra.Command{
 			return fmt.Errorf("deleting team permission: %w", err)
 		}
 
-		fmt.Printf("Successfully removed permission for team %s from %s/%s\n",
+		fmt.Fprintf(os.Stderr, "Successfully removed permission for team %s from %s/%s\n",
 			permissionTeamName, namespace, repository)
 		return nil
 	},

--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -12,6 +12,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -159,7 +160,7 @@ var prototypeDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting prototype: %w", err)
 		}
 
-		fmt.Printf("Prototype %s deleted successfully\n", prototypeUUID)
+		fmt.Fprintf(os.Stderr, "Prototype %s deleted successfully\n", prototypeUUID)
 		return nil
 	},
 }

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -71,7 +71,7 @@ var repoCreateCmd = &cobra.Command{
 			return fmt.Errorf("creating repository: %w", err)
 		}
 
-		fmt.Printf("Successfully created repository %s/%s\n", namespace, repository)
+		fmt.Fprintf(os.Stderr, "Successfully created repository %s/%s\n", namespace, repository)
 		return printJSON(repo)
 	},
 }
@@ -92,7 +92,7 @@ var repoUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating repository: %w", err)
 		}
 
-		fmt.Printf("Successfully updated repository %s/%s\n", namespace, repository)
+		fmt.Fprintf(os.Stderr, "Successfully updated repository %s/%s\n", namespace, repository)
 		return printJSON(repo)
 	},
 }
@@ -117,7 +117,7 @@ var repoDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting repository: %w", err)
 		}
 
-		fmt.Printf("Successfully deleted repository %s/%s\n", namespace, repository)
+		fmt.Fprintf(os.Stderr, "Successfully deleted repository %s/%s\n", namespace, repository)
 		return nil
 	},
 }
@@ -222,7 +222,7 @@ var repoChangeVisibilityCmd = &cobra.Command{
 			return fmt.Errorf("changing repository visibility: %w", err)
 		}
 
-		fmt.Printf("Successfully changed visibility of %s/%s to %s\n", namespace, repository, repoVisibility)
+		fmt.Fprintf(os.Stderr, "Successfully changed visibility of %s/%s to %s\n", namespace, repository, repoVisibility)
 		return nil
 	},
 }

--- a/cmd/repotoken.go
+++ b/cmd/repotoken.go
@@ -14,6 +14,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -146,7 +147,7 @@ var repotokenDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting token: %w", err)
 		}
 
-		fmt.Printf("Token %s deleted successfully\n", repoTokenCode)
+		fmt.Fprintf(os.Stderr, "Token %s deleted successfully\n", repoTokenCode)
 		return nil
 	},
 }

--- a/cmd/robot.go
+++ b/cmd/robot.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -49,7 +50,7 @@ var robotListCmd = &cobra.Command{
 			return fmt.Errorf("getting robot accounts: %w", err)
 		}
 
-		fmt.Println("User robot accounts:")
+		fmt.Fprintln(os.Stderr, "User robot accounts:")
 		return printJSON(robots)
 	},
 }
@@ -70,7 +71,7 @@ var robotInfoCmd = &cobra.Command{
 			return fmt.Errorf("getting robot account: %w", err)
 		}
 
-		fmt.Printf("Robot account: %s\n", robotShortname)
+		fmt.Fprintf(os.Stderr, "Robot account: %s\n", robotShortname)
 		return printJSON(robot)
 	},
 }
@@ -91,8 +92,8 @@ var robotCreateCmd = &cobra.Command{
 			return fmt.Errorf("creating robot account: %w", err)
 		}
 
-		fmt.Printf("Successfully created robot account: %s\n", robotShortname)
-		fmt.Println("IMPORTANT: Save the token below - it will not be shown again!")
+		fmt.Fprintf(os.Stderr, "Successfully created robot account: %s\n", robotShortname)
+		fmt.Fprintln(os.Stderr, "IMPORTANT: Save the token below - it will not be shown again!")
 		return printJSON(robot)
 	},
 }
@@ -117,7 +118,7 @@ var robotDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting robot account: %w", err)
 		}
 
-		fmt.Printf("Successfully deleted robot account: %s\n", robotShortname)
+		fmt.Fprintf(os.Stderr, "Successfully deleted robot account: %s\n", robotShortname)
 		return nil
 	},
 }
@@ -138,8 +139,8 @@ var robotRegenerateCmd = &cobra.Command{
 			return fmt.Errorf("regenerating robot token: %w", err)
 		}
 
-		fmt.Printf("Successfully regenerated token for robot: %s\n", robotShortname)
-		fmt.Println("IMPORTANT: Save the new token below - it will not be shown again!")
+		fmt.Fprintf(os.Stderr, "Successfully regenerated token for robot: %s\n", robotShortname)
+		fmt.Fprintln(os.Stderr, "IMPORTANT: Save the new token below - it will not be shown again!")
 		return printJSON(robot)
 	},
 }
@@ -160,7 +161,7 @@ var robotPermissionsCmd = &cobra.Command{
 			return fmt.Errorf("getting robot permissions: %w", err)
 		}
 
-		fmt.Printf("Permissions for robot: %s\n", robotShortname)
+		fmt.Fprintf(os.Stderr, "Permissions for robot: %s\n", robotShortname)
 		return printJSON(permissions)
 	},
 }
@@ -203,7 +204,7 @@ var robotFederationCreateCmd = &cobra.Command{
 			return fmt.Errorf("creating robot federation: %w", err)
 		}
 
-		fmt.Printf("Successfully configured federation for robot: %s\n", robotShortname)
+		fmt.Fprintf(os.Stderr, "Successfully configured federation for robot: %s\n", robotShortname)
 		return nil
 	},
 }
@@ -223,7 +224,7 @@ var robotFederationDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting robot federation: %w", err)
 		}
 
-		fmt.Printf("Successfully deleted federation for robot: %s\n", robotShortname)
+		fmt.Fprintf(os.Stderr, "Successfully deleted federation for robot: %s\n", robotShortname)
 		return nil
 	},
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -38,7 +39,7 @@ var searchReposCmd = &cobra.Command{
 			return fmt.Errorf("searching repositories: %w", err)
 		}
 
-		fmt.Printf("Repository search results for: %s\n", searchQuery)
+		fmt.Fprintf(os.Stderr, "Repository search results for: %s\n", searchQuery)
 		return printJSON(result)
 	},
 }
@@ -66,7 +67,7 @@ Results include a 'kind' field indicating the entity type:
 			return fmt.Errorf("searching: %w", err)
 		}
 
-		fmt.Printf("Search results for: %s\n", searchQuery)
+		fmt.Fprintf(os.Stderr, "Search results for: %s\n", searchQuery)
 		return printJSON(result)
 	},
 }

--- a/cmd/secscan.go
+++ b/cmd/secscan.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -47,7 +48,7 @@ The scan status can be:
 			return fmt.Errorf("getting security scan: %w", err)
 		}
 
-		fmt.Printf("Security scan for %s/%s@%s\n", namespace, repository, secScanManifestRef)
+		fmt.Fprintf(os.Stderr, "Security scan for %s/%s@%s\n", namespace, repository, secScanManifestRef)
 		return printJSON(security)
 	},
 }

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -43,7 +44,7 @@ var tagInfoCmd = &cobra.Command{
 			return fmt.Errorf("getting tag information: %w", err)
 		}
 
-		fmt.Printf("Tag information for %s/%s:%s\n", namespace, repository, tagName)
+		fmt.Fprintf(os.Stderr, "Tag information for %s/%s:%s\n", namespace, repository, tagName)
 		return printJSON(tag)
 	},
 }
@@ -64,7 +65,7 @@ var tagUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating tag: %w", err)
 		}
 
-		fmt.Printf("Successfully updated tag %s/%s:%s\n", namespace, repository, tagName)
+		fmt.Fprintf(os.Stderr, "Successfully updated tag %s/%s:%s\n", namespace, repository, tagName)
 		return printJSON(tag)
 	},
 }
@@ -89,7 +90,7 @@ var tagDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting tag: %w", err)
 		}
 
-		fmt.Printf("Successfully deleted tag %s/%s:%s\n", namespace, repository, tagName)
+		fmt.Fprintf(os.Stderr, "Successfully deleted tag %s/%s:%s\n", namespace, repository, tagName)
 		return nil
 	},
 }
@@ -110,7 +111,7 @@ var tagHistoryCmd = &cobra.Command{
 			return fmt.Errorf("getting tag history: %w", err)
 		}
 
-		fmt.Printf("History for tag %s/%s:%s\n", namespace, repository, tagName)
+		fmt.Fprintf(os.Stderr, "History for tag %s/%s:%s\n", namespace, repository, tagName)
 		return printJSON(history)
 	},
 }
@@ -131,7 +132,7 @@ var tagRevertCmd = &cobra.Command{
 			return fmt.Errorf("reverting tag: %w", err)
 		}
 
-		fmt.Printf("Successfully reverted tag %s/%s:%s to manifest %s\n", namespace, repository, tagName, manifestDigest)
+		fmt.Fprintf(os.Stderr, "Successfully reverted tag %s/%s:%s to manifest %s\n", namespace, repository, tagName, manifestDigest)
 		return printJSON(tag)
 	},
 }
@@ -152,7 +153,7 @@ var tagChangeCmd = &cobra.Command{
 			return fmt.Errorf("changing tag: %w", err)
 		}
 
-		fmt.Printf("Successfully changed tag %s/%s:%s to manifest %s\n", namespace, repository, tagName, manifestDigest)
+		fmt.Fprintf(os.Stderr, "Successfully changed tag %s/%s:%s to manifest %s\n", namespace, repository, tagName, manifestDigest)
 		return nil
 	},
 }
@@ -172,7 +173,7 @@ var tagRestoreCmd = &cobra.Command{
 			return fmt.Errorf("restoring tag: %w", err)
 		}
 
-		fmt.Printf("Successfully restored tag %s/%s:%s from manifest %s\n", namespace, repository, tagName, manifestDigest)
+		fmt.Fprintf(os.Stderr, "Successfully restored tag %s/%s:%s from manifest %s\n", namespace, repository, tagName, manifestDigest)
 		return nil
 	},
 }

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -57,7 +58,7 @@ var teamListCmd = &cobra.Command{
 			return fmt.Errorf("getting teams: %w", err)
 		}
 
-		fmt.Printf("Teams in organization '%s':\n", teamCmdOrgname)
+		fmt.Fprintf(os.Stderr, "Teams in organization '%s':\n", teamCmdOrgname)
 		return printJSON(teams)
 	},
 }
@@ -78,7 +79,7 @@ var teamCmdInfoCmd = &cobra.Command{
 			return fmt.Errorf("getting team: %w", err)
 		}
 
-		fmt.Printf("Team: %s/%s\n", teamCmdOrgname, teamCmdName)
+		fmt.Fprintf(os.Stderr, "Team: %s/%s\n", teamCmdOrgname, teamCmdName)
 		return printJSON(team)
 	},
 }
@@ -104,7 +105,7 @@ Roles:
 			return fmt.Errorf("creating team: %w", err)
 		}
 
-		fmt.Printf("Successfully created team: %s/%s\n", teamCmdOrgname, teamCmdName)
+		fmt.Fprintf(os.Stderr, "Successfully created team: %s/%s\n", teamCmdOrgname, teamCmdName)
 		return printJSON(team)
 	},
 }
@@ -125,7 +126,7 @@ var teamUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating team: %w", err)
 		}
 
-		fmt.Printf("Successfully updated team: %s/%s\n", teamCmdOrgname, teamCmdName)
+		fmt.Fprintf(os.Stderr, "Successfully updated team: %s/%s\n", teamCmdOrgname, teamCmdName)
 		return printJSON(team)
 	},
 }
@@ -150,7 +151,7 @@ var teamDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting team: %w", err)
 		}
 
-		fmt.Printf("Successfully deleted team: %s/%s\n", teamCmdOrgname, teamCmdName)
+		fmt.Fprintf(os.Stderr, "Successfully deleted team: %s/%s\n", teamCmdOrgname, teamCmdName)
 		return nil
 	},
 }
@@ -171,7 +172,7 @@ var teamCmdMembersCmd = &cobra.Command{
 			return fmt.Errorf("getting team members: %w", err)
 		}
 
-		fmt.Printf("Members of team '%s/%s':\n", teamCmdOrgname, teamCmdName)
+		fmt.Fprintf(os.Stderr, "Members of team '%s/%s':\n", teamCmdOrgname, teamCmdName)
 		return printJSON(members)
 	},
 }
@@ -192,7 +193,7 @@ var teamAddMemberCmd = &cobra.Command{
 			return fmt.Errorf("adding team member: %w", err)
 		}
 
-		fmt.Printf("Successfully added '%s' to team '%s/%s'\n", teamCmdMemberName, teamCmdOrgname, teamCmdName)
+		fmt.Fprintf(os.Stderr, "Successfully added '%s' to team '%s/%s'\n", teamCmdMemberName, teamCmdOrgname, teamCmdName)
 		return nil
 	},
 }
@@ -217,7 +218,7 @@ var teamRemoveMemberCmd = &cobra.Command{
 			return fmt.Errorf("removing team member: %w", err)
 		}
 
-		fmt.Printf("Successfully removed '%s' from team '%s/%s'\n", teamCmdMemberName, teamCmdOrgname, teamCmdName)
+		fmt.Fprintf(os.Stderr, "Successfully removed '%s' from team '%s/%s'\n", teamCmdMemberName, teamCmdOrgname, teamCmdName)
 		return nil
 	},
 }
@@ -238,7 +239,7 @@ var teamPermissionsCmd = &cobra.Command{
 			return fmt.Errorf("getting team permissions: %w", err)
 		}
 
-		fmt.Printf("Repository permissions for team '%s/%s':\n", teamCmdOrgname, teamCmdName)
+		fmt.Fprintf(os.Stderr, "Repository permissions for team '%s/%s':\n", teamCmdOrgname, teamCmdName)
 		return printJSON(permissions)
 	},
 }
@@ -264,7 +265,7 @@ Permission roles:
 			return fmt.Errorf("setting team permission: %w", err)
 		}
 
-		fmt.Printf("Successfully set '%s' permission for team '%s/%s' on repository '%s'\n",
+		fmt.Fprintf(os.Stderr, "Successfully set '%s' permission for team '%s/%s' on repository '%s'\n",
 			teamCmdPermissionRole, teamCmdOrgname, teamCmdName, teamCmdRepository)
 		return nil
 	},
@@ -291,7 +292,7 @@ var teamRemovePermissionCmd = &cobra.Command{
 			return fmt.Errorf("removing team permission: %w", err)
 		}
 
-		fmt.Printf("Successfully removed permissions for team '%s/%s' on repository '%s'\n",
+		fmt.Fprintf(os.Stderr, "Successfully removed permissions for team '%s/%s' on repository '%s'\n",
 			teamCmdOrgname, teamCmdName, teamCmdRepository)
 		return nil
 	},

--- a/cmd/trigger.go
+++ b/cmd/trigger.go
@@ -14,6 +14,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -94,7 +95,7 @@ var triggerDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting trigger: %w", err)
 		}
 
-		fmt.Printf("Trigger %s deleted successfully\n", triggerUUID)
+		fmt.Fprintf(os.Stderr, "Trigger %s deleted successfully\n", triggerUUID)
 		return nil
 	},
 }

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -37,7 +38,7 @@ var userInfoCmd = &cobra.Command{
 			return fmt.Errorf("getting user information: %w", err)
 		}
 
-		fmt.Printf("User information for %s:\n", user.Username)
+		fmt.Fprintf(os.Stderr, "User information for %s:\n", user.Username)
 		return printJSON(user)
 	},
 }
@@ -58,7 +59,7 @@ var userStarredCmd = &cobra.Command{
 			return fmt.Errorf("getting starred repositories: %w", err)
 		}
 
-		fmt.Println("Starred repositories:")
+		fmt.Fprintln(os.Stderr, "Starred repositories:")
 		return printJSON(starred)
 	},
 }
@@ -79,7 +80,7 @@ var starRepoCmd = &cobra.Command{
 			return fmt.Errorf("starring repository: %w", err)
 		}
 
-		fmt.Printf("Successfully starred repository %s/%s\n", namespace, repository)
+		fmt.Fprintf(os.Stderr, "Successfully starred repository %s/%s\n", namespace, repository)
 		return nil
 	},
 }
@@ -100,7 +101,7 @@ var unstarRepoCmd = &cobra.Command{
 			return fmt.Errorf("unstarring repository: %w", err)
 		}
 
-		fmt.Printf("Successfully unstarred repository %s/%s\n", namespace, repository)
+		fmt.Fprintf(os.Stderr, "Successfully unstarred repository %s/%s\n", namespace, repository)
 		return nil
 	},
 }


### PR DESCRIPTION
## Summary
- Moves all status messages, headers, and confirmations from stdout to stderr across 17 cmd/ files
- Keeps JSON data output (`printJSON`) and table output on stdout
- Enables clean piping to `jq` and other tools without noise from informational messages

Closes #118