### PR TITLE
test: add command execution tests for repository, tag, and organization

### DIFF
--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -7,4 +7,11 @@ const (
 	subcmdUpdate      = "update"
 	subcmdDelete      = "delete"
 	subcmdPermissions = "permissions"
+
+	// Command name constants
+	cmdGet          = "get"
+	cmdRepository   = "repository"
+	cmdOrganization = "organization"
+	cmdTag          = "tag"
+	cmdMembers      = "members"
 )

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -36,7 +36,7 @@ var (
 
 // organizationCmd represents the organization command
 var organizationCmd = &cobra.Command{
-	Use:   "organization",
+	Use:   cmdOrganization,
 	Short: "Organization management commands",
 	Long: `Commands for managing organizations, teams, members, robots, and other organization-related operations.
 
@@ -72,7 +72,7 @@ var orgInfoCmd = &cobra.Command{
 
 // Organization Members
 var orgMembersCmd = &cobra.Command{
-	Use:   "members",
+	Use:   cmdMembers,
 	Short: "Get organization members",
 	Long:  `Get list of all members in an organization.`,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/organization_test.go
+++ b/cmd/organization_test.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// resetOrgFlags resets all organization-related flags to their zero values
+// so that Cobra's persistent flag state does not leak between tests.
+func resetOrgFlags(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		orgName = ""
+		token = ""
+		quayURL = ""
+
+		rootCmd.SetArgs([]string{})
+	})
+}
+
+func TestOrgInfoCmd(t *testing.T) {
+	resetOrgFlags(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		expectedPath := "/organization/" + testOrgName
+		if !strings.HasSuffix(r.URL.Path, expectedPath) {
+			t.Errorf("expected path ending with %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name": "` + testOrgName + `", "email": "admin@testorg.com", "is_org_admin": true}`))
+	}))
+	defer server.Close()
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	rootCmd.SetArgs([]string{
+		cmdGet, testTokenFlag, testTokenValue, testQuayURLFlag, server.URL,
+		cmdOrganization, subcmdInfo, "-o", testOrgName,
+	})
+	err := rootCmd.Execute()
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	output := buf.String()
+
+	if !strings.Contains(output, `"name": "`+testOrgName+`"`) {
+		t.Errorf("expected org name in output, got: %s", output)
+	}
+	if !strings.Contains(output, `"email": "admin@testorg.com"`) {
+		t.Errorf("expected email in output, got: %s", output)
+	}
+}
+
+func TestOrgMembersCmd(t *testing.T) {
+	resetOrgFlags(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		expectedPath := "/organization/" + testOrgName + "/members"
+		if !strings.HasSuffix(r.URL.Path, expectedPath) {
+			t.Errorf("expected path ending with %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"members": [{"name": "user1", "kind": "user"}, {"name": "user2", "kind": "user"}]}`))
+	}))
+	defer server.Close()
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	rootCmd.SetArgs([]string{
+		cmdGet, testTokenFlag, testTokenValue, testQuayURLFlag, server.URL,
+		cmdOrganization, cmdMembers, "-o", testOrgName,
+	})
+	err := rootCmd.Execute()
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	output := buf.String()
+
+	if !strings.Contains(output, `"name": "user1"`) {
+		t.Errorf("expected user1 in output, got: %s", output)
+	}
+	if !strings.Contains(output, `"name": "user2"`) {
+		t.Errorf("expected user2 in output, got: %s", output)
+	}
+}

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -25,7 +25,7 @@ var (
 
 // repositoryCmd represents the repository command group
 var repositoryCmd = &cobra.Command{
-	Use:   "repository",
+	Use:   cmdRepository,
 	Short: "Repository management commands",
 	Long: `Commands for managing repositories including creation, updates, deletion, and information retrieval.
 

--- a/cmd/repository_test.go
+++ b/cmd/repository_test.go
@@ -1,0 +1,220 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+const (
+	testQuayURLFlag = "--quay-url"
+	testTokenFlag   = "--token"
+	testTokenValue  = "test-token"
+	testNamespace   = "testns"
+	testRepository  = "testrepo"
+	testOrgName     = "testorg"
+)
+
+// resetRepositoryFlags resets all repository-related flags to their zero values
+// so that Cobra's persistent flag state does not leak between tests.
+func resetRepositoryFlags(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		namespace = ""
+		repository = ""
+		token = ""
+		quayURL = ""
+		repoVisibility = ""
+		repoDescription = ""
+		confirmDeletion = false
+		repoPublic = false
+		repoStarred = false
+		repoPopularity = false
+		repoTable = false
+		repoPage = 0
+		repoLimit = 0
+
+		rootCmd.SetArgs([]string{})
+	})
+}
+
+func TestRepoInfoCmd(t *testing.T) {
+	resetRepositoryFlags(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/repository/"+testNamespace+"/"+testRepository+"/tag/"):
+			// ListTags call made by GetRepository
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"tags": [{"name": "latest", "manifest_digest": "sha256:abc123"}]}`))
+		case strings.HasSuffix(r.URL.Path, "/repository/"+testNamespace+"/"+testRepository):
+			if r.Method != http.MethodGet {
+				t.Errorf("expected GET, got %s", r.Method)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"namespace": "` + testNamespace + `", "name": "` + testRepository + `", "is_public": true}`))
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	rootCmd.SetArgs([]string{
+		cmdGet, testTokenFlag, testTokenValue, testQuayURLFlag, server.URL,
+		cmdRepository, subcmdInfo, "-n", testNamespace, "-r", testRepository,
+	})
+	err := rootCmd.Execute()
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	output := buf.String()
+
+	if !strings.Contains(output, `"namespace": "`+testNamespace+`"`) {
+		t.Errorf("expected namespace in output, got: %s", output)
+	}
+	if !strings.Contains(output, `"name": "`+testRepository+`"`) {
+		t.Errorf("expected repo name in output, got: %s", output)
+	}
+	if !strings.Contains(output, `"is_public": true`) {
+		t.Errorf("expected is_public in output, got: %s", output)
+	}
+}
+
+func TestRepoListCmd(t *testing.T) {
+	resetRepositoryFlags(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/repository") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("namespace") != testNamespace {
+			t.Errorf("expected namespace=%s, got %s", testNamespace, q.Get("namespace"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"repositories": [{"name": "repo1", "namespace": "` + testNamespace + `"}, {"name": "repo2", "namespace": "` + testNamespace + `"}]}`))
+	}))
+	defer server.Close()
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	rootCmd.SetArgs([]string{
+		cmdGet, testTokenFlag, testTokenValue, testQuayURLFlag, server.URL,
+		cmdRepository, subcmdList, "-n", testNamespace,
+	})
+	err := rootCmd.Execute()
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	output := buf.String()
+
+	if !strings.Contains(output, `"name": "repo1"`) {
+		t.Errorf("expected repo1 in output, got: %s", output)
+	}
+	if !strings.Contains(output, `"name": "repo2"`) {
+		t.Errorf("expected repo2 in output, got: %s", output)
+	}
+}
+
+func TestRepoInfoMissingRepositoryFlag(t *testing.T) {
+	resetRepositoryFlags(t)
+
+	rootCmd.SetArgs([]string{
+		cmdGet, testTokenFlag, testTokenValue,
+		cmdRepository, subcmdInfo, "-n", testNamespace,
+		// --repository flag intentionally omitted
+	})
+
+	// Discard stdout to keep test output clean.
+	oldStdout := os.Stdout
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := rootCmd.Execute()
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err == nil {
+		t.Fatal("expected error for missing --repository flag, got nil")
+	}
+	if !strings.Contains(err.Error(), "repository") {
+		t.Errorf("expected error about repository flag, got: %v", err)
+	}
+}
+
+func TestRepoCreateCmd(t *testing.T) {
+	resetRepositoryFlags(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/repository") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"namespace": "` + testNamespace + `", "name": "newrepo", "is_public": false}`))
+	}))
+	defer server.Close()
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	rootCmd.SetArgs([]string{
+		cmdGet, testTokenFlag, testTokenValue, testQuayURLFlag, server.URL,
+		cmdRepository, subcmdCreate, "-n", testNamespace, "-r", "newrepo",
+		"--visibility", "private", "--description", "a test repo",
+	})
+	err := rootCmd.Execute()
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	output := buf.String()
+
+	if !strings.Contains(output, `"name": "newrepo"`) {
+		t.Errorf("expected newrepo in output, got: %s", output)
+	}
+	if !strings.Contains(output, `"namespace": "`+testNamespace+`"`) {
+		t.Errorf("expected namespace in output, got: %s", output)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,7 @@ func SetVersion(v string) {
 }
 
 var getCmd = &cobra.Command{
-	Use:   "get",
+	Use:   cmdGet,
 	Short: "Get objects from Quay.io",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// Validate token is provided

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -16,7 +16,7 @@ var (
 
 // tagCmd represents the tag command group
 var tagCmd = &cobra.Command{
-	Use:   "tag",
+	Use:   cmdTag,
 	Short: "Repository tag management commands",
 	Long: `Commands for managing repository tags including detailed information, updates, deletion, and history.
 

--- a/cmd/tag_test.go
+++ b/cmd/tag_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// resetTagFlags resets all tag-related flags to their zero values
+// so that Cobra's persistent flag state does not leak between tests.
+func resetTagFlags(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		namespace = ""
+		repository = ""
+		token = ""
+		quayURL = ""
+		tagName = ""
+		tagExpiration = ""
+		manifestDigest = ""
+		confirmTagDeletion = false
+
+		rootCmd.SetArgs([]string{})
+	})
+}
+
+func TestTagInfoCmd(t *testing.T) {
+	resetTagFlags(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		expectedPath := "/repository/" + testNamespace + "/" + testRepository + "/tag/v1.0"
+		if !strings.HasSuffix(r.URL.Path, expectedPath) {
+			t.Errorf("expected path ending with %s, got %s", expectedPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name": "v1.0", "manifest_digest": "sha256:deadbeef", "size": 12345}`))
+	}))
+	defer server.Close()
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	rootCmd.SetArgs([]string{
+		cmdGet, testTokenFlag, testTokenValue, testQuayURLFlag, server.URL,
+		cmdTag, subcmdInfo, "-n", testNamespace, "-r", testRepository, "-T", "v1.0",
+	})
+	err := rootCmd.Execute()
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	output := buf.String()
+
+	if !strings.Contains(output, `"name": "v1.0"`) {
+		t.Errorf("expected tag name in output, got: %s", output)
+	}
+	if !strings.Contains(output, `"manifest_digest": "sha256:deadbeef"`) {
+		t.Errorf("expected manifest_digest in output, got: %s", output)
+	}
+}
+
+func TestTagChangeCmd(t *testing.T) {
+	resetTagFlags(t)
+
+	var receivedMethod string
+	var receivedPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+		receivedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	// Discard stdout (change command prints to stderr, not stdout).
+	oldStdout := os.Stdout
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+
+	rootCmd.SetArgs([]string{
+		cmdGet, testTokenFlag, testTokenValue, testQuayURLFlag, server.URL,
+		cmdTag, "change", "-n", testNamespace, "-r", testRepository, "-T", "latest",
+		"--manifest", "sha256:abc123",
+	})
+	err := rootCmd.Execute()
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if receivedMethod != http.MethodPut {
+		t.Errorf("expected PUT, got %s", receivedMethod)
+	}
+	expectedPath := "/repository/" + testNamespace + "/" + testRepository + "/tag/latest"
+	if !strings.HasSuffix(receivedPath, expectedPath) {
+		t.Errorf("expected path ending with %s, got %s", expectedPath, receivedPath)
+	}
+}
+
+func TestTagDeleteWithoutConfirmErrors(t *testing.T) {
+	resetTagFlags(t)
+
+	// Discard stdout.
+	oldStdout := os.Stdout
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+
+	rootCmd.SetArgs([]string{
+		cmdGet, testTokenFlag, testTokenValue,
+		cmdTag, subcmdDelete, "-n", testNamespace, "-r", testRepository, "-T", "v1.0",
+		// --confirm intentionally omitted
+	})
+	err := rootCmd.Execute()
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err == nil {
+		t.Fatal("expected error when --confirm is not passed, got nil")
+	}
+	if !strings.Contains(err.Error(), "confirm") {
+		t.Errorf("expected error message about --confirm, got: %v", err)
+	}
+}

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -158,7 +158,7 @@ var teamDeleteCmd = &cobra.Command{
 
 // Team Members
 var teamCmdMembersCmd = &cobra.Command{
-	Use:   "members",
+	Use:   cmdMembers,
 	Short: "List team members",
 	Long:  `List all members of a specific team.`,
 	RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary
- Adds 9 command execution tests across 3 new test files (`repository_test.go`, `tag_test.go`, `organization_test.go`)
- Tests actual command execution with mock HTTP servers via `--quay-url`
- Covers flag validation (missing required flags), success paths, and confirmation guards
- Extracts repeated string literals into constants to fix goconst lint warnings

Closes #135