### PR TITLE
feat: add configurable retry with rate-limit (429) handling

### DIFF
--- a/lib/client.go
+++ b/lib/client.go
@@ -27,11 +27,14 @@ package lib
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -41,10 +44,18 @@ const queryValueTrue = "true"
 // DefaultQuayURL is the default Quay.io API base URL.
 const DefaultQuayURL = "https://quay.io/api/v1"
 
+// RetryConfig controls automatic retry behavior for failed HTTP requests.
+type RetryConfig struct {
+	MaxRetries     int
+	InitialBackoff time.Duration
+	MaxBackoff     time.Duration
+}
+
 type Client struct {
 	BearerToken string
 	BaseURL     string
 	Version     string
+	Retry       *RetryConfig
 	HTTPClient  *http.Client
 }
 
@@ -84,42 +95,141 @@ func (c *Client) buildURL(pathFmt string, args ...any) string {
 }
 
 func (c *Client) do(req *http.Request, v any, acceptedStatuses ...int) error {
+	c.setHeaders(req)
+
+	maxAttempts := 1
+	if c.Retry != nil && c.Retry.MaxRetries > 0 {
+		maxAttempts = 1 + c.Retry.MaxRetries
+	}
+
+	var lastErr error
+	for attempt := range maxAttempts {
+		result, err := c.doOnce(req, v, acceptedStatuses)
+		if err == nil {
+			return result
+		}
+
+		lastErr = err
+		if !c.shouldRetry(attempt, maxAttempts) {
+			return err
+		}
+
+		retryable, retryAfter := isRetryableError(err)
+		if !retryable {
+			return err
+		}
+
+		c.backoff(attempt, retryAfter)
+	}
+
+	return lastErr
+}
+
+func (c *Client) setHeaders(req *http.Request) {
 	if c.BearerToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.BearerToken)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "go-quay/"+c.Version)
+}
 
+type retryableError struct {
+	err        error
+	retryAfter int
+}
+
+func (e *retryableError) Error() string { return e.err.Error() }
+func (e *retryableError) Unwrap() error { return e.err }
+
+func (c *Client) doOnce(req *http.Request, v any, acceptedStatuses []int) (error, error) {
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return err
+		return nil, &retryableError{err: err}
 	}
 	defer resp.Body.Close()
 
-	accepted := false
-	for _, s := range acceptedStatuses {
-		if resp.StatusCode == s {
-			accepted = true
-			break
+	if isAccepted(resp.StatusCode, acceptedStatuses) {
+		if v != nil && resp.StatusCode != http.StatusNoContent {
+			return decodeJSON(resp.Body, v), nil
+		}
+		return nil, nil
+	}
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
+	apiErr := buildAPIError(resp.StatusCode, body)
+
+	if isRetryableStatus(resp.StatusCode) {
+		return nil, &retryableError{
+			err:        apiErr,
+			retryAfter: parseRetryAfter(resp.Header.Get("Retry-After")),
 		}
 	}
-	if !accepted {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
 
-		var quayErr QuayError
-		if json.Unmarshal(body, &quayErr) == nil && quayErr.Message != "" {
-			quayErr.Status = resp.StatusCode
-			return &quayErr
+	return nil, apiErr
+}
+
+func isAccepted(status int, accepted []int) bool {
+	for _, s := range accepted {
+		if status == s {
+			return true
 		}
+	}
+	return false
+}
 
-		return fmt.Errorf("unexpected status code: %d, response: %s", resp.StatusCode, string(body))
+func buildAPIError(status int, body []byte) error {
+	var quayErr QuayError
+	if json.Unmarshal(body, &quayErr) == nil && quayErr.Message != "" {
+		quayErr.Status = status
+		return &quayErr
+	}
+	return fmt.Errorf("unexpected status code: %d, response: %s", status, string(body))
+}
+
+func isRetryableError(err error) (bool, int) {
+	var re *retryableError
+	if errors.As(err, &re) {
+		return true, re.retryAfter
+	}
+	return false, 0
+}
+
+func (c *Client) shouldRetry(attempt, maxAttempts int) bool {
+	return c.Retry != nil && attempt < maxAttempts-1
+}
+
+func (c *Client) backoff(attempt int, retryAfterSecs int) {
+	if c.Retry == nil {
+		return
 	}
 
-	if v != nil && resp.StatusCode != http.StatusNoContent {
-		return decodeJSON(resp.Body, v)
+	var wait time.Duration
+	if retryAfterSecs > 0 {
+		wait = time.Duration(retryAfterSecs) * time.Second
+	} else {
+		wait = c.Retry.InitialBackoff * time.Duration(math.Pow(2, float64(attempt)))
 	}
 
-	return nil
+	if c.Retry.MaxBackoff > 0 && wait > c.Retry.MaxBackoff {
+		wait = c.Retry.MaxBackoff
+	}
+
+	time.Sleep(wait)
+}
+
+func isRetryableStatus(status int) bool {
+	return status == http.StatusTooManyRequests || status >= http.StatusInternalServerError
+}
+
+func parseRetryAfter(header string) int {
+	if header == "" {
+		return 0
+	}
+	seconds, err := strconv.Atoi(header)
+	if err != nil {
+		return 0
+	}
+	return seconds
 }
 
 func (c *Client) get(req *http.Request, v any) error {

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 const (
@@ -505,5 +507,191 @@ func TestDeleteRequestError(t *testing.T) {
 	err = client.delete(req)
 	if err == nil {
 		t.Error("Expected error for 500 response, got nil")
+	}
+}
+
+func TestRetryOn429(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := attempts.Add(1)
+		if n <= 2 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte(`{"error":"rate_limited"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"name":"success"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL(testTokenValue, server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	client.Retry = &RetryConfig{
+		MaxRetries:     3,
+		InitialBackoff: 1 * time.Millisecond,
+		MaxBackoff:     10 * time.Millisecond,
+	}
+
+	req, err := newRequest(httpMethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	var result map[string]string
+	err = client.get(req, &result)
+	if err != nil {
+		t.Fatalf("Expected success after retries, got error: %v", err)
+	}
+
+	if result["name"] != "success" {
+		t.Errorf("Expected name 'success', got '%s'", result["name"])
+	}
+
+	if attempts.Load() != 3 {
+		t.Errorf("Expected 3 attempts, got %d", attempts.Load())
+	}
+}
+
+func TestRetryOn500(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := attempts.Add(1)
+		if n == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":"internal"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL(testTokenValue, server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	client.Retry = &RetryConfig{
+		MaxRetries:     2,
+		InitialBackoff: 1 * time.Millisecond,
+		MaxBackoff:     10 * time.Millisecond,
+	}
+
+	req, err := newRequest(httpMethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	var result map[string]any
+	err = client.get(req, &result)
+	if err != nil {
+		t.Fatalf("Expected success after retry, got error: %v", err)
+	}
+
+	if attempts.Load() != 2 {
+		t.Errorf("Expected 2 attempts, got %d", attempts.Load())
+	}
+}
+
+func TestRetryExhausted(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"error":"rate_limited"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL(testTokenValue, server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	client.Retry = &RetryConfig{
+		MaxRetries:     2,
+		InitialBackoff: 1 * time.Millisecond,
+		MaxBackoff:     10 * time.Millisecond,
+	}
+
+	req, err := newRequest(httpMethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	var result map[string]string
+	err = client.get(req, &result)
+	if err == nil {
+		t.Fatal("Expected error after exhausted retries, got nil")
+	}
+
+	if attempts.Load() != 3 {
+		t.Errorf("Expected 3 attempts (1 + 2 retries), got %d", attempts.Load())
+	}
+}
+
+func TestNoRetryOn4xx(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error":"not_found"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL(testTokenValue, server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	client.Retry = &RetryConfig{
+		MaxRetries:     3,
+		InitialBackoff: 1 * time.Millisecond,
+	}
+
+	req, err := newRequest(httpMethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	var result map[string]string
+	err = client.get(req, &result)
+	if err == nil {
+		t.Fatal("Expected error for 404, got nil")
+	}
+
+	if attempts.Load() != 1 {
+		t.Errorf("Expected 1 attempt (no retry on 404), got %d", attempts.Load())
+	}
+}
+
+func TestNoRetryWithoutConfig(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"internal"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL(testTokenValue, server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	req, err := newRequest(httpMethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	var result map[string]string
+	err = client.get(req, &result)
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	if attempts.Load() != 1 {
+		t.Errorf("Expected 1 attempt (no retry config), got %d", attempts.Load())
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `RetryConfig` struct with `MaxRetries`, `InitialBackoff`, and `MaxBackoff` fields
- Retries on HTTP 429 (honoring `Retry-After` header) and 5xx errors with exponential backoff
- Does not retry on 4xx client errors (except 429)
- No retry behavior by default — callers opt in via `client.Retry = &lib.RetryConfig{...}`
- Refactors `do()` into smaller functions to stay under cyclomatic complexity limits
- Adds 5 tests covering: 429 retry, 500 retry, retry exhaustion, no retry on 404, no retry without config

Closes #131