### PR TITLE
docs: fix ListRepositories example signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ func main() {
     }
     fmt.Printf("Logged in as: %s\n", user.Username)
 
-    repos, err := client.ListRepositories("my-namespace", false, false, 1, 10)
+    repos, err := client.ListRepositories("my-namespace", false, false, false, 1, 10)
     if err != nil {
         log.Fatal(err)
     }


### PR DESCRIPTION
## Summary

- add the missing `popularity` argument to the README example
- align the example with the current `ListRepositories` signature

## Testing

- `go test ./...
- `git diff --check`

Closes #178

AI assistance was used to prepare the initial patch. I reviewed the final change and ran the complete Go test suite.