### PR TITLE
feat: add repository mirror configuration support

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sebrandon1/go-quay/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	mirrorExternalRef   string
+	mirrorSyncInterval  int
+	mirrorSyncStartDate string
+	mirrorRobotUsername string
+	mirrorTagRule       string
+	mirrorTagRuleKind   string
+	mirrorExtUser       string
+	mirrorExtPassword   string
+	mirrorEnabled       bool
+)
+
+var mirrorCmd = &cobra.Command{
+	Use:   "mirror",
+	Short: "Manage repository mirror configuration",
+	Long:  `Commands for managing repository mirror configuration including viewing, creating, and updating mirror settings.`,
+}
+
+var mirrorInfoCmd = &cobra.Command{
+	Use:   subcmdInfo,
+	Short: "Get mirror configuration",
+	Long:  `Get the mirror configuration for a repository.`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		config, err := client.GetMirrorConfig(namespace, repository)
+		if err != nil {
+			return fmt.Errorf("getting mirror config: %w", err)
+		}
+
+		return printJSON(config)
+	},
+}
+
+var mirrorCreateCmd = &cobra.Command{
+	Use:   subcmdCreate,
+	Short: "Create mirror configuration",
+	Long:  `Create mirror configuration for a repository to sync from an external registry.`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		createReq := &lib.CreateMirrorConfigRequest{
+			ExternalRef:              mirrorExternalRef,
+			SyncInterval:             mirrorSyncInterval,
+			SyncStartDate:            mirrorSyncStartDate,
+			RobotUsername:            mirrorRobotUsername,
+			ExternalRegistryUsername: mirrorExtUser,
+			ExternalRegistryPassword: mirrorExtPassword,
+		}
+		createReq.RootRule.Rule = mirrorTagRule
+		createReq.RootRule.RuleKind = mirrorTagRuleKind
+
+		config, err := client.CreateMirrorConfig(namespace, repository, createReq)
+		if err != nil {
+			return fmt.Errorf("creating mirror config: %w", err)
+		}
+
+		fmt.Fprintln(os.Stderr, "Mirror configuration created successfully")
+		return printJSON(config)
+	},
+}
+
+var mirrorUpdateCmd = &cobra.Command{
+	Use:   subcmdUpdate,
+	Short: "Update mirror configuration",
+	Long:  `Update mirror configuration for a repository.`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		client, err := getClient()
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
+		}
+
+		updateReq := &lib.UpdateMirrorConfigRequest{
+			IsEnabled: &mirrorEnabled,
+		}
+		if mirrorExternalRef != "" {
+			updateReq.ExternalRef = mirrorExternalRef
+		}
+		if mirrorSyncInterval > 0 {
+			updateReq.SyncInterval = &mirrorSyncInterval
+		}
+		if mirrorSyncStartDate != "" {
+			updateReq.SyncStartDate = mirrorSyncStartDate
+		}
+		if mirrorRobotUsername != "" {
+			updateReq.RobotUsername = mirrorRobotUsername
+		}
+
+		config, err := client.UpdateMirrorConfig(namespace, repository, updateReq)
+		if err != nil {
+			return fmt.Errorf("updating mirror config: %w", err)
+		}
+
+		fmt.Fprintln(os.Stderr, "Mirror configuration updated successfully")
+		return printJSON(config)
+	},
+}
+
+func init() {
+	mirrorCmd.AddCommand(mirrorInfoCmd)
+	mirrorCmd.AddCommand(mirrorCreateCmd)
+	mirrorCmd.AddCommand(mirrorUpdateCmd)
+
+	mirrorCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
+	mirrorCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
+	_ = mirrorCmd.MarkPersistentFlagRequired("namespace")
+	_ = mirrorCmd.MarkPersistentFlagRequired("repository")
+
+	mirrorCreateCmd.Flags().StringVar(&mirrorExternalRef, "external-ref", "", "External registry reference (e.g. docker.io/library/nginx)")
+	_ = mirrorCreateCmd.MarkFlagRequired("external-ref")
+	mirrorCreateCmd.Flags().IntVar(&mirrorSyncInterval, "sync-interval", 86400, "Sync interval in seconds")
+	mirrorCreateCmd.Flags().StringVar(&mirrorSyncStartDate, "sync-start-date", "", "Sync start date (ISO format)")
+	mirrorCreateCmd.Flags().StringVar(&mirrorRobotUsername, "robot-username", "", "Robot account for pulling")
+	_ = mirrorCreateCmd.MarkFlagRequired("robot-username")
+	mirrorCreateCmd.Flags().StringVar(&mirrorTagRule, "tag-rule", ".*", "Tag filter rule (regex)")
+	mirrorCreateCmd.Flags().StringVar(&mirrorTagRuleKind, "tag-rule-kind", "tag_glob_csv", "Tag rule kind")
+	mirrorCreateCmd.Flags().StringVar(&mirrorExtUser, "ext-username", "", "External registry username")
+	mirrorCreateCmd.Flags().StringVar(&mirrorExtPassword, "ext-password", "", "External registry password")
+
+	mirrorUpdateCmd.Flags().BoolVar(&mirrorEnabled, "enabled", true, "Enable or disable mirroring")
+	mirrorUpdateCmd.Flags().StringVar(&mirrorExternalRef, "external-ref", "", "External registry reference")
+	mirrorUpdateCmd.Flags().IntVar(&mirrorSyncInterval, "sync-interval", 0, "Sync interval in seconds")
+	mirrorUpdateCmd.Flags().StringVar(&mirrorSyncStartDate, "sync-start-date", "", "Sync start date")
+	mirrorUpdateCmd.Flags().StringVar(&mirrorRobotUsername, "robot-username", "", "Robot account for pulling")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,6 +75,7 @@ func init() {
 	getCmd.AddCommand(prototypeCmd)
 	getCmd.AddCommand(repotokenCmd)
 	getCmd.AddCommand(logsCmd)
+	getCmd.AddCommand(mirrorCmd)
 }
 
 // Execute executes the root command.

--- a/lib/mirror.go
+++ b/lib/mirror.go
@@ -1,0 +1,81 @@
+/*
+Package lib provides Quay.io API client functionality.
+
+This file covers REPOSITORY MIRROR CONFIGURATION endpoints:
+
+Repository Mirror Configuration:
+  - GET  /api/v1/repository/{namespace}/{repository}/mirror   - GetMirrorConfig()
+  - POST /api/v1/repository/{namespace}/{repository}/mirror   - CreateMirrorConfig()
+  - PUT  /api/v1/repository/{namespace}/{repository}/mirror   - UpdateMirrorConfig()
+*/
+package lib
+
+import (
+	"fmt"
+)
+
+// GetMirrorConfig retrieves mirror configuration for a repository
+func (c *Client) GetMirrorConfig(namespace, repository string) (*MirrorConfig, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
+	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/mirror", namespace, repository), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get mirror config request: %w", err)
+	}
+
+	var config MirrorConfig
+	if err := c.get(req, &config); err != nil {
+		return nil, fmt.Errorf("failed to get mirror config: %w", err)
+	}
+
+	return &config, nil
+}
+
+// CreateMirrorConfig creates mirror configuration for a repository
+func (c *Client) CreateMirrorConfig(namespace, repository string, config *CreateMirrorConfigRequest) (*MirrorConfig, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
+	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/mirror", namespace, repository), config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mirror config request: %w", err)
+	}
+
+	var result MirrorConfig
+	if err := c.post(req, &result); err != nil {
+		return nil, fmt.Errorf("failed to create mirror config: %w", err)
+	}
+
+	return &result, nil
+}
+
+// UpdateMirrorConfig updates mirror configuration for a repository
+func (c *Client) UpdateMirrorConfig(namespace, repository string, config *UpdateMirrorConfigRequest) (*MirrorConfig, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+
+	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/mirror", namespace, repository), config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update mirror config request: %w", err)
+	}
+
+	var result MirrorConfig
+	if err := c.put(req, &result); err != nil {
+		return nil, fmt.Errorf("failed to update mirror config: %w", err)
+	}
+
+	return &result, nil
+}

--- a/lib/mirror_test.go
+++ b/lib/mirror_test.go
@@ -1,0 +1,168 @@
+package lib
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const testExternalRef = "docker.io/library/nginx"
+
+func TestGetMirrorConfig(t *testing.T) {
+	mockConfig := MirrorConfig{
+		IsEnabled:   true,
+		MirrorType:  "PULL",
+		ExternalRef: testExternalRef,
+	}
+	mockResponseJSON, _ := json.Marshal(mockConfig)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpMethodGet {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/v1/repository/" + testNamespace + "/" + testRepository + "/mirror"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL(testTokenValue, server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	config, err := client.GetMirrorConfig(testNamespace, testRepository)
+	if err != nil {
+		t.Fatalf("GetMirrorConfig returned error: %v", err)
+	}
+
+	if config.ExternalRef != testExternalRef {
+		t.Errorf("Expected external ref 'docker.io/library/nginx', got '%s'", config.ExternalRef)
+	}
+}
+
+func TestCreateMirrorConfig(t *testing.T) {
+	mockConfig := MirrorConfig{
+		IsEnabled:   true,
+		ExternalRef: testExternalRef,
+	}
+	mockResponseJSON, _ := json.Marshal(mockConfig)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpMethodPost {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL(testTokenValue, server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	createReq := &CreateMirrorConfigRequest{
+		ExternalRef:   testExternalRef,
+		SyncInterval:  86400,
+		SyncStartDate: "2025-01-01T00:00:00Z",
+		RobotUsername: "org+robot",
+	}
+
+	config, err := client.CreateMirrorConfig(testNamespace, testRepository, createReq)
+	if err != nil {
+		t.Fatalf("CreateMirrorConfig returned error: %v", err)
+	}
+
+	if config.ExternalRef != testExternalRef {
+		t.Errorf("Expected external ref 'docker.io/library/nginx', got '%s'", config.ExternalRef)
+	}
+}
+
+func TestUpdateMirrorConfig(t *testing.T) {
+	enabled := false
+	mockConfig := MirrorConfig{
+		IsEnabled:   enabled,
+		ExternalRef: testExternalRef,
+	}
+	mockResponseJSON, _ := json.Marshal(mockConfig)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != httpMethodPut {
+			t.Errorf("Expected PUT request, got %s", r.Method)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(mockResponseJSON)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL(testTokenValue, server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	updateReq := &UpdateMirrorConfigRequest{
+		IsEnabled: &enabled,
+	}
+
+	config, err := client.UpdateMirrorConfig(testNamespace, testRepository, updateReq)
+	if err != nil {
+		t.Fatalf("UpdateMirrorConfig returned error: %v", err)
+	}
+
+	if config.IsEnabled {
+		t.Error("Expected mirror to be disabled")
+	}
+}
+
+func TestMirrorConfigHTTPErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error":"not_found"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL(testTokenValue, server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	_, err = client.GetMirrorConfig(testNamespace, testRepository)
+	if err == nil {
+		t.Error("Expected error from GetMirrorConfig, got nil")
+	}
+
+	_, err = client.CreateMirrorConfig(testNamespace, testRepository, &CreateMirrorConfigRequest{})
+	if err == nil {
+		t.Error("Expected error from CreateMirrorConfig, got nil")
+	}
+
+	_, err = client.UpdateMirrorConfig(testNamespace, testRepository, &UpdateMirrorConfigRequest{})
+	if err == nil {
+		t.Error("Expected error from UpdateMirrorConfig, got nil")
+	}
+}
+
+func TestMirrorConfigValidation(t *testing.T) {
+	client, _ := NewClient(testTokenValue)
+
+	_, err := client.GetMirrorConfig("", testRepository)
+	if err == nil {
+		t.Error("Expected error for empty namespace")
+	}
+
+	_, err = client.GetMirrorConfig(testNamespace, "")
+	if err == nil {
+		t.Error("Expected error for empty repository")
+	}
+}

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -821,6 +821,49 @@ type TestNotificationResponse struct {
 	Message string `json:"message,omitempty"`
 }
 
+// Mirror Configuration Structures
+
+// MirrorConfig represents the mirror configuration for a repository
+type MirrorConfig struct {
+	IsEnabled       bool   `json:"is_enabled,omitempty"`
+	MirrorType      string `json:"mirror_type,omitempty"`
+	ExternalRef     string `json:"external_reference,omitempty"`
+	ExternalRefType string `json:"external_reference_type,omitempty"`
+	SyncInterval    int    `json:"sync_interval,omitempty"`
+	SyncStartDate   string `json:"sync_start_date,omitempty"`
+	RobotUsername   string `json:"robot_username,omitempty"`
+	RootRule        struct {
+		Rule     string `json:"rule,omitempty"`
+		RuleKind string `json:"rule_kind,omitempty"`
+	} `json:"root_rule,omitempty"`
+	ExternalRegistryUsername string `json:"external_registry_username,omitempty"`
+}
+
+// CreateMirrorConfigRequest represents the request to create a mirror configuration
+type CreateMirrorConfigRequest struct {
+	ExternalRef   string `json:"external_reference"`
+	SyncInterval  int    `json:"sync_interval"`
+	SyncStartDate string `json:"sync_start_date"`
+	RobotUsername string `json:"robot_username"`
+	RootRule      struct {
+		Rule     string `json:"rule"`
+		RuleKind string `json:"rule_kind"`
+	} `json:"root_rule"`
+	ExternalRegistryUsername string `json:"external_registry_username,omitempty"`
+	ExternalRegistryPassword string `json:"external_registry_password,omitempty"`
+}
+
+// UpdateMirrorConfigRequest represents the request to update a mirror configuration
+type UpdateMirrorConfigRequest struct {
+	IsEnabled                *bool  `json:"is_enabled,omitempty"`
+	ExternalRef              string `json:"external_reference,omitempty"`
+	SyncInterval             *int   `json:"sync_interval,omitempty"`
+	SyncStartDate            string `json:"sync_start_date,omitempty"`
+	RobotUsername            string `json:"robot_username,omitempty"`
+	ExternalRegistryUsername string `json:"external_registry_username,omitempty"`
+	ExternalRegistryPassword string `json:"external_registry_password,omitempty"`
+}
+
 // Error Response Structure
 
 // QuayError represents a Quay API error response and implements the error interface.


### PR DESCRIPTION
## Summary
- Adds `GetMirrorConfig`, `CreateMirrorConfig`, and `UpdateMirrorConfig` lib methods
- Adds `quay get mirror {info, create, update}` CLI commands
- Adds `MirrorConfig`, `CreateMirrorConfigRequest`, and `UpdateMirrorConfigRequest` structs
- Includes unit tests for all methods including error and validation paths
- Follows the existing proxy_cache.go pattern

Closes #143