### PR TITLE
feat: add input validation to all lib/ client methods

### DIFF
--- a/lib/application.go
+++ b/lib/application.go
@@ -19,6 +19,10 @@ import (
 
 // GetApplications retrieves applications for an organization
 func (c *Client) GetApplications(orgname string) (*Applications, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/applications", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get applications request: %w", err)
@@ -34,6 +38,13 @@ func (c *Client) GetApplications(orgname string) (*Applications, error) {
 
 // CreateApplication creates a new application for an organization
 func (c *Client) CreateApplication(orgname, name, description, applicationURI, redirectURI string) (*Application, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
 	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/applications", orgname), CreateApplicationRequest{
 		Name:           name,
 		Description:    description,
@@ -54,6 +65,13 @@ func (c *Client) CreateApplication(orgname, name, description, applicationURI, r
 
 // GetApplication retrieves details for a specific application
 func (c *Client) GetApplication(orgname, clientID string) (*Application, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if clientID == "" {
+		return nil, fmt.Errorf("clientID is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/applications/%s", orgname, clientID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get application request: %w", err)
@@ -69,6 +87,13 @@ func (c *Client) GetApplication(orgname, clientID string) (*Application, error) 
 
 // UpdateApplication updates an application
 func (c *Client) UpdateApplication(orgname, clientID, name, description, applicationURI, redirectURI string) (*Application, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if clientID == "" {
+		return nil, fmt.Errorf("clientID is required")
+	}
+
 	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/applications/%s", orgname, clientID), CreateApplicationRequest{
 		Name:           name,
 		Description:    description,
@@ -89,6 +114,13 @@ func (c *Client) UpdateApplication(orgname, clientID, name, description, applica
 
 // DeleteApplication deletes an application
 func (c *Client) DeleteApplication(orgname, clientID string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+	if clientID == "" {
+		return fmt.Errorf("clientID is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/applications/%s", orgname, clientID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete application request: %w", err)
@@ -103,6 +135,13 @@ func (c *Client) DeleteApplication(orgname, clientID string) error {
 
 // ResetApplicationClientSecret resets the client secret for an application
 func (c *Client) ResetApplicationClientSecret(orgname, clientID string) (*Application, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if clientID == "" {
+		return nil, fmt.Errorf("clientID is required")
+	}
+
 	req, err := newRequest("POST", c.buildURL("/organization/%s/applications/%s/resetclientsecret", orgname, clientID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create reset application client secret request: %w", err)

--- a/lib/auto_prune.go
+++ b/lib/auto_prune.go
@@ -18,6 +18,10 @@ import (
 
 // GetAutoPrunePolicies retrieves auto-prune policies for an organization
 func (c *Client) GetAutoPrunePolicies(orgname string) (*AutoPrunePolicies, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/autoprunepolicy", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get auto-prune policies request: %w", err)
@@ -33,6 +37,13 @@ func (c *Client) GetAutoPrunePolicies(orgname string) (*AutoPrunePolicies, error
 
 // CreateAutoPrunePolicy creates an auto-prune policy for an organization
 func (c *Client) CreateAutoPrunePolicy(orgname, method string, value int, tagPattern string) (*AutoPrunePolicy, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if method == "" {
+		return nil, fmt.Errorf("method is required")
+	}
+
 	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/autoprunepolicy", orgname), CreateAutoPruneRequest{
 		Method:     method,
 		Value:      value,
@@ -52,6 +63,13 @@ func (c *Client) CreateAutoPrunePolicy(orgname, method string, value int, tagPat
 
 // GetAutoPrunePolicy retrieves a specific auto-prune policy
 func (c *Client) GetAutoPrunePolicy(orgname, policyUUID string) (*AutoPrunePolicy, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if policyUUID == "" {
+		return nil, fmt.Errorf("policyUUID is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get auto-prune policy request: %w", err)
@@ -67,6 +85,16 @@ func (c *Client) GetAutoPrunePolicy(orgname, policyUUID string) (*AutoPrunePolic
 
 // UpdateAutoPrunePolicy updates an auto-prune policy
 func (c *Client) UpdateAutoPrunePolicy(orgname, policyUUID, method string, value int, tagPattern string) (*AutoPrunePolicy, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if policyUUID == "" {
+		return nil, fmt.Errorf("policyUUID is required")
+	}
+	if method == "" {
+		return nil, fmt.Errorf("method is required")
+	}
+
 	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), CreateAutoPruneRequest{
 		Method:     method,
 		Value:      value,
@@ -86,6 +114,13 @@ func (c *Client) UpdateAutoPrunePolicy(orgname, policyUUID, method string, value
 
 // DeleteAutoPrunePolicy deletes an auto-prune policy
 func (c *Client) DeleteAutoPrunePolicy(orgname, policyUUID string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+	if policyUUID == "" {
+		return fmt.Errorf("policyUUID is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete auto-prune policy request: %w", err)

--- a/lib/billing.go
+++ b/lib/billing.go
@@ -25,6 +25,10 @@ import (
 
 // GetOrganizationBilling returns billing information for an organization
 func (c *Client) GetOrganizationBilling(orgname string) (*BillingInfo, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	// Get new request
 	req, err := newRequest("GET", c.buildURL("/organization/%s/plan", orgname), nil)
 	if err != nil {
@@ -57,6 +61,10 @@ func (c *Client) GetUserBilling() (*BillingInfo, error) {
 
 // GetOrganizationSubscription returns subscription details for an organization
 func (c *Client) GetOrganizationSubscription(orgname string) (*Subscription, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	// Get new request
 	req, err := newRequest("GET", c.buildURL("/organization/%s/plan", orgname), nil)
 	if err != nil {
@@ -89,6 +97,10 @@ func (c *Client) GetUserSubscription() (*Subscription, error) {
 
 // GetOrganizationInvoices returns invoices for an organization
 func (c *Client) GetOrganizationInvoices(orgname string) ([]Invoice, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	// Get new request
 	req, err := newRequest("GET", c.buildURL("/organization/%s/invoices", orgname), nil)
 	if err != nil {

--- a/lib/build.go
+++ b/lib/build.go
@@ -21,6 +21,13 @@ import (
 
 // GetBuilds retrieves a list of builds for a repository
 func (c *Client) GetBuilds(namespace, repository string, limit int) (*Builds, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
 	url := c.buildURL("/repository/%s/%s/build/", namespace, repository)
 	if limit > 0 {
 		url = fmt.Sprintf("%s?limit=%d", url, limit)
@@ -41,6 +48,16 @@ func (c *Client) GetBuilds(namespace, repository string, limit int) (*Builds, er
 
 // GetBuild retrieves a specific build by UUID
 func (c *Client) GetBuild(namespace, repository, buildUUID string) (*Build, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if buildUUID == "" {
+		return nil, fmt.Errorf("buildUUID is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/build/%s", namespace, repository, buildUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get build request: %w", err)
@@ -56,6 +73,16 @@ func (c *Client) GetBuild(namespace, repository, buildUUID string) (*Build, erro
 
 // GetBuildLogs retrieves the logs for a specific build
 func (c *Client) GetBuildLogs(namespace, repository, buildUUID string) (*BuildLogs, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if buildUUID == "" {
+		return nil, fmt.Errorf("buildUUID is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/build/%s/logs", namespace, repository, buildUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get build logs request: %w", err)
@@ -71,6 +98,13 @@ func (c *Client) GetBuildLogs(namespace, repository, buildUUID string) (*BuildLo
 
 // RequestBuild triggers a new build for a repository
 func (c *Client) RequestBuild(namespace, repository string, buildRequest *RequestBuildRequest) (*Build, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
 	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/build/", namespace, repository), buildRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request build request: %w", err)
@@ -86,6 +120,16 @@ func (c *Client) RequestBuild(namespace, repository string, buildRequest *Reques
 
 // CancelBuild cancels an ongoing build
 func (c *Client) CancelBuild(namespace, repository, buildUUID string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if buildUUID == "" {
+		return fmt.Errorf("buildUUID is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/build/%s", namespace, repository, buildUUID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create cancel build request: %w", err)
@@ -100,6 +144,16 @@ func (c *Client) CancelBuild(namespace, repository, buildUUID string) error {
 
 // GetBuildStatus gets the status of a build
 func (c *Client) GetBuildStatus(namespace, repository, buildUUID string) (*BuildStatus, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if buildUUID == "" {
+		return nil, fmt.Errorf("buildUUID is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/build/%s/status", namespace, repository, buildUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get build status request: %w", err)

--- a/lib/discovery.go
+++ b/lib/discovery.go
@@ -47,6 +47,10 @@ func (c *Client) GetRegistryCapabilities() (*RegistryCapabilities, error) {
 
 // GetAppInfo retrieves public information about an OAuth application by client ID
 func (c *Client) GetAppInfo(clientID string) (*Application, error) {
+	if clientID == "" {
+		return nil, fmt.Errorf("clientID is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/app/%s", clientID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get app info request: %w", err)
@@ -62,6 +66,10 @@ func (c *Client) GetAppInfo(clientID string) (*Application, error) {
 
 // GetEntities searches for entities (users, robots, teams) matching a prefix
 func (c *Client) GetEntities(prefix string, includeOrgs, includeTeams bool) (*Entities, error) {
+	if prefix == "" {
+		return nil, fmt.Errorf("prefix is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/entities/%s", prefix), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get entities request: %w", err)

--- a/lib/error.go
+++ b/lib/error.go
@@ -17,6 +17,10 @@ import (
 
 // GetErrorType retrieves details about a specific error type
 func (c *Client) GetErrorType(errorType string) (*ErrorType, error) {
+	if errorType == "" {
+		return nil, fmt.Errorf("errorType is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/error/%s", errorType), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create error type request: %w", err)

--- a/lib/logs.go
+++ b/lib/logs.go
@@ -43,6 +43,13 @@ func addLogQueryParams(req *http.Request, nextPage, startDate, endDate string) {
 
 // GetAggregatedLogs returns the aggregated logs for a repository
 func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate string) (*AggregatedLogs, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
 	// Get new request
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/aggregatelogs", namespace, repository), nil)
 	if err != nil {
@@ -65,6 +72,13 @@ func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate str
 
 // GetLogs returns the logs for a repository
 func (c *Client) GetLogs(namespace, repository, nextPage, startDate, endDate string) (*Logs, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/logs", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repository logs request: %w", err)
@@ -82,6 +96,10 @@ func (c *Client) GetLogs(namespace, repository, nextPage, startDate, endDate str
 
 // GetOrganizationLogs returns the logs for an organization
 func (c *Client) GetOrganizationLogs(orgname, nextPage, startDate, endDate string) (*Logs, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/logs", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization logs request: %w", err)
@@ -99,6 +117,10 @@ func (c *Client) GetOrganizationLogs(orgname, nextPage, startDate, endDate strin
 
 // GetOrganizationAggregatedLogs returns the aggregated logs for an organization
 func (c *Client) GetOrganizationAggregatedLogs(orgname, startDate, endDate string) (*AggregatedLogs, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/aggregatelogs", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization aggregate logs request: %w", err)
@@ -119,6 +141,10 @@ func (c *Client) GetOrganizationAggregatedLogs(orgname, startDate, endDate strin
 
 // ExportOrganizationLogs exports the logs for an organization
 func (c *Client) ExportOrganizationLogs(orgname string, request *ExportLogsRequest) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/exportlogs", orgname), request)
 	if err != nil {
 		return fmt.Errorf("failed to create export organization logs request: %w", err)
@@ -184,6 +210,13 @@ func (c *Client) ExportUserLogs(request *ExportLogsRequest) error {
 
 // ExportRepositoryLogs exports the logs for a repository
 func (c *Client) ExportRepositoryLogs(namespace, repository string, request *ExportLogsRequest) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+
 	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/exportlogs", namespace, repository), request)
 	if err != nil {
 		return fmt.Errorf("failed to create export repository logs request: %w", err)

--- a/lib/manifest.go
+++ b/lib/manifest.go
@@ -24,6 +24,16 @@ import (
 
 // GetManifest retrieves detailed information about a specific manifest
 func (c *Client) GetManifest(namespace, repository, manifestRef string) (*Manifest, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if manifestRef == "" {
+		return nil, fmt.Errorf("manifestRef is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/manifest/%s", namespace, repository, manifestRef), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest request: %w", err)
@@ -39,6 +49,16 @@ func (c *Client) GetManifest(namespace, repository, manifestRef string) (*Manife
 
 // DeleteManifest deletes a specific manifest from a repository
 func (c *Client) DeleteManifest(namespace, repository, manifestRef string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if manifestRef == "" {
+		return fmt.Errorf("manifestRef is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/manifest/%s", namespace, repository, manifestRef), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete manifest request: %w", err)
@@ -53,6 +73,16 @@ func (c *Client) DeleteManifest(namespace, repository, manifestRef string) error
 
 // GetManifestLabels retrieves all labels for a specific manifest
 func (c *Client) GetManifestLabels(namespace, repository, manifestRef string) (*ManifestLabels, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if manifestRef == "" {
+		return nil, fmt.Errorf("manifestRef is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/manifest/%s/labels", namespace, repository, manifestRef), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest labels request: %w", err)
@@ -68,6 +98,22 @@ func (c *Client) GetManifestLabels(namespace, repository, manifestRef string) (*
 
 // AddManifestLabel adds a label to a specific manifest
 func (c *Client) AddManifestLabel(namespace, repository, manifestRef, key, value, mediaType string) (*ManifestLabel, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if manifestRef == "" {
+		return nil, fmt.Errorf("manifestRef is required")
+	}
+	if key == "" {
+		return nil, fmt.Errorf("key is required")
+	}
+	if value == "" {
+		return nil, fmt.Errorf("value is required")
+	}
+
 	addReq := AddManifestLabelRequest{
 		Key:   key,
 		Value: value,
@@ -92,6 +138,19 @@ func (c *Client) AddManifestLabel(namespace, repository, manifestRef, key, value
 
 // GetManifestLabel retrieves a specific label from a manifest
 func (c *Client) GetManifestLabel(namespace, repository, manifestRef, labelID string) (*ManifestLabel, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if manifestRef == "" {
+		return nil, fmt.Errorf("manifestRef is required")
+	}
+	if labelID == "" {
+		return nil, fmt.Errorf("labelID is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/manifest/%s/labels/%s", namespace, repository, manifestRef, labelID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest label request: %w", err)
@@ -107,6 +166,19 @@ func (c *Client) GetManifestLabel(namespace, repository, manifestRef, labelID st
 
 // DeleteManifestLabel deletes a specific label from a manifest
 func (c *Client) DeleteManifestLabel(namespace, repository, manifestRef, labelID string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if manifestRef == "" {
+		return fmt.Errorf("manifestRef is required")
+	}
+	if labelID == "" {
+		return fmt.Errorf("labelID is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/manifest/%s/labels/%s", namespace, repository, manifestRef, labelID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete manifest label request: %w", err)

--- a/lib/messages.go
+++ b/lib/messages.go
@@ -32,6 +32,13 @@ func (c *Client) GetMessages() (*Messages, error) {
 
 // CreateMessage creates a new global message (admin only)
 func (c *Client) CreateMessage(content, severity, mediaType string) (*Message, error) {
+	if content == "" {
+		return nil, fmt.Errorf("content is required")
+	}
+	if severity == "" {
+		return nil, fmt.Errorf("severity is required")
+	}
+
 	body := struct {
 		Message struct {
 			Content   string `json:"content"`

--- a/lib/notification.go
+++ b/lib/notification.go
@@ -38,6 +38,13 @@ import (
 
 // GetNotifications retrieves all notifications for a repository
 func (c *Client) GetNotifications(namespace, repository string) (*RepositoryNotifications, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/notification/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get notifications request: %w", err)
@@ -53,6 +60,16 @@ func (c *Client) GetNotifications(namespace, repository string) (*RepositoryNoti
 
 // GetNotification retrieves a specific notification by UUID
 func (c *Client) GetNotification(namespace, repository, uuid string) (*RepositoryNotification, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if uuid == "" {
+		return nil, fmt.Errorf("uuid is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/notification/%s", namespace, repository, uuid), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get notification request: %w", err)
@@ -68,6 +85,13 @@ func (c *Client) GetNotification(namespace, repository, uuid string) (*Repositor
 
 // CreateNotification creates a new notification for a repository
 func (c *Client) CreateNotification(namespace, repository string, notificationReq *CreateNotificationRequest) (*RepositoryNotification, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
 	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/notification/", namespace, repository), notificationReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create notification request: %w", err)
@@ -83,6 +107,16 @@ func (c *Client) CreateNotification(namespace, repository string, notificationRe
 
 // DeleteNotification deletes a notification from a repository
 func (c *Client) DeleteNotification(namespace, repository, uuid string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if uuid == "" {
+		return fmt.Errorf("uuid is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/notification/%s", namespace, repository, uuid), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete notification request: %w", err)
@@ -97,6 +131,16 @@ func (c *Client) DeleteNotification(namespace, repository, uuid string) error {
 
 // TestNotification tests a notification by sending a test event
 func (c *Client) TestNotification(namespace, repository, uuid string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if uuid == "" {
+		return fmt.Errorf("uuid is required")
+	}
+
 	req, err := newRequest("POST", c.buildURL("/repository/%s/%s/notification/%s/test", namespace, repository, uuid), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create test notification request: %w", err)
@@ -111,6 +155,16 @@ func (c *Client) TestNotification(namespace, repository, uuid string) error {
 
 // ResetNotification resets failure count for a notification
 func (c *Client) ResetNotification(namespace, repository, uuid string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if uuid == "" {
+		return fmt.Errorf("uuid is required")
+	}
+
 	req, err := newRequest("POST", c.buildURL("/repository/%s/%s/notification/%s/reset", namespace, repository, uuid), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create reset notification request: %w", err)
@@ -125,6 +179,16 @@ func (c *Client) ResetNotification(namespace, repository, uuid string) error {
 
 // UpdateNotification updates an existing notification
 func (c *Client) UpdateNotification(namespace, repository, uuid string, notificationReq *CreateNotificationRequest) (*RepositoryNotification, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if uuid == "" {
+		return nil, fmt.Errorf("uuid is required")
+	}
+
 	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/notification/%s", namespace, repository, uuid), notificationReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update notification request: %w", err)

--- a/lib/org_marketplace.go
+++ b/lib/org_marketplace.go
@@ -17,6 +17,10 @@ import (
 
 // GetOrganizationMarketplace gets marketplace information for an organization
 func (c *Client) GetOrganizationMarketplace(orgname string) (*MarketplaceInfo, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/marketplace", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization marketplace request: %w", err)
@@ -32,6 +36,10 @@ func (c *Client) GetOrganizationMarketplace(orgname string) (*MarketplaceInfo, e
 
 // CreateOrganizationMarketplaceSubscription creates a marketplace subscription
 func (c *Client) CreateOrganizationMarketplaceSubscription(orgname string, subscription *MarketplaceSubscriptionRequest) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/marketplace", orgname), subscription)
 	if err != nil {
 		return fmt.Errorf("failed to create marketplace subscription request: %w", err)
@@ -46,6 +54,10 @@ func (c *Client) CreateOrganizationMarketplaceSubscription(orgname string, subsc
 
 // BatchRemoveOrganizationMarketplaceSubscriptions removes multiple marketplace subscriptions
 func (c *Client) BatchRemoveOrganizationMarketplaceSubscriptions(orgname string, subscriptionIDs []string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+
 	body := struct {
 		SubscriptionIDs []string `json:"subscription_ids"`
 	}{
@@ -65,6 +77,13 @@ func (c *Client) BatchRemoveOrganizationMarketplaceSubscriptions(orgname string,
 
 // DeleteOrganizationMarketplaceSubscription removes a specific marketplace subscription
 func (c *Client) DeleteOrganizationMarketplaceSubscription(orgname, subscriptionID string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+	if subscriptionID == "" {
+		return fmt.Errorf("subscriptionID is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/marketplace/%s", orgname, subscriptionID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete marketplace subscription request: %w", err)

--- a/lib/org_robot.go
+++ b/lib/org_robot.go
@@ -30,6 +30,10 @@ import (
 
 // GetRobotAccounts retrieves all robot accounts for an organization
 func (c *Client) GetRobotAccounts(orgname string) (*RobotAccounts, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/robots", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get robot accounts request: %w", err)
@@ -45,6 +49,13 @@ func (c *Client) GetRobotAccounts(orgname string) (*RobotAccounts, error) {
 
 // CreateRobotAccount creates a new robot account in an organization
 func (c *Client) CreateRobotAccount(orgname, robotShortname, description string, unstructured map[string]interface{}) (*RobotAccount, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if robotShortname == "" {
+		return nil, fmt.Errorf("robotShortname is required")
+	}
+
 	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), CreateRobotRequest{
 		Description:  description,
 		Unstructured: unstructured,
@@ -63,6 +74,13 @@ func (c *Client) CreateRobotAccount(orgname, robotShortname, description string,
 
 // GetRobotAccount retrieves details for a specific robot account
 func (c *Client) GetRobotAccount(orgname, robotShortname string) (*RobotAccount, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if robotShortname == "" {
+		return nil, fmt.Errorf("robotShortname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get robot account request: %w", err)
@@ -78,6 +96,13 @@ func (c *Client) GetRobotAccount(orgname, robotShortname string) (*RobotAccount,
 
 // DeleteRobotAccount deletes a robot account from an organization
 func (c *Client) DeleteRobotAccount(orgname, robotShortname string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+	if robotShortname == "" {
+		return fmt.Errorf("robotShortname is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete robot account request: %w", err)
@@ -92,6 +117,13 @@ func (c *Client) DeleteRobotAccount(orgname, robotShortname string) error {
 
 // RegenerateRobotToken regenerates the token for a robot account
 func (c *Client) RegenerateRobotToken(orgname, robotShortname string) (*RobotAccount, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if robotShortname == "" {
+		return nil, fmt.Errorf("robotShortname is required")
+	}
+
 	req, err := newRequest("POST", c.buildURL("/organization/%s/robots/%s/regenerate", orgname, robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create regenerate robot token request: %w", err)
@@ -109,6 +141,13 @@ func (c *Client) RegenerateRobotToken(orgname, robotShortname string) (*RobotAcc
 
 // GetRobotPermissions retrieves repository permissions for a robot account
 func (c *Client) GetRobotPermissions(orgname, robotShortname string) (*RobotPermissions, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if robotShortname == "" {
+		return nil, fmt.Errorf("robotShortname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/robots/%s/permissions", orgname, robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get robot permissions request: %w", err)
@@ -124,6 +163,19 @@ func (c *Client) GetRobotPermissions(orgname, robotShortname string) (*RobotPerm
 
 // SetRobotRepositoryPermission sets repository permission for a robot account
 func (c *Client) SetRobotRepositoryPermission(orgname, robotShortname, repository, role string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+	if robotShortname == "" {
+		return fmt.Errorf("robotShortname is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if role == "" {
+		return fmt.Errorf("role is required")
+	}
+
 	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/robots/%s/permissions/%s", orgname, robotShortname, repository), map[string]interface{}{
 		fieldRole: role,
 	})
@@ -140,6 +192,16 @@ func (c *Client) SetRobotRepositoryPermission(orgname, robotShortname, repositor
 
 // RemoveRobotRepositoryPermission removes repository permission for a robot account
 func (c *Client) RemoveRobotRepositoryPermission(orgname, robotShortname, repository string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+	if robotShortname == "" {
+		return fmt.Errorf("robotShortname is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/robots/%s/permissions/%s", orgname, robotShortname, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create remove robot repository permission request: %w", err)
@@ -156,6 +218,13 @@ func (c *Client) RemoveRobotRepositoryPermission(orgname, robotShortname, reposi
 
 // GetRobotFederation retrieves the federation configuration for an organization's robot account
 func (c *Client) GetRobotFederation(orgname, robotShortname string) (*RobotFederation, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if robotShortname == "" {
+		return nil, fmt.Errorf("robotShortname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/robots/%s/federation", orgname, robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get robot federation request: %w", err)
@@ -171,6 +240,13 @@ func (c *Client) GetRobotFederation(orgname, robotShortname string) (*RobotFeder
 
 // CreateRobotFederation creates or updates the federation configuration for an organization's robot account
 func (c *Client) CreateRobotFederation(orgname, robotShortname string, configs []RobotFederationConfig) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+	if robotShortname == "" {
+		return fmt.Errorf("robotShortname is required")
+	}
+
 	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/robots/%s/federation", orgname, robotShortname), configs)
 	if err != nil {
 		return fmt.Errorf("failed to create robot federation request: %w", err)
@@ -185,6 +261,13 @@ func (c *Client) CreateRobotFederation(orgname, robotShortname string, configs [
 
 // DeleteRobotFederation deletes the federation configuration for an organization's robot account
 func (c *Client) DeleteRobotFederation(orgname, robotShortname string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+	if robotShortname == "" {
+		return fmt.Errorf("robotShortname is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/robots/%s/federation", orgname, robotShortname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete robot federation request: %w", err)

--- a/lib/org_team.go
+++ b/lib/org_team.go
@@ -38,6 +38,10 @@ const (
 
 // GetTeams retrieves all teams for an organization
 func (c *Client) GetTeams(orgname string) ([]Team, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/teams", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get teams request: %w", err)
@@ -55,6 +59,16 @@ func (c *Client) GetTeams(orgname string) ([]Team, error) {
 
 // CreateTeam creates a new team in an organization
 func (c *Client) CreateTeam(orgname, teamname, description, role string) (*Team, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if teamname == "" {
+		return nil, fmt.Errorf("teamname is required")
+	}
+	if role == "" {
+		return nil, fmt.Errorf("role is required")
+	}
+
 	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/team/%s", orgname, teamname), CreateTeamRequest{
 		Name:        teamname,
 		Description: description,
@@ -74,6 +88,13 @@ func (c *Client) CreateTeam(orgname, teamname, description, role string) (*Team,
 
 // GetTeam retrieves details for a specific team
 func (c *Client) GetTeam(orgname, teamname string) (*Team, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if teamname == "" {
+		return nil, fmt.Errorf("teamname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/team/%s", orgname, teamname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get team request: %w", err)
@@ -89,6 +110,13 @@ func (c *Client) GetTeam(orgname, teamname string) (*Team, error) {
 
 // DeleteTeam deletes a team from an organization
 func (c *Client) DeleteTeam(orgname, teamname string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+	if teamname == "" {
+		return fmt.Errorf("teamname is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/team/%s", orgname, teamname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete team request: %w", err)
@@ -103,6 +131,16 @@ func (c *Client) DeleteTeam(orgname, teamname string) error {
 
 // UpdateTeam updates team settings
 func (c *Client) UpdateTeam(orgname, teamname, description, role string) (*Team, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if teamname == "" {
+		return nil, fmt.Errorf("teamname is required")
+	}
+	if role == "" {
+		return nil, fmt.Errorf("role is required")
+	}
+
 	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/team/%s", orgname, teamname), map[string]interface{}{
 		"description": description,
 		fieldRole:     role,
@@ -123,6 +161,13 @@ func (c *Client) UpdateTeam(orgname, teamname, description, role string) (*Team,
 
 // GetTeamMembers retrieves members of a team
 func (c *Client) GetTeamMembers(orgname, teamname string) (*TeamMembers, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if teamname == "" {
+		return nil, fmt.Errorf("teamname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/team/%s/members", orgname, teamname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get team members request: %w", err)
@@ -138,6 +183,16 @@ func (c *Client) GetTeamMembers(orgname, teamname string) (*TeamMembers, error) 
 
 // AddTeamMember adds a member to a team
 func (c *Client) AddTeamMember(orgname, teamname, membername string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+	if teamname == "" {
+		return fmt.Errorf("teamname is required")
+	}
+	if membername == "" {
+		return fmt.Errorf("membername is required")
+	}
+
 	req, err := newRequest("PUT", c.buildURL("/organization/%s/team/%s/members/%s", orgname, teamname, membername), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create add team member request: %w", err)
@@ -152,6 +207,16 @@ func (c *Client) AddTeamMember(orgname, teamname, membername string) error {
 
 // RemoveTeamMember removes a member from a team
 func (c *Client) RemoveTeamMember(orgname, teamname, membername string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+	if teamname == "" {
+		return fmt.Errorf("teamname is required")
+	}
+	if membername == "" {
+		return fmt.Errorf("membername is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/team/%s/members/%s", orgname, teamname, membername), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create remove team member request: %w", err)
@@ -168,6 +233,13 @@ func (c *Client) RemoveTeamMember(orgname, teamname, membername string) error {
 
 // GetTeamPermissions retrieves repository permissions for a team
 func (c *Client) GetTeamPermissions(orgname, teamname string) (*TeamPermissions, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if teamname == "" {
+		return nil, fmt.Errorf("teamname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/team/%s/permissions", orgname, teamname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get team permissions request: %w", err)
@@ -183,6 +255,19 @@ func (c *Client) GetTeamPermissions(orgname, teamname string) (*TeamPermissions,
 
 // SetTeamRepositoryPermission sets repository permission for a team
 func (c *Client) SetTeamRepositoryPermission(orgname, teamname, repository, role string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+	if teamname == "" {
+		return fmt.Errorf("teamname is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if role == "" {
+		return fmt.Errorf("role is required")
+	}
+
 	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/team/%s/permissions/%s", orgname, teamname, repository), map[string]interface{}{
 		fieldRole: role,
 	})
@@ -199,6 +284,16 @@ func (c *Client) SetTeamRepositoryPermission(orgname, teamname, repository, role
 
 // RemoveTeamRepositoryPermission removes repository permission for a team
 func (c *Client) RemoveTeamRepositoryPermission(orgname, teamname, repository string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+	if teamname == "" {
+		return fmt.Errorf("teamname is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/team/%s/permissions/%s", orgname, teamname, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create remove team repository permission request: %w", err)
@@ -215,6 +310,16 @@ func (c *Client) RemoveTeamRepositoryPermission(orgname, teamname, repository st
 
 // InviteTeamMember invites a member to a team via email
 func (c *Client) InviteTeamMember(orgname, teamname, email string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+	if teamname == "" {
+		return fmt.Errorf("teamname is required")
+	}
+	if email == "" {
+		return fmt.Errorf("email is required")
+	}
+
 	req, err := newRequest("PUT", c.buildURL("/organization/%s/team/%s/invite/%s", orgname, teamname, email), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create invite team member request: %w", err)
@@ -229,6 +334,16 @@ func (c *Client) InviteTeamMember(orgname, teamname, email string) error {
 
 // DeleteTeamInvite deletes a pending team invitation
 func (c *Client) DeleteTeamInvite(orgname, teamname, email string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+	if teamname == "" {
+		return fmt.Errorf("teamname is required")
+	}
+	if email == "" {
+		return fmt.Errorf("email is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/team/%s/invite/%s", orgname, teamname, email), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete team invite request: %w", err)

--- a/lib/organization.go
+++ b/lib/organization.go
@@ -31,6 +31,13 @@ import (
 
 // CreateOrganization creates a new organization
 func (c *Client) CreateOrganization(name, email string) (*Organization, error) {
+	if name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	if email == "" {
+		return nil, fmt.Errorf("email is required")
+	}
+
 	req, err := newRequestWithBody("POST", c.BaseURL+"/organization/", CreateOrganizationRequest{
 		Name:  name,
 		Email: email,
@@ -49,6 +56,10 @@ func (c *Client) CreateOrganization(name, email string) (*Organization, error) {
 
 // GetOrganization retrieves organization details
 func (c *Client) GetOrganization(orgname string) (*Organization, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization request: %w", err)
@@ -64,6 +75,10 @@ func (c *Client) GetOrganization(orgname string) (*Organization, error) {
 
 // DeleteOrganization deletes an organization
 func (c *Client) DeleteOrganization(orgname string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s", orgname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete organization request: %w", err)
@@ -78,6 +93,13 @@ func (c *Client) DeleteOrganization(orgname string) error {
 
 // UpdateOrganization updates organization settings
 func (c *Client) UpdateOrganization(orgname, email string) (*Organization, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if email == "" {
+		return nil, fmt.Errorf("email is required")
+	}
+
 	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s", orgname), map[string]interface{}{
 		"email": email,
 	})
@@ -97,6 +119,10 @@ func (c *Client) UpdateOrganization(orgname, email string) (*Organization, error
 
 // GetOrganizationMembers retrieves organization members
 func (c *Client) GetOrganizationMembers(orgname string) (*OrganizationMembers, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/members", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization members request: %w", err)
@@ -112,6 +138,13 @@ func (c *Client) GetOrganizationMembers(orgname string) (*OrganizationMembers, e
 
 // GetOrganizationMember gets information about a specific organization member
 func (c *Client) GetOrganizationMember(orgname, membername string) (*OrganizationMember, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if membername == "" {
+		return nil, fmt.Errorf("membername is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization member request: %w", err)
@@ -127,6 +160,13 @@ func (c *Client) GetOrganizationMember(orgname, membername string) (*Organizatio
 
 // AddOrganizationMember adds a member to an organization
 func (c *Client) AddOrganizationMember(orgname, membername string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+	if membername == "" {
+		return fmt.Errorf("membername is required")
+	}
+
 	req, err := newRequest("PUT", c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create add organization member request: %w", err)
@@ -141,6 +181,13 @@ func (c *Client) AddOrganizationMember(orgname, membername string) error {
 
 // RemoveOrganizationMember removes a member from an organization
 func (c *Client) RemoveOrganizationMember(orgname, membername string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+	if membername == "" {
+		return fmt.Errorf("membername is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create remove organization member request: %w", err)
@@ -157,6 +204,10 @@ func (c *Client) RemoveOrganizationMember(orgname, membername string) error {
 
 // GetOrganizationRepositories retrieves repositories for an organization
 func (c *Client) GetOrganizationRepositories(orgname string) (*OrganizationRepositories, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/repositories", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization repositories request: %w", err)
@@ -174,6 +225,10 @@ func (c *Client) GetOrganizationRepositories(orgname string) (*OrganizationRepos
 
 // GetOrganizationCollaborators gets the list of collaborators for an organization
 func (c *Client) GetOrganizationCollaborators(orgname string) (*Collaborators, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/collaborators", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization collaborators request: %w", err)

--- a/lib/permissions.go
+++ b/lib/permissions.go
@@ -19,6 +19,13 @@ import (
 
 // GetRepositoryPermissions retrieves permissions for a repository
 func (c *Client) GetRepositoryPermissions(namespace, repository string) (*RepositoryPermissions, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/permissions", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repository permissions request: %w", err)
@@ -35,6 +42,19 @@ func (c *Client) GetRepositoryPermissions(namespace, repository string) (*Reposi
 // SetRepositoryPermission sets permission for a user/robot on a repository
 // role should be one of: "read", "write", "admin"
 func (c *Client) SetRepositoryPermission(namespace, repository, username, role string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if username == "" {
+		return fmt.Errorf("username is required")
+	}
+	if role == "" {
+		return fmt.Errorf("role is required")
+	}
+
 	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/permissions/%s", namespace, repository, username), SetRepositoryPermissionRequest{
 		Role: role,
 	})
@@ -51,6 +71,16 @@ func (c *Client) SetRepositoryPermission(namespace, repository, username, role s
 
 // RemoveRepositoryPermission removes permission for a user/robot from a repository
 func (c *Client) RemoveRepositoryPermission(namespace, repository, username string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if username == "" {
+		return fmt.Errorf("username is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/permissions/%s", namespace, repository, username), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create remove repository permission request: %w", err)
@@ -67,6 +97,13 @@ func (c *Client) RemoveRepositoryPermission(namespace, repository, username stri
 
 // ListUserPermissions lists all user permissions for a repository
 func (c *Client) ListUserPermissions(namespace, repository string) (*RepositoryPermissions, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/permissions/user/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list user permissions request: %w", err)
@@ -82,6 +119,16 @@ func (c *Client) ListUserPermissions(namespace, repository string) (*RepositoryP
 
 // GetUserPermission gets permission for a specific user on a repository
 func (c *Client) GetUserPermission(namespace, repository, username string) (*RepositoryPermission, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if username == "" {
+		return nil, fmt.Errorf("username is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/permissions/user/%s", namespace, repository, username), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user permission request: %w", err)
@@ -98,6 +145,19 @@ func (c *Client) GetUserPermission(namespace, repository, username string) (*Rep
 // SetUserPermission sets permission for a user on a repository
 // role should be one of: "read", "write", "admin"
 func (c *Client) SetUserPermission(namespace, repository, username, role string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if username == "" {
+		return fmt.Errorf("username is required")
+	}
+	if role == "" {
+		return fmt.Errorf("role is required")
+	}
+
 	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/permissions/user/%s", namespace, repository, username), SetRepositoryPermissionRequest{
 		Role: role,
 	})
@@ -114,6 +174,16 @@ func (c *Client) SetUserPermission(namespace, repository, username, role string)
 
 // DeleteUserPermission removes permission for a user from a repository
 func (c *Client) DeleteUserPermission(namespace, repository, username string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if username == "" {
+		return fmt.Errorf("username is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/permissions/user/%s", namespace, repository, username), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete user permission request: %w", err)
@@ -128,6 +198,16 @@ func (c *Client) DeleteUserPermission(namespace, repository, username string) er
 
 // GetUserTransitivePermission gets the transitive permission for a user on a repository
 func (c *Client) GetUserTransitivePermission(namespace, repository, username string) (*RepositoryPermission, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if username == "" {
+		return nil, fmt.Errorf("username is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/permissions/user/%s/transitive", namespace, repository, username), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user transitive permission request: %w", err)
@@ -145,6 +225,13 @@ func (c *Client) GetUserTransitivePermission(namespace, repository, username str
 
 // ListTeamPermissions lists all team permissions for a repository
 func (c *Client) ListTeamPermissions(namespace, repository string) (*RepositoryPermissions, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/permissions/team/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list team permissions request: %w", err)
@@ -160,6 +247,16 @@ func (c *Client) ListTeamPermissions(namespace, repository string) (*RepositoryP
 
 // GetTeamPermission gets permission for a specific team on a repository
 func (c *Client) GetTeamPermission(namespace, repository, teamname string) (*RepositoryPermission, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if teamname == "" {
+		return nil, fmt.Errorf("teamname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/permissions/team/%s", namespace, repository, teamname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get team permission request: %w", err)
@@ -176,6 +273,19 @@ func (c *Client) GetTeamPermission(namespace, repository, teamname string) (*Rep
 // SetTeamPermission sets permission for a team on a repository
 // role should be one of: "read", "write", "admin"
 func (c *Client) SetTeamPermission(namespace, repository, teamname, role string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if teamname == "" {
+		return fmt.Errorf("teamname is required")
+	}
+	if role == "" {
+		return fmt.Errorf("role is required")
+	}
+
 	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/permissions/team/%s", namespace, repository, teamname), SetRepositoryPermissionRequest{
 		Role: role,
 	})
@@ -192,6 +302,16 @@ func (c *Client) SetTeamPermission(namespace, repository, teamname, role string)
 
 // DeleteTeamPermission removes permission for a team from a repository
 func (c *Client) DeleteTeamPermission(namespace, repository, teamname string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if teamname == "" {
+		return fmt.Errorf("teamname is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/permissions/team/%s", namespace, repository, teamname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete team permission request: %w", err)

--- a/lib/prototype.go
+++ b/lib/prototype.go
@@ -27,6 +27,10 @@ import (
 
 // GetPrototypes retrieves all permission prototypes for an organization
 func (c *Client) GetPrototypes(orgname string) (*Prototypes, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/prototypes", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get prototypes request: %w", err)
@@ -42,6 +46,10 @@ func (c *Client) GetPrototypes(orgname string) (*Prototypes, error) {
 
 // CreatePrototype creates a new permission prototype for an organization
 func (c *Client) CreatePrototype(orgname string, createReq *CreatePrototypeRequest) (*Prototype, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/prototypes", orgname), createReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create prototype request: %w", err)
@@ -57,6 +65,13 @@ func (c *Client) CreatePrototype(orgname string, createReq *CreatePrototypeReque
 
 // GetPrototype retrieves a specific prototype by UUID
 func (c *Client) GetPrototype(orgname, prototypeUUID string) (*Prototype, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if prototypeUUID == "" {
+		return nil, fmt.Errorf("prototypeUUID is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get prototype request: %w", err)
@@ -72,6 +87,13 @@ func (c *Client) GetPrototype(orgname, prototypeUUID string) (*Prototype, error)
 
 // UpdatePrototype updates an existing prototype
 func (c *Client) UpdatePrototype(orgname, prototypeUUID string, updateReq *UpdatePrototypeRequest) (*Prototype, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if prototypeUUID == "" {
+		return nil, fmt.Errorf("prototypeUUID is required")
+	}
+
 	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeUUID), updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update prototype request: %w", err)
@@ -87,6 +109,13 @@ func (c *Client) UpdatePrototype(orgname, prototypeUUID string, updateReq *Updat
 
 // DeletePrototype deletes a prototype
 func (c *Client) DeletePrototype(orgname, prototypeUUID string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+	if prototypeUUID == "" {
+		return fmt.Errorf("prototypeUUID is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeUUID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete prototype request: %w", err)

--- a/lib/proxy_cache.go
+++ b/lib/proxy_cache.go
@@ -16,6 +16,10 @@ import (
 
 // GetProxyCacheConfig retrieves proxy cache configuration for an organization
 func (c *Client) GetProxyCacheConfig(orgname string) (*ProxyCacheConfig, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/proxycache", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get proxy cache config request: %w", err)
@@ -31,6 +35,13 @@ func (c *Client) GetProxyCacheConfig(orgname string) (*ProxyCacheConfig, error) 
 
 // CreateProxyCacheConfig creates proxy cache configuration for an organization
 func (c *Client) CreateProxyCacheConfig(orgname, upstreamRegistry string, insecure bool, expiration int) (*ProxyCacheConfig, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+	if upstreamRegistry == "" {
+		return nil, fmt.Errorf("upstreamRegistry is required")
+	}
+
 	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/proxycache", orgname), map[string]interface{}{
 		"upstream_registry": upstreamRegistry,
 		"insecure":          insecure,
@@ -50,6 +61,10 @@ func (c *Client) CreateProxyCacheConfig(orgname, upstreamRegistry string, insecu
 
 // DeleteProxyCacheConfig deletes proxy cache configuration for an organization
 func (c *Client) DeleteProxyCacheConfig(orgname string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/proxycache", orgname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete proxy cache config request: %w", err)

--- a/lib/quota.go
+++ b/lib/quota.go
@@ -17,6 +17,10 @@ import (
 
 // GetQuota retrieves quota information for an organization
 func (c *Client) GetQuota(orgname string) (*Quota, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/organization/%s/quota", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get quota request: %w", err)
@@ -32,6 +36,10 @@ func (c *Client) GetQuota(orgname string) (*Quota, error) {
 
 // CreateQuota creates a quota for an organization
 func (c *Client) CreateQuota(orgname string, limitBytes int64) (*Quota, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/quota", orgname), CreateQuotaRequest{
 		LimitBytes: limitBytes,
 	})
@@ -49,6 +57,10 @@ func (c *Client) CreateQuota(orgname string, limitBytes int64) (*Quota, error) {
 
 // UpdateQuota updates quota limits for an organization
 func (c *Client) UpdateQuota(orgname string, limitBytes int64) (*Quota, error) {
+	if orgname == "" {
+		return nil, fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/quota", orgname), CreateQuotaRequest{
 		LimitBytes: limitBytes,
 	})
@@ -66,6 +78,10 @@ func (c *Client) UpdateQuota(orgname string, limitBytes int64) (*Quota, error) {
 
 // DeleteQuota deletes quota for an organization
 func (c *Client) DeleteQuota(orgname string) error {
+	if orgname == "" {
+		return fmt.Errorf("orgname is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/organization/%s/quota", orgname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete quota request: %w", err)

--- a/lib/repository.go
+++ b/lib/repository.go
@@ -48,6 +48,13 @@ type RepositoryWithTags struct {
 
 // GetRepository returns a repository with tags information baked in
 func (c *Client) GetRepository(namespace, repository string) (RepositoryWithTags, error) {
+	if namespace == "" {
+		return RepositoryWithTags{}, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return RepositoryWithTags{}, fmt.Errorf("repository is required")
+	}
+
 	repoURL := c.buildURL("/repository/%s/%s", namespace, repository)
 	req, err := newRequest("GET", repoURL, nil)
 	if err != nil {
@@ -72,6 +79,16 @@ func (c *Client) GetRepository(namespace, repository string) (RepositoryWithTags
 
 // CreateRepository creates a new repository
 func (c *Client) CreateRepository(namespace, repository, visibility, description string) (*Repository, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if visibility == "" {
+		return nil, fmt.Errorf("visibility is required")
+	}
+
 	req, err := newRequestWithBody("POST", c.BaseURL+"/repository", CreateRepositoryRequest{
 		Repository:  repository,
 		Namespace:   namespace,
@@ -92,6 +109,13 @@ func (c *Client) CreateRepository(namespace, repository, visibility, description
 
 // UpdateRepository updates an existing repository
 func (c *Client) UpdateRepository(namespace, repository, description, visibility string) (*Repository, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
 	updateReq := UpdateRepositoryRequest{}
 
 	// Only include fields that are not empty
@@ -117,6 +141,13 @@ func (c *Client) UpdateRepository(namespace, repository, description, visibility
 
 // DeleteRepository deletes a repository
 func (c *Client) DeleteRepository(namespace, repository string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s", namespace, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete repository request: %w", err)
@@ -167,6 +198,16 @@ func (c *Client) ListRepositories(namespace string, public, starred, popularity 
 
 // ChangeRepositoryVisibility changes the visibility (public/private) of a repository
 func (c *Client) ChangeRepositoryVisibility(namespace, repository, visibility string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if visibility == "" {
+		return fmt.Errorf("visibility is required")
+	}
+
 	body := struct {
 		Visibility string `json:"visibility"`
 	}{
@@ -186,6 +227,13 @@ func (c *Client) ChangeRepositoryVisibility(namespace, repository, visibility st
 
 // ListTags lists tags for a repository
 func (c *Client) ListTags(namespace, repository string, limit int, onlyActive bool) (*RepositoryTags, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/tag/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list tags request: %w", err)

--- a/lib/repotoken.go
+++ b/lib/repotoken.go
@@ -23,6 +23,13 @@ import (
 //
 // Deprecated: Use robot accounts instead.
 func (c *Client) GetRepoTokens(namespace, repository string) (*RepoTokens, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/tokens", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repo tokens request: %w", err)
@@ -40,6 +47,13 @@ func (c *Client) GetRepoTokens(namespace, repository string) (*RepoTokens, error
 //
 // Deprecated: Use robot accounts instead.
 func (c *Client) CreateRepoToken(namespace, repository string, createReq *CreateRepoTokenRequest) (*RepoToken, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
 	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/tokens", namespace, repository), createReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create repo token request: %w", err)
@@ -57,6 +71,16 @@ func (c *Client) CreateRepoToken(namespace, repository string, createReq *Create
 //
 // Deprecated: Use robot accounts instead.
 func (c *Client) GetRepoToken(namespace, repository, code string) (*RepoToken, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if code == "" {
+		return nil, fmt.Errorf("code is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/tokens/%s", namespace, repository, code), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repo token request: %w", err)
@@ -74,6 +98,16 @@ func (c *Client) GetRepoToken(namespace, repository, code string) (*RepoToken, e
 //
 // Deprecated: Use robot accounts instead.
 func (c *Client) UpdateRepoToken(namespace, repository, code string, updateReq *UpdateRepoTokenRequest) (*RepoToken, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if code == "" {
+		return nil, fmt.Errorf("code is required")
+	}
+
 	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/tokens/%s", namespace, repository, code), updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update repo token request: %w", err)
@@ -91,6 +125,16 @@ func (c *Client) UpdateRepoToken(namespace, repository, code string, updateReq *
 //
 // Deprecated: Use robot accounts instead.
 func (c *Client) DeleteRepoToken(namespace, repository, code string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if code == "" {
+		return fmt.Errorf("code is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/tokens/%s", namespace, repository, code), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete repo token request: %w", err)

--- a/lib/robot.go
+++ b/lib/robot.go
@@ -37,6 +37,10 @@ func (c *Client) GetUserRobotAccounts() (*RobotAccounts, error) {
 
 // GetUserRobotAccount retrieves a specific robot account for the authenticated user
 func (c *Client) GetUserRobotAccount(robotShortname string) (*RobotAccount, error) {
+	if robotShortname == "" {
+		return nil, fmt.Errorf("robotShortname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/user/robots/%s", robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user robot request: %w", err)
@@ -52,6 +56,10 @@ func (c *Client) GetUserRobotAccount(robotShortname string) (*RobotAccount, erro
 
 // CreateUserRobotAccount creates a new robot account for the authenticated user
 func (c *Client) CreateUserRobotAccount(robotShortname, description string, unstructured map[string]interface{}) (*RobotAccount, error) {
+	if robotShortname == "" {
+		return nil, fmt.Errorf("robotShortname is required")
+	}
+
 	createReq := CreateRobotRequest{
 		Description:  description,
 		Unstructured: unstructured,
@@ -72,6 +80,10 @@ func (c *Client) CreateUserRobotAccount(robotShortname, description string, unst
 
 // DeleteUserRobotAccount deletes a robot account for the authenticated user
 func (c *Client) DeleteUserRobotAccount(robotShortname string) error {
+	if robotShortname == "" {
+		return fmt.Errorf("robotShortname is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/user/robots/%s", robotShortname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete user robot request: %w", err)
@@ -86,6 +98,10 @@ func (c *Client) DeleteUserRobotAccount(robotShortname string) error {
 
 // RegenerateUserRobotToken regenerates the token for a user's robot account
 func (c *Client) RegenerateUserRobotToken(robotShortname string) (*RobotAccount, error) {
+	if robotShortname == "" {
+		return nil, fmt.Errorf("robotShortname is required")
+	}
+
 	req, err := newRequest("POST", c.buildURL("/user/robots/%s/regenerate", robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create regenerate user robot token request: %w", err)
@@ -101,6 +117,10 @@ func (c *Client) RegenerateUserRobotToken(robotShortname string) (*RobotAccount,
 
 // GetUserRobotPermissions retrieves the repository permissions for a user's robot account
 func (c *Client) GetUserRobotPermissions(robotShortname string) (*RobotPermissions, error) {
+	if robotShortname == "" {
+		return nil, fmt.Errorf("robotShortname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/user/robots/%s/permissions", robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user robot permissions request: %w", err)
@@ -116,6 +136,10 @@ func (c *Client) GetUserRobotPermissions(robotShortname string) (*RobotPermissio
 
 // GetUserRobotFederation retrieves the federation configuration for a user's robot account
 func (c *Client) GetUserRobotFederation(robotShortname string) (*RobotFederation, error) {
+	if robotShortname == "" {
+		return nil, fmt.Errorf("robotShortname is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/user/robots/%s/federation", robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user robot federation request: %w", err)
@@ -131,6 +155,10 @@ func (c *Client) GetUserRobotFederation(robotShortname string) (*RobotFederation
 
 // CreateUserRobotFederation creates or updates the federation configuration for a user's robot account
 func (c *Client) CreateUserRobotFederation(robotShortname string, configs []RobotFederationConfig) error {
+	if robotShortname == "" {
+		return fmt.Errorf("robotShortname is required")
+	}
+
 	req, err := newRequestWithBody("POST", c.buildURL("/user/robots/%s/federation", robotShortname), configs)
 	if err != nil {
 		return fmt.Errorf("failed to create user robot federation request: %w", err)
@@ -145,6 +173,10 @@ func (c *Client) CreateUserRobotFederation(robotShortname string, configs []Robo
 
 // DeleteUserRobotFederation deletes the federation configuration for a user's robot account
 func (c *Client) DeleteUserRobotFederation(robotShortname string) error {
+	if robotShortname == "" {
+		return fmt.Errorf("robotShortname is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/user/robots/%s/federation", robotShortname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete user robot federation request: %w", err)

--- a/lib/search.go
+++ b/lib/search.go
@@ -18,6 +18,10 @@ import (
 
 // SearchRepositories searches for repositories matching the query
 func (c *Client) SearchRepositories(query string, page int) (*SearchRepositoryResult, error) {
+	if query == "" {
+		return nil, fmt.Errorf("query is required")
+	}
+
 	req, err := newRequest("GET", c.BaseURL+"/find/repositories", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create search repositories request: %w", err)
@@ -39,6 +43,10 @@ func (c *Client) SearchRepositories(query string, page int) (*SearchRepositoryRe
 
 // SearchAll searches for all entity types (repositories, users, organizations, teams, robots)
 func (c *Client) SearchAll(query string) (*SearchAllResult, error) {
+	if query == "" {
+		return nil, fmt.Errorf("query is required")
+	}
+
 	req, err := newRequest("GET", c.BaseURL+"/find/all", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create search all request: %w", err)

--- a/lib/secscan.go
+++ b/lib/secscan.go
@@ -17,6 +17,16 @@ import (
 
 // GetManifestSecurity retrieves security scan information for a specific manifest
 func (c *Client) GetManifestSecurity(namespace, repository, manifestRef string, vulnerabilities bool) (*SecurityScan, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if manifestRef == "" {
+		return nil, fmt.Errorf("manifestRef is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/manifest/%s/security", namespace, repository, manifestRef), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest security request: %w", err)

--- a/lib/tag.go
+++ b/lib/tag.go
@@ -21,6 +21,16 @@ import (
 
 // GetTag retrieves detailed information about a specific tag
 func (c *Client) GetTag(namespace, repository, tag string) (*Tag, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if tag == "" {
+		return nil, fmt.Errorf("tag is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get tag request: %w", err)
@@ -36,6 +46,16 @@ func (c *Client) GetTag(namespace, repository, tag string) (*Tag, error) {
 
 // UpdateTag updates tag metadata (currently supports expiration)
 func (c *Client) UpdateTag(namespace, repository, tag, expiration string) (*Tag, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if tag == "" {
+		return nil, fmt.Errorf("tag is required")
+	}
+
 	updateReq := UpdateTagRequest{}
 
 	if expiration != "" {
@@ -57,6 +77,16 @@ func (c *Client) UpdateTag(namespace, repository, tag, expiration string) (*Tag,
 
 // DeleteTag deletes a specific tag from a repository
 func (c *Client) DeleteTag(namespace, repository, tag string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if tag == "" {
+		return fmt.Errorf("tag is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete tag request: %w", err)
@@ -71,6 +101,16 @@ func (c *Client) DeleteTag(namespace, repository, tag string) error {
 
 // GetTagHistory retrieves the history of changes for a specific tag
 func (c *Client) GetTagHistory(namespace, repository, tag string) (*TagHistory, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if tag == "" {
+		return nil, fmt.Errorf("tag is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/tag/%s/history", namespace, repository, tag), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get tag history request: %w", err)
@@ -86,6 +126,19 @@ func (c *Client) GetTagHistory(namespace, repository, tag string) (*TagHistory, 
 
 // RevertTag reverts a tag to a previous state by manifest digest
 func (c *Client) RevertTag(namespace, repository, tag, manifestDigest string) (*Tag, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if tag == "" {
+		return nil, fmt.Errorf("tag is required")
+	}
+	if manifestDigest == "" {
+		return nil, fmt.Errorf("manifestDigest is required")
+	}
+
 	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/tag/%s/revert", namespace, repository, tag), map[string]interface{}{
 		"manifest_digest": manifestDigest,
 	})
@@ -103,6 +156,19 @@ func (c *Client) RevertTag(namespace, repository, tag, manifestDigest string) (*
 
 // ChangeTag creates or moves a tag to point at a specific manifest digest
 func (c *Client) ChangeTag(namespace, repository, tag, manifestDigest string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if tag == "" {
+		return fmt.Errorf("tag is required")
+	}
+	if manifestDigest == "" {
+		return fmt.Errorf("manifestDigest is required")
+	}
+
 	body := struct {
 		ManifestDigest string `json:"manifest_digest"`
 	}{
@@ -122,6 +188,19 @@ func (c *Client) ChangeTag(namespace, repository, tag, manifestDigest string) er
 
 // RestoreTag restores a tag to a previous image
 func (c *Client) RestoreTag(namespace, repository, tag, manifestDigest string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if tag == "" {
+		return fmt.Errorf("tag is required")
+	}
+	if manifestDigest == "" {
+		return fmt.Errorf("manifestDigest is required")
+	}
+
 	body := struct {
 		ManifestDigest string `json:"manifest_digest"`
 	}{

--- a/lib/trigger.go
+++ b/lib/trigger.go
@@ -28,6 +28,13 @@ import (
 
 // GetTriggers retrieves all build triggers for a repository
 func (c *Client) GetTriggers(namespace, repository string) (*BuildTriggers, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/trigger/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get triggers request: %w", err)
@@ -43,6 +50,16 @@ func (c *Client) GetTriggers(namespace, repository string) (*BuildTriggers, erro
 
 // GetTrigger retrieves a specific build trigger by UUID
 func (c *Client) GetTrigger(namespace, repository, triggerUUID string) (*BuildTrigger, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if triggerUUID == "" {
+		return nil, fmt.Errorf("triggerUUID is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get trigger request: %w", err)
@@ -58,6 +75,16 @@ func (c *Client) GetTrigger(namespace, repository, triggerUUID string) (*BuildTr
 
 // DeleteTrigger deletes a build trigger
 func (c *Client) DeleteTrigger(namespace, repository, triggerUUID string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if triggerUUID == "" {
+		return fmt.Errorf("triggerUUID is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete trigger request: %w", err)
@@ -72,6 +99,16 @@ func (c *Client) DeleteTrigger(namespace, repository, triggerUUID string) error 
 
 // UpdateTrigger updates a build trigger (enable/disable)
 func (c *Client) UpdateTrigger(namespace, repository, triggerUUID string, enabled bool) (*BuildTrigger, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if triggerUUID == "" {
+		return nil, fmt.Errorf("triggerUUID is required")
+	}
+
 	body := map[string]interface{}{
 		"enabled": enabled,
 	}
@@ -91,6 +128,16 @@ func (c *Client) UpdateTrigger(namespace, repository, triggerUUID string, enable
 
 // StartTriggerBuild manually starts a build from a trigger
 func (c *Client) StartTriggerBuild(namespace, repository, triggerUUID string, triggerReq *ManualTriggerRequest) (*Build, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if triggerUUID == "" {
+		return nil, fmt.Errorf("triggerUUID is required")
+	}
+
 	var body interface{}
 	if triggerReq != nil {
 		body = triggerReq
@@ -111,6 +158,16 @@ func (c *Client) StartTriggerBuild(namespace, repository, triggerUUID string, tr
 
 // ActivateTrigger activates a build trigger with configuration
 func (c *Client) ActivateTrigger(namespace, repository, triggerUUID string, activateReq *ActivateTriggerRequest) (*BuildTrigger, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if triggerUUID == "" {
+		return nil, fmt.Errorf("triggerUUID is required")
+	}
+
 	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/trigger/%s/activate", namespace, repository, triggerUUID), activateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create activate trigger request: %w", err)
@@ -126,6 +183,16 @@ func (c *Client) ActivateTrigger(namespace, repository, triggerUUID string, acti
 
 // GetTriggerBuilds gets the builds started by a specific trigger
 func (c *Client) GetTriggerBuilds(namespace, repository, triggerUUID string, limit int) (*Builds, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if triggerUUID == "" {
+		return nil, fmt.Errorf("triggerUUID is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/trigger/%s/builds", namespace, repository, triggerUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get trigger builds request: %w", err)

--- a/lib/user.go
+++ b/lib/user.go
@@ -52,6 +52,13 @@ func (c *Client) GetStarredRepositories() (*StarredRepositories, error) {
 
 // StarRepository adds a repository to the user's starred list
 func (c *Client) StarRepository(namespace, repository string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+
 	req, err := newRequest("PUT", c.buildURL("/repository/%s/%s/star", namespace, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create star repository request: %w", err)
@@ -66,6 +73,13 @@ func (c *Client) StarRepository(namespace, repository string) error {
 
 // UnstarRepository removes a repository from the user's starred list
 func (c *Client) UnstarRepository(namespace, repository string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+
 	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/star", namespace, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create unstar repository request: %w", err)
@@ -80,6 +94,10 @@ func (c *Client) UnstarRepository(namespace, repository string) error {
 
 // GetUserByUsername retrieves information about a specific user
 func (c *Client) GetUserByUsername(username string) (*UserDetails, error) {
+	if username == "" {
+		return nil, fmt.Errorf("username is required")
+	}
+
 	req, err := newRequest("GET", c.buildURL("/users/%s", username), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user by username request: %w", err)


### PR DESCRIPTION
## Summary
- Adds non-empty string validation at the top of every exported Client method for required parameters
- Empty strings now return descriptive errors instead of producing malformed API URLs (e.g. `/api/v1/repository//`)
- 354 validation checks across ~130 methods in 26 files
- Optional params (description, expiration, tagPattern, etc.) are not validated
- Uses plain `fmt.Errorf` for validation errors (client-side, not API errors)

Closes #167