### PR TITLE
feat: add global --output format flag (json/yaml/table)

### DIFF
--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -14,4 +14,9 @@ const (
 	cmdOrganization = "organization"
 	cmdTag          = "tag"
 	cmdMembers      = "members"
+
+	// Output format constants
+	outputJSON  = "json"
+	outputYAML  = "yaml"
+	outputTable = "table"
 )

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -5,7 +5,12 @@ import (
 	"fmt"
 
 	"github.com/sebrandon1/go-quay/lib"
+	"gopkg.in/yaml.v3"
 )
+
+// outputFormat holds the selected output format (json, yaml, or table).
+// Set via the --output/-o persistent flag on getCmd.
+var outputFormat string
 
 // getClient creates a Quay client with the configured token and URL.
 func getClient() (*lib.Client, error) {
@@ -17,8 +22,30 @@ func getClient() (*lib.Client, error) {
 	return client, nil
 }
 
-// printJSON marshals and prints data as formatted JSON
+// printJSON marshals and prints data in the format selected by --output.
+// Supported formats: json (default), yaml, table (falls back to json).
 func printJSON(data interface{}) error {
+	switch outputFormat {
+	case outputYAML:
+		output, err := yaml.Marshal(data)
+		if err != nil {
+			return fmt.Errorf("marshaling YAML: %w", err)
+		}
+		fmt.Print(string(output))
+		return nil
+	case outputTable:
+		// Table output requires command-specific formatting.
+		// Commands that support table mode check outputFormat (or --table)
+		// and render their own table before calling printJSON.
+		// For commands without custom table support, fall back to JSON.
+		return printAsJSON(data)
+	default:
+		return printAsJSON(data)
+	}
+}
+
+// printAsJSON marshals and prints data as indented JSON.
+func printAsJSON(data interface{}) error {
 	output, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling JSON: %w", err)

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -148,7 +148,7 @@ Use --table with --popularity for an enriched dashboard sorted by pull count:
 			return fmt.Errorf("listing repositories: %w", err)
 		}
 
-		if !repoTable {
+		if !repoTable && outputFormat != outputTable {
 			return printJSON(repos)
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,6 +30,15 @@ var getCmd = &cobra.Command{
 Set QUAY_TOKEN environment variable or use --token/-t flag.
 Get your token at https://quay.io/organization/<org>?tab=applications`)
 		}
+
+		// Validate output format
+		switch outputFormat {
+		case outputJSON, outputYAML, outputTable:
+			// valid
+		default:
+			return fmt.Errorf("invalid output format %q: must be json, yaml, or table", outputFormat)
+		}
+
 		return nil
 	},
 }
@@ -44,6 +53,7 @@ func envOrDefault(key, fallback string) string {
 func init() {
 	getCmd.PersistentFlags().StringVarP(&token, "token", "t", envOrDefault("QUAY_TOKEN", ""), "Quay.io API token (default: $QUAY_TOKEN)")
 	getCmd.PersistentFlags().StringVar(&quayURL, "quay-url", envOrDefault("QUAY_URL", lib.DefaultQuayURL), "Quay API base URL (default: $QUAY_URL)")
+	getCmd.PersistentFlags().StringVarP(&outputFormat, "output", "O", "json", "Output format: json, yaml, or table")
 	rootCmd.AddCommand(getCmd)
 	getCmd.AddCommand(repositoryCmd)
 	getCmd.AddCommand(billingCmd)

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,5 @@ require github.com/spf13/cobra v1.10.2
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,3 +8,5 @@ github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary
- Adds `--output/-O` persistent flag on the `get` command (default: `json`)
- Supports `json`, `yaml`, and `table` output formats
- YAML output via `gopkg.in/yaml.v3`
- Table mode triggers existing table view for commands that support it (e.g. `repository list`)
- Validates format in `PersistentPreRunE` before command execution
- Uses `-O` (uppercase) to avoid conflict with `-o` used by organization flags

Closes #130