### PR TITLE
feat: add config file support for default values

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// appConfig holds values loaded from the config file.
+// Fields are applied as defaults — CLI flags and environment variables always take priority.
+type appConfig struct {
+	Token     string `yaml:"token"`
+	Namespace string `yaml:"namespace"`
+	QuayURL   string `yaml:"quay-url"`
+}
+
+// appCfg is initialized at package load time, before any init() functions run.
+// This ensures config values are available when flags are registered.
+var appCfg = loadConfig()
+
+// loadConfig reads the config file from the user's config directory.
+// Returns an empty config if the file doesn't exist or can't be parsed.
+func loadConfig() appConfig {
+	path := configFilePath()
+	if path == "" {
+		return appConfig{}
+	}
+
+	data, err := os.ReadFile(path) // #nosec G304 -- path is from os.UserConfigDir(), not user input
+	if err != nil {
+		return appConfig{}
+	}
+
+	var cfg appConfig
+	if err := parseConfig(data, &cfg); err != nil {
+		return appConfig{}
+	}
+
+	return cfg
+}
+
+// parseConfig unmarshals YAML config data into the given appConfig.
+func parseConfig(data []byte, cfg *appConfig) error {
+	return yaml.Unmarshal(data, cfg)
+}
+
+// configFilePath returns the path to the config file.
+// Uses os.UserConfigDir() to determine the platform-appropriate config directory:
+//   - Linux:   ~/.config/go-quay/config.yaml
+//   - macOS:   ~/Library/Application Support/go-quay/config.yaml
+//   - Windows: %AppData%/go-quay/config.yaml
+func configFilePath() string {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+
+	return filepath.Join(dir, "go-quay", "config.yaml")
+}

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfigMissingFile(t *testing.T) {
+	cfg := loadConfig()
+	if cfg.Token != "" {
+		t.Errorf("Expected empty token, got %q", cfg.Token)
+	}
+	if cfg.Namespace != "" {
+		t.Errorf("Expected empty namespace, got %q", cfg.Namespace)
+	}
+	if cfg.QuayURL != "" {
+		t.Errorf("Expected empty quay-url, got %q", cfg.QuayURL)
+	}
+}
+
+func TestLoadConfigFromFile(t *testing.T) {
+	// Create a temp config dir
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "go-quay")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	configContent := []byte(`token: "test-token-123"
+namespace: "my-org"
+quay-url: "https://custom.quay.io/api/v1"
+`)
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, configContent, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Override XDG_CONFIG_HOME (Linux) or use platform-specific approach
+	// Since loadConfig uses os.UserConfigDir, we test the parsing logic directly
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg appConfig
+	if err := parseConfig(data, &cfg); err != nil {
+		t.Fatalf("Failed to parse config: %v", err)
+	}
+
+	if cfg.Token != "test-token-123" {
+		t.Errorf("Expected token 'test-token-123', got %q", cfg.Token)
+	}
+	if cfg.Namespace != "my-org" {
+		t.Errorf("Expected namespace 'my-org', got %q", cfg.Namespace)
+	}
+	if cfg.QuayURL != "https://custom.quay.io/api/v1" {
+		t.Errorf("Expected quay-url 'https://custom.quay.io/api/v1', got %q", cfg.QuayURL)
+	}
+}
+
+func TestLoadConfigPartialValues(t *testing.T) {
+	configContent := []byte(`token: "only-token"
+`)
+	var cfg appConfig
+	if err := parseConfig(configContent, &cfg); err != nil {
+		t.Fatalf("Failed to parse config: %v", err)
+	}
+
+	if cfg.Token != "only-token" {
+		t.Errorf("Expected token 'only-token', got %q", cfg.Token)
+	}
+	if cfg.Namespace != "" {
+		t.Errorf("Expected empty namespace, got %q", cfg.Namespace)
+	}
+	if cfg.QuayURL != "" {
+		t.Errorf("Expected empty quay-url, got %q", cfg.QuayURL)
+	}
+}
+
+func TestLoadConfigInvalidYAML(t *testing.T) {
+	configContent := []byte(`{invalid yaml: [`)
+	var cfg appConfig
+	err := parseConfig(configContent, &cfg)
+	if err == nil {
+		t.Error("Expected error for invalid YAML, got nil")
+	}
+}
+
+func TestConfigFilePath(t *testing.T) {
+	path := configFilePath()
+	if path == "" {
+		t.Skip("os.UserConfigDir() not available on this platform")
+	}
+	if filepath.Base(path) != "config.yaml" {
+		t.Errorf("Expected config file named 'config.yaml', got %q", filepath.Base(path))
+	}
+	if filepath.Base(filepath.Dir(path)) != "go-quay" {
+		t.Errorf("Expected config dir named 'go-quay', got %q", filepath.Base(filepath.Dir(path)))
+	}
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []string
+		want   string
+	}{
+		{"all empty", []string{"", "", ""}, ""},
+		{"first non-empty", []string{"a", "b", "c"}, "a"},
+		{"middle non-empty", []string{"", "b", "c"}, "b"},
+		{"last non-empty", []string{"", "", "c"}, "c"},
+		{"no values", []string{}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := firstNonEmpty(tt.values...)
+			if got != tt.want {
+				t.Errorf("firstNonEmpty(%v) = %q, want %q", tt.values, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -228,14 +228,14 @@ func init() {
 	logsCmd.AddCommand(exportRepoLogsCmd)
 
 	// repo-logs flags
-	repoLogsCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Repository namespace")
+	repoLogsCmd.Flags().StringVarP(&namespace, "namespace", "n", appCfg.Namespace, "Repository namespace (default: config file)")
 	repoLogsCmd.Flags().StringVarP(&repository, "repository", "r", "", "Repository name")
 	repoLogsCmd.Flags().StringVar(&nextPage, "next-page", "", "Next page token for pagination")
 	repoLogsCmd.Flags().StringVarP(&startdate, "startdate", "s", "", "Start date for the logs")
 	repoLogsCmd.Flags().StringVarP(&enddate, "enddate", "e", "", "End date for the logs")
 
 	// repo-aggregated-logs flags
-	repoAggregatedLogsCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Repository namespace")
+	repoAggregatedLogsCmd.Flags().StringVarP(&namespace, "namespace", "n", appCfg.Namespace, "Repository namespace (default: config file)")
 	repoAggregatedLogsCmd.Flags().StringVarP(&repository, "repository", "r", "", "Repository name")
 	repoAggregatedLogsCmd.Flags().StringVarP(&startdate, "startdate", "s", "", "Start date")
 	repoAggregatedLogsCmd.Flags().StringVarP(&enddate, "enddate", "e", "", "End date")
@@ -274,7 +274,7 @@ func init() {
 	exportUserLogsCmd.Flags().StringVar(&callbackEmail, "callback-email", "", "Email for export results")
 
 	// export-repo-logs flags
-	exportRepoLogsCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Repository namespace")
+	exportRepoLogsCmd.Flags().StringVarP(&namespace, "namespace", "n", appCfg.Namespace, "Repository namespace (default: config file)")
 	exportRepoLogsCmd.Flags().StringVarP(&repository, "repository", "r", "", "Repository name")
 	exportRepoLogsCmd.Flags().StringVar(&starttime, "start-time", "", "Start time for export")
 	exportRepoLogsCmd.Flags().StringVar(&endtime, "end-time", "", "End time for export")

--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -171,12 +171,14 @@ func init() {
 	manifestCmd.AddCommand(manifestRemoveLabelCmd)
 
 	// Global manifest flags (repository context)
-	manifestCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
+	manifestCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", appCfg.Namespace, "Name of the namespace (default: config file)")
 	manifestCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
 	manifestCmd.PersistentFlags().StringVarP(&manifestRef, "manifest", "m", "", "Manifest reference (digest like sha256:...)")
 
-	// Mark global flags as required
-	_ = manifestCmd.MarkPersistentFlagRequired("namespace")
+	// Mark namespace as required only when no config default is available
+	if appCfg.Namespace == "" {
+		_ = manifestCmd.MarkPersistentFlagRequired("namespace")
+	}
 	_ = manifestCmd.MarkPersistentFlagRequired("repository")
 	_ = manifestCmd.MarkPersistentFlagRequired("manifest")
 

--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -117,9 +117,11 @@ func init() {
 	mirrorCmd.AddCommand(mirrorCreateCmd)
 	mirrorCmd.AddCommand(mirrorUpdateCmd)
 
-	mirrorCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
+	mirrorCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", appCfg.Namespace, "Name of the namespace (default: config file)")
 	mirrorCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
-	_ = mirrorCmd.MarkPersistentFlagRequired("namespace")
+	if appCfg.Namespace == "" {
+		_ = mirrorCmd.MarkPersistentFlagRequired("namespace")
+	}
 	_ = mirrorCmd.MarkPersistentFlagRequired("repository")
 
 	mirrorCreateCmd.Flags().StringVar(&mirrorExternalRef, "external-ref", "", "External registry reference (e.g. docker.io/library/nginx)")

--- a/cmd/permissions.go
+++ b/cmd/permissions.go
@@ -289,11 +289,13 @@ func init() {
 	permissionsCmd.AddCommand(permDeleteTeamPermCmd)
 
 	// Global permissions flags (repository context)
-	permissionsCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
+	permissionsCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", appCfg.Namespace, "Name of the namespace (default: config file)")
 	permissionsCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
 
-	// Mark global flags as required
-	_ = permissionsCmd.MarkPersistentFlagRequired("namespace")
+	// Mark namespace as required only when no config default is available
+	if appCfg.Namespace == "" {
+		_ = permissionsCmd.MarkPersistentFlagRequired("namespace")
+	}
 	_ = permissionsCmd.MarkPersistentFlagRequired("repository")
 
 	// Set command specific flags

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -237,11 +237,13 @@ func init() {
 	repositoryCmd.AddCommand(repoChangeVisibilityCmd)
 
 	// Global repository flags
-	repositoryCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
+	repositoryCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", appCfg.Namespace, "Name of the namespace (default: config file)")
 	repositoryCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
 
-	// Mark global flags as required
-	_ = repositoryCmd.MarkPersistentFlagRequired("namespace")
+	// Mark namespace as required only when no config default is available
+	if appCfg.Namespace == "" {
+		_ = repositoryCmd.MarkPersistentFlagRequired("namespace")
+	}
 	for _, cmd := range []*cobra.Command{repoInfoCmd, repoCreateCmd, repoUpdateCmd, repoDeleteCmd, repoChangeVisibilityCmd} {
 		_ = cmd.MarkFlagRequired("repository")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,8 +27,8 @@ var getCmd = &cobra.Command{
 		if token == "" {
 			return fmt.Errorf(`authentication token required
 
-Set QUAY_TOKEN environment variable or use --token/-t flag.
-Get your token at https://quay.io/organization/<org>?tab=applications`)
+Set QUAY_TOKEN environment variable, use --token/-t flag, or add to config file (%s).
+Get your token at https://quay.io/organization/<org>?tab=applications`, configFilePath())
 		}
 
 		// Validate output format
@@ -50,9 +50,19 @@ func envOrDefault(key, fallback string) string {
 	return fallback
 }
 
+// firstNonEmpty returns the first non-empty string from the given values.
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 func init() {
-	getCmd.PersistentFlags().StringVarP(&token, "token", "t", envOrDefault("QUAY_TOKEN", ""), "Quay.io API token (default: $QUAY_TOKEN)")
-	getCmd.PersistentFlags().StringVar(&quayURL, "quay-url", envOrDefault("QUAY_URL", lib.DefaultQuayURL), "Quay API base URL (default: $QUAY_URL)")
+	getCmd.PersistentFlags().StringVarP(&token, "token", "t", envOrDefault("QUAY_TOKEN", appCfg.Token), "Quay.io API token (default: $QUAY_TOKEN or config file)")
+	getCmd.PersistentFlags().StringVar(&quayURL, "quay-url", envOrDefault("QUAY_URL", firstNonEmpty(appCfg.QuayURL, lib.DefaultQuayURL)), "Quay API base URL (default: $QUAY_URL or config file)")
 	getCmd.PersistentFlags().StringVarP(&outputFormat, "output", "O", "json", "Output format: json, yaml, or table")
 	rootCmd.AddCommand(getCmd)
 	getCmd.AddCommand(repositoryCmd)

--- a/cmd/secscan.go
+++ b/cmd/secscan.go
@@ -58,12 +58,14 @@ func init() {
 	secscanCmd.AddCommand(secscanInfoCmd)
 
 	// Global secscan flags (repository context)
-	secscanCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
+	secscanCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", appCfg.Namespace, "Name of the namespace (default: config file)")
 	secscanCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
 	secscanCmd.PersistentFlags().StringVarP(&secScanManifestRef, "manifest", "m", "", "Manifest reference (digest like sha256:...)")
 
-	// Mark global flags as required
-	_ = secscanCmd.MarkPersistentFlagRequired("namespace")
+	// Mark namespace as required only when no config default is available
+	if appCfg.Namespace == "" {
+		_ = secscanCmd.MarkPersistentFlagRequired("namespace")
+	}
 	_ = secscanCmd.MarkPersistentFlagRequired("repository")
 	_ = secscanCmd.MarkPersistentFlagRequired("manifest")
 

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -189,12 +189,14 @@ func init() {
 	tagCmd.AddCommand(tagChangeCmd)
 
 	// Global tag flags (repository context)
-	tagCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
+	tagCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", appCfg.Namespace, "Name of the namespace (default: config file)")
 	tagCmd.PersistentFlags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
 	tagCmd.PersistentFlags().StringVarP(&tagName, "tag", "T", "", "Name of the tag")
 
-	// Mark global flags as required
-	_ = tagCmd.MarkPersistentFlagRequired("namespace")
+	// Mark namespace as required only when no config default is available
+	if appCfg.Namespace == "" {
+		_ = tagCmd.MarkPersistentFlagRequired("namespace")
+	}
 	_ = tagCmd.MarkPersistentFlagRequired("repository")
 	_ = tagCmd.MarkPersistentFlagRequired("tag")
 

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -155,15 +155,19 @@ func init() {
 	userCmd.AddCommand(userLookupCmd)
 	userCmd.AddCommand(userMarketplaceCmd)
 	// Star command specific flags (requires repository context)
-	starRepoCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
+	starRepoCmd.Flags().StringVarP(&namespace, "namespace", "n", appCfg.Namespace, "Name of the namespace (default: config file)")
 	starRepoCmd.Flags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
-	_ = starRepoCmd.MarkFlagRequired("namespace")
+	if appCfg.Namespace == "" {
+		_ = starRepoCmd.MarkFlagRequired("namespace")
+	}
 	_ = starRepoCmd.MarkFlagRequired("repository")
 
 	// Unstar command specific flags (requires repository context)
-	unstarRepoCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Name of the namespace")
+	unstarRepoCmd.Flags().StringVarP(&namespace, "namespace", "n", appCfg.Namespace, "Name of the namespace (default: config file)")
 	unstarRepoCmd.Flags().StringVarP(&repository, "repository", "r", "", "Name of the repository")
-	_ = unstarRepoCmd.MarkFlagRequired("namespace")
+	if appCfg.Namespace == "" {
+		_ = unstarRepoCmd.MarkFlagRequired("namespace")
+	}
 	_ = unstarRepoCmd.MarkFlagRequired("repository")
 
 	// Lookup command flags

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,12 @@ go 1.26
 
 toolchain go1.26.5
 
-require github.com/spf13/cobra v1.10.2
+require (
+	github.com/spf13/cobra v1.10.2
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary
- Supports `~/.config/go-quay/config.yaml` for default `token`, `namespace`, and `quay-url` values
- Priority order: CLI flags > env vars (`QUAY_TOKEN`, `QUAY_URL`) > config file > built-in defaults
- Namespace flag is only marked required when no default is configured
- Config file is not auto-created — users create it manually
- Uses `gopkg.in/yaml.v3` (already a dependency) — no viper needed
- Includes tests for config parsing, missing file, partial config, and invalid YAML

Closes #142