### PR TITLE
feat: add automatic pagination helpers for repositories and tags

### DIFF
--- a/lib/repository.go
+++ b/lib/repository.go
@@ -196,6 +196,59 @@ func (c *Client) ListRepositories(namespace string, public, starred, popularity 
 	return &repos, nil
 }
 
+// ListAllRepositories fetches all repositories by following pagination automatically.
+func (c *Client) ListAllRepositories(namespace string, public, starred, popularity bool) ([]OrganizationRepository, error) {
+	var all []OrganizationRepository
+	page := 1
+	const pageSize = 100
+
+	for {
+		repos, err := c.ListRepositories(namespace, public, starred, popularity, page, pageSize)
+		if err != nil {
+			return nil, err
+		}
+
+		all = append(all, repos.Repositories...)
+
+		if !repos.HasAdditional {
+			break
+		}
+		page++
+	}
+
+	return all, nil
+}
+
+// ListAllTags fetches all tags for a repository by following pagination automatically.
+func (c *Client) ListAllTags(namespace, repository string, onlyActive bool) ([]Tag, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
+	var all []Tag
+	page := 1
+	const pageSize = 100
+
+	for {
+		tags, err := c.ListTagsPage(namespace, repository, pageSize, page, onlyActive)
+		if err != nil {
+			return nil, err
+		}
+
+		all = append(all, tags.Tags...)
+
+		if !tags.HasAdditional {
+			break
+		}
+		page++
+	}
+
+	return all, nil
+}
+
 // ChangeRepositoryVisibility changes the visibility (public/private) of a repository
 func (c *Client) ChangeRepositoryVisibility(namespace, repository, visibility string) error {
 	if namespace == "" {
@@ -223,6 +276,40 @@ func (c *Client) ChangeRepositoryVisibility(namespace, repository, visibility st
 	}
 
 	return nil
+}
+
+// ListTagsPage lists tags for a repository with pagination support.
+func (c *Client) ListTagsPage(namespace, repository string, limit, page int, onlyActive bool) (*RepositoryTags, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/tag/", namespace, repository), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create list tags request: %w", err)
+	}
+
+	params := map[string]string{}
+	if limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", limit)
+	}
+	if page > 0 {
+		params["page"] = fmt.Sprintf("%d", page)
+	}
+	if onlyActive {
+		params["onlyActiveTags"] = queryValueTrue
+	}
+	addQueryParams(req, params)
+
+	var tags RepositoryTags
+	if err := c.get(req, &tags); err != nil {
+		return nil, fmt.Errorf("failed to list tags: %w", err)
+	}
+
+	return &tags, nil
 }
 
 // ListTags lists tags for a repository

--- a/lib/repository_test.go
+++ b/lib/repository_test.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -379,5 +380,70 @@ func TestRepositoryHTTPErrors(t *testing.T) {
 	err = client.ChangeRepositoryVisibility(testNamespace, testRepository, "public")
 	if err == nil {
 		t.Error("Expected error from ChangeRepositoryVisibility, got nil")
+	}
+}
+
+func TestListAllRepositories(t *testing.T) {
+	page := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page++
+		hasMore := page < 3
+		repos := RepositoryList{
+			Repositories: []OrganizationRepository{
+				{Name: fmt.Sprintf("repo-%d", page)},
+			},
+			HasAdditional: hasMore,
+		}
+		data, _ := json.Marshal(repos)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(data)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL(testTokenValue, server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	repos, err := client.ListAllRepositories(testNamespace, true, false, false)
+	if err != nil {
+		t.Fatalf("ListAllRepositories returned error: %v", err)
+	}
+
+	if len(repos) != 3 {
+		t.Errorf("Expected 3 repos across 3 pages, got %d", len(repos))
+	}
+}
+
+func TestListAllTags(t *testing.T) {
+	page := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page++
+		hasMore := page < 2
+		tags := RepositoryTags{
+			Tags:          []Tag{{Name: fmt.Sprintf("v%d", page)}},
+			Page:          page,
+			HasAdditional: hasMore,
+		}
+		data, _ := json.Marshal(tags)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(data)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL(testTokenValue, server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	tags, err := client.ListAllTags(testNamespace, testRepository, true)
+	if err != nil {
+		t.Fatalf("ListAllTags returned error: %v", err)
+	}
+
+	if len(tags) != 2 {
+		t.Errorf("Expected 2 tags across 2 pages, got %d", len(tags))
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `ListAllRepositories()` that auto-paginates through all repository pages
- Adds `ListAllTags()` that auto-paginates through all tag pages
- Adds `ListTagsPage()` with explicit page parameter for manual pagination control
- Includes tests verifying multi-page fetching

Closes #134