### PR TITLE
docs: align CLI and library docs with current API surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,11 @@
 go.work
 go.work.sum
 go-quay
+
+# Built example binaries (go build in example dirs)
+/examples/basic-usage/basic-usage
+/examples/ci-cd-integration/ci-cd-integration
+/examples/organization-management/organization-management
+/examples/security-scan/security-scan
 .vscode
 *.bck.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,12 @@ make build                    # Build the go-quay binary
 make test                     # Run all unit tests (go test ./... -v)
 make lint                     # Run golangci-lint
 make vet                      # Run go vet
+make fmt                      # gofmt + goimports
+make coverage                 # Unit tests with coverage report
+make govulncheck              # Vulnerability scan
+make ci                       # lint + vet + test + build
 make check-swagger-alignment  # Verify lib functions match Quay's Swagger spec
+make clean                    # Remove the built binary
 go test ./lib/ -run TestCreateRepository -v  # Run a single test
 ```
 
@@ -22,38 +27,53 @@ Integration tests require `QUAY_TOKEN` and `QUAY_ORG` environment variables:
 make integration-test
 ```
 
+Optional for repo-scoped integration tests: `QUAY_NAMESPACE` and `QUAY_REPOSITORY`.
+
 ## Architecture
 
 ### Two-layer design: lib → cmd
 
 Every API domain follows the same pattern:
 
-1. **`lib/<domain>.go`** — API client methods on `*Client`. Each file's doc comment lists the HTTP endpoints it covers. All methods use the shared HTTP helpers in `client.go` (`get`, `post`, `put`, `delete`) and build URLs from the package-level `QuayURL` variable.
+1. **`lib/<domain>.go`** — API client methods on `*Client`. Each file's doc comment lists the HTTP endpoints it covers. All methods use the shared HTTP helpers in `client.go` (`get`, `post`, `put`, `delete`) and build URLs from the client's `BaseURL` field.
 
 2. **`lib/structs.go`** — All request/response types for the entire API in one file, with JSON tags matching the Quay API.
 
-3. **`cmd/<domain>.go`** — Cobra commands that parse flags, call `lib.NewClient(token)`, invoke the lib method, and print JSON output via `printJSON()`. Commands are registered in `cmd/root.go` under the `get` parent command.
+3. **`cmd/<domain>.go`** — Cobra commands that parse flags, call `getClient()` (`lib.NewClientWithURL(token, quayURL)`), invoke the lib method, and print output via `printJSON()`. Commands are registered in `cmd/root.go` under the `get` parent command.
 
 ### Key patterns
 
-- **`lib.QuayURL`** is a package-level `var` (not `const`) set to `https://quay.io/api/v1` in `lib/logs.go`. Tests override it by pointing to `httptest.NewServer` and restoring with `defer`.
-- **`lib.NewClient(bearerToken)`** creates an authenticated client. The token is passed via `--token` / `-t` flag in CLI commands.
+- **`lib.DefaultQuayURL`** is a package-level `const` (`https://quay.io/api/v1`) in `lib/client.go`. Each `Client` has its own `BaseURL`.
+- **`lib.NewClient(bearerToken)`** creates a client against `DefaultQuayURL`. **`lib.NewClientWithURL(bearerToken, baseURL)`** is used by the CLI and by unit tests (point `baseURL` at `httptest.NewServer`).
+- **`Client.Retry`** (`*RetryConfig`) is optional. When set, HTTP calls retry on 429 and 5xx. `NewClient` leaves it nil.
+- API errors that include a Quay JSON body are returned as `*lib.QuayError` (implements `error`; use `errors.As` and `StatusCode()`).
+- CLI authentication: `--token` / `-t`, else `$QUAY_TOKEN`, else the config file. API base URL: `--quay-url`, else `$QUAY_URL`, else config `quay-url`, else `DefaultQuayURL`. Output: `--output` / `-O` (`json`, `yaml`, or `table`).
+- Config file (optional defaults): `token`, `namespace`, `quay-url` in platform config dir (`~/.config/go-quay/config.yaml` on Linux). Flags and env vars override the file.
 - CLI commands use persistent flags (`--namespace`, `--repository`, `--token`) on parent commands so subcommands inherit them.
-- The `cmd/helpers.go` file contains shared CLI utilities like `markFlagRequired()`.
+- The `cmd/helpers.go` file contains shared CLI utilities like `getClient()` and `printJSON()`.
 
-### Adding a new API endpoint
+### CLI command tree
 
-1. Add request/response structs to `lib/structs.go`
-2. Add client method(s) to `lib/<domain>.go` following the existing pattern
-3. Add unit tests to `lib/<domain>_test.go` using `httptest.NewServer` with the `QuayURL` override pattern
-4. Add Cobra command in `cmd/<domain>.go` and register it in `cmd/root.go`
+All API commands hang off `go-quay get`:
+
+`repository`, `billing`, `organization`, `permissions`, `tag`, `user`, `manifest`, `secscan`, `robot`, `search`, `team`, `build`, `notification`, `trigger`, `discovery`, `error`, `messages`, `prototype`, `repotoken`, `logs`, `mirror`
 
 ## Configuration
 
-Set your Quay.io API token:
 ```bash
-export QUAY_TOKEN="your-token"
+export QUAY_TOKEN="your-token"          # required for API calls
+export QUAY_URL="https://quay.io/api/v1"  # optional; self-hosted Quay
 ```
+
+CLI flag precedence: flags > environment variables > config file > built-in defaults.
+
+## Adding a new API endpoint
+
+1. Add request/response structs to `lib/structs.go`
+2. Add client method(s) to `lib/<domain>.go` following the existing pattern
+3. Add unit tests to `lib/<domain>_test.go` using `httptest.NewServer` and `NewClientWithURL`
+4. Add Cobra command in `cmd/<domain>.go` and register it in `cmd/root.go`
+5. Update `README.md` API coverage, `docs/cli-reference.md`, and `docs/library-guide.md`
 
 ## Requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,108 +1,76 @@
 # Contributing to go-quay
 
-Thank you for your interest in contributing to go-quay! This document provides guidelines and information for contributors.
+Thank you for contributing! This guide covers setup, development workflow, and how to add new API endpoints.
 
-## Getting Started
+## Prerequisites
 
-### Prerequisites
+- Go 1.26+
+- golangci-lint (for `make lint`)
+- Quay.io API token (`QUAY_TOKEN`) and organization (`QUAY_ORG`) for integration tests
 
-- Go 1.21 or later
-- Valid Quay.io API token (for integration testing)
-- golangci-lint (for linting)
-
-### Setup
-
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/sebrandon1/go-quay.git
-   cd go-quay
-   ```
-
-2. Install dependencies:
-   ```bash
-   go mod download
-   ```
-
-3. Build the project:
-   ```bash
-   make build
-   ```
-
-## Development Workflow
-
-### Running Tests
+## Setup
 
 ```bash
-make test
-```
-
-### Running Linter
-
-```bash
-make lint
-```
-
-### Building
-
-```bash
+git clone https://github.com/sebrandon1/go-quay.git
+cd go-quay
+go mod download
 make build
+```
+
+## Development
+
+```bash
+make test              # Unit tests
+make lint              # golangci-lint
+make vet               # go vet
+make fmt               # gofmt + goimports
+make coverage          # Unit tests with coverage report
+make govulncheck       # Vulnerability scan
+make ci                # lint + vet + test + build
+make integration-test  # Live API tests (requires QUAY_TOKEN and QUAY_ORG)
+make check-swagger-alignment  # Verify lib methods match Quay Swagger spec
+```
+
+Run a single test:
+
+```bash
+go test ./lib/ -run TestCreateRepository -v
 ```
 
 ## Code Style
 
-- Follow standard Go conventions
-- Run `go fmt` before committing
-- Ensure `golangci-lint` passes with no issues
+- Follow standard Go conventions and run `go fmt` before committing
+- All tests and lint checks must pass
 - Add tests for new functionality
 
 ## Pull Request Process
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/my-feature`)
-3. Make your changes
-4. Run tests and linting:
-   ```bash
-   make test
-   make lint
-   ```
-5. Commit your changes with a descriptive commit message
-6. Push to your fork
-7. Open a Pull Request against the `main` branch
+1. Fork the repository and create a feature branch
+2. Make your changes with tests
+3. Run `make test` and `make lint`
+4. Update documentation if you add features or CLI commands
+5. Open a pull request against `main`
 
-### PR Requirements
+## Adding a New API Endpoint
 
-- All tests must pass
-- Linting must pass with no issues
-- Include tests for new functionality
-- Update documentation if adding new features or CLI commands
+Every API domain follows the same pattern:
 
-## Adding New Quay API Endpoints
+1. Add request/response structs to `lib/structs.go`
+2. Add client method(s) to `lib/<domain>.go`
+3. Add unit tests to `lib/<domain>_test.go` using `httptest.NewServer` and `lib.NewClientWithURL(token, server.URL+"/api/v1")`
+4. Add Cobra command in `cmd/<domain>.go` and register it in `cmd/root.go`
+5. Update `README.md` (API coverage table), `docs/cli-reference.md`, and `docs/library-guide.md`
 
-When adding support for a new Quay API endpoint:
-
-1. Add data structures to `lib/structs.go`
-2. Add the client method to `lib/client.go`
-3. Add tests to `lib/client_test.go`
-4. Add CLI command to appropriate file in `cmd/`
-5. Add CLI tests if applicable
-6. Update the README.md with usage documentation
-7. Update the API coverage table in README.md
+See [CLAUDE.md](CLAUDE.md) for architecture details.
 
 ## Project Structure
 
 ```
 go-quay/
-├── cmd/           # CLI command implementations
-│   ├── root.go    # Root command and subcommand registration
-│   ├── billing.go # Billing API commands
-│   ├── build.go   # Build API commands
-│   ├── manifest.go# Manifest API commands
-│   ├── organization.go # Organization API commands
-│   ├── repository.go   # Repository API commands
-│   └── ...        # Other API command files
+├── cmd/           # CLI commands (Cobra)
 ├── lib/           # Quay API client library
-│   ├── client.go  # HTTP client and API methods
-│   └── structs.go # Data structures
+├── docs/          # Guides, CLI reference, and tutorials
+├── examples/      # Runnable example programs
 ├── scripts/       # Helper scripts
 ├── main.go        # Application entry point
 └── Makefile       # Build and development commands
@@ -110,4 +78,4 @@ go-quay/
 
 ## Questions?
 
-If you have questions, please open an issue on GitHub.
+Open an issue on GitHub.

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,6 @@ check-swagger-alignment:
 	@go run ./scripts/check-swagger-alignment.go \
 		--swagger-url="https://quay.io/api/v1/discovery" \
 		--lib-path="./lib" \
-		--base-url-var="QuayURL"
+		--base-url-var="BaseURL"
 
 .PHONY: vet build lint test integration-test clean coverage govulncheck fmt ci check-swagger-alignment

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Provides both a reusable library (`lib/`) and a CLI (`cmd/`) built with Cobra.
 - **Full API Coverage** — Billing, builds, manifests, organizations, permissions, repos, robots, security scans, tags, teams, and more
 - **Library + CLI** — Use as a Go package or as a standalone command-line tool
 - **Container Image** — Available at `quay.io/bapalm/go-quay` for quick use without installation
-- **Popularity Sorting** — List repositories ranked by pull count or star count
+- **Popularity Sorting** — List repositories with pull-count scores (`--popularity --table` sorts by that score)
 
 ## Quick Start
 
@@ -86,8 +86,8 @@ func main() {
 # Get repository info
 go-quay get repository info -n myorg -r myapp -t "$QUAY_TOKEN"
 
-# List repositories sorted by popularity
-go-quay get repository list -n myorg --popularity stars --table -t "$QUAY_TOKEN"
+# List repositories sorted by pull count
+go-quay get repository list -n myorg --popularity --table -t "$QUAY_TOKEN"
 
 # Security scan a manifest
 go-quay get secscan info -n myorg -r myapp -m sha256:abc123... -t "$QUAY_TOKEN"
@@ -119,6 +119,7 @@ Each API links to the corresponding [Quay.io Swagger documentation](https://docs
 | [Messages](https://docs.quay.io/api/swagger/#Messages) | Yes | Yes | /api/v1/messages |
 | [Logs](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--aggregatelogs-get) | Yes | Yes | /api/v1/repository/{namespace}/{repository}/aggregatelogs, /api/v1/repository/{namespace}/{repository}/logs, /api/v1/organization/{orgname}/logs, /api/v1/organization/{orgname}/aggregatelogs, /api/v1/user/logs, /api/v1/user/aggregatelogs |
 | [Manifest](https://docs.quay.io/api/swagger/#Manifest) | Yes | Yes | /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}, /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/labels, /api/v1/repository/{namespace}/{repository}/manifest/{manifestref}/labels/{labelid} |
+| Mirror | Yes | Yes | /api/v1/repository/{namespace}/{repository}/mirror |
 | [Organization](https://docs.quay.io/api/swagger/#operation--api-v1-organization--orgname--get) | Yes | Yes | /api/v1/organization/{orgname}, /api/v1/organization/{orgname}/members, /api/v1/organization/{orgname}/teams, /api/v1/organization/{orgname}/team/{teamname}, /api/v1/organization/{orgname}/robots, /api/v1/organization/{orgname}/quota, /api/v1/organization/{orgname}/autoprunepolicy, /api/v1/organization/{orgname}/applications |
 | [Permission](https://docs.quay.io/api/swagger/#operation--api-v1-repository--namespace---repository--permissions-get) | Yes | Yes | /api/v1/repository/{namespace}/{repository}/permissions, /api/v1/repository/{namespace}/{repository}/permissions/{username} |
 | [Prototype](https://docs.quay.io/api/swagger/#Prototype) | Yes | Yes | /api/v1/organization/{orgname}/prototypes, /api/v1/organization/{orgname}/prototypes/{uuid} |
@@ -136,16 +137,20 @@ Each API links to the corresponding [Quay.io Swagger documentation](https://docs
 ## Authentication
 
 1. Go to [Quay.io](https://quay.io) and log in
-2. Navigate to **Account Settings** and generate a token with appropriate permissions
-3. Use the token with `--token` / `-t` or set `QUAY_TOKEN`
+2. Create an **application token** (Account Settings → Applications) or a **robot account** token. Encrypted/CLI passwords are for `docker login`, not this API.
+3. Use the token with `--token` / `-t`, `QUAY_TOKEN`, or a config file (`token:` in `~/.config/go-quay/config.yaml` on Linux)
+
+Optional: `--quay-url` / `QUAY_URL` for a self-hosted registry. Output format: `--output` / `-O` (`json`, `yaml`, `table`). See [CLI Reference](docs/cli-reference.md).
 
 ## Development
 
 ```bash
-make build    # Build binary
-make test     # Run unit tests
-make lint     # Run linter
-make vet      # Run go vet
+make build     # Build binary
+make test      # Run unit tests
+make lint      # Run linter
+make vet       # Run go vet
+make coverage  # Tests with coverage
+make ci        # lint + vet + test + build
 ```
 
 ## Prerequisites

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -56,5 +56,5 @@ func configFilePath() string {
 		return ""
 	}
 
-	return filepath.Join(dir, "go-quay", "config.yaml")
+	return filepath.Join(dir, cliName, "config.yaml")
 }

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -22,7 +22,7 @@ func TestLoadConfigMissingFile(t *testing.T) {
 func TestLoadConfigFromFile(t *testing.T) {
 	// Create a temp config dir
 	tmpDir := t.TempDir()
-	configDir := filepath.Join(tmpDir, "go-quay")
+	configDir := filepath.Join(tmpDir, cliName)
 	if err := os.MkdirAll(configDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -95,8 +95,8 @@ func TestConfigFilePath(t *testing.T) {
 	if filepath.Base(path) != "config.yaml" {
 		t.Errorf("Expected config file named 'config.yaml', got %q", filepath.Base(path))
 	}
-	if filepath.Base(filepath.Dir(path)) != "go-quay" {
-		t.Errorf("Expected config dir named 'go-quay', got %q", filepath.Base(filepath.Dir(path)))
+	if filepath.Base(filepath.Dir(path)) != cliName {
+		t.Errorf("Expected config dir named %q, got %q", cliName, filepath.Base(filepath.Dir(path)))
 	}
 }
 

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -9,6 +9,7 @@ const (
 	subcmdPermissions = "permissions"
 
 	// Command name constants
+	cliName         = "go-quay"
 	cmdGet          = "get"
 	cmdRepository   = "repository"
 	cmdOrganization = "organization"

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -9,7 +9,7 @@ import (
 )
 
 // outputFormat holds the selected output format (json, yaml, or table).
-// Set via the --output/-o persistent flag on getCmd.
+// Set via the --output/-O persistent flag on getCmd.
 var outputFormat string
 
 // getClient creates a Quay client with the configured token and URL.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ import (
 var quayURL string
 
 var rootCmd = &cobra.Command{
-	Use:   "go-quay",
+	Use:   cliName,
 	Short: "Quay CLI interacts with Quay.io API",
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ import (
 var quayURL string
 
 var rootCmd = &cobra.Command{
-	Use:   "quay",
+	Use:   "go-quay",
 	Short: "Quay CLI interacts with Quay.io API",
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -42,6 +42,12 @@ func TestSetVersion(t *testing.T) {
 	}
 }
 
+func TestRootCommandUse(t *testing.T) {
+	if rootCmd.Use != "go-quay" {
+		t.Errorf("Expected root command Use 'go-quay', got %q", rootCmd.Use)
+	}
+}
+
 func TestQuayURLFlagExists(t *testing.T) {
 	flag := getCmd.PersistentFlags().Lookup("quay-url")
 	if flag == nil {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -43,8 +43,8 @@ func TestSetVersion(t *testing.T) {
 }
 
 func TestRootCommandUse(t *testing.T) {
-	if rootCmd.Use != "go-quay" {
-		t.Errorf("Expected root command Use 'go-quay', got %q", rootCmd.Use)
+	if rootCmd.Use != cliName {
+		t.Errorf("Expected root command Use %q, got %q", cliName, rootCmd.Use)
 	}
 }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,32 @@
 # CLI Reference
 
-Complete command reference for the `go-quay` CLI. All commands require a Quay.io authentication token via `--token` or `-t`.
+Complete command reference for the `go-quay` CLI.
+
+## Global flags and configuration
+
+Every `get` subcommand inherits these flags:
+
+| Flag | Env / config | Description |
+|------|----------------|-------------|
+| `--token` / `-t` | `QUAY_TOKEN` or config `token` | Quay.io API token |
+| `--quay-url` | `QUAY_URL` or config `quay-url` | API base URL (default `https://quay.io/api/v1`) |
+| `--output` / `-O` | — | `json` (default), `yaml`, or `table` |
+
+Precedence: flags > environment variables > config file > built-in defaults.
+
+Optional config file (YAML):
+
+- Linux: `~/.config/go-quay/config.yaml`
+- macOS: `~/Library/Application Support/go-quay/config.yaml`
+- Windows: `%AppData%/go-quay/config.yaml`
+
+```yaml
+token: your-token
+namespace: myorg
+quay-url: https://quay.io/api/v1
+```
+
+`namespace` supplies the default for `--namespace` / `-n` on commands that use it.
 
 ## Billing API
 
@@ -23,6 +49,10 @@ go-quay get billing org-info --organization ORG_NAME --token YOUR_TOKEN
 go-quay get billing org-subscription --organization ORG_NAME --token YOUR_TOKEN
 go-quay get billing org-invoices --organization ORG_NAME --token YOUR_TOKEN
 ```
+
+### User invoices (not supported)
+
+`go-quay get billing user-invoices` exists for completeness but the Quay API has no user-invoice endpoint. The command always errors. Use `org-invoices` for organizations.
 
 ## Build API
 
@@ -406,6 +436,8 @@ go-quay get repository list \
   --token YOUR_TOKEN
 ```
 
+`--popularity` is a boolean: it includes pull-count scores. Combine with `--table` to sort by that score. There is no `--popularity stars` mode; use `--starred` to filter starred repositories.
+
 ### Change repository visibility
 ```bash
 go-quay get repository change-visibility \
@@ -580,6 +612,16 @@ go-quay get tag restore \
   --namespace myorg \
   --repository myrepo \
   --tag deleted-tag \
+  --manifest sha256:abc123... \
+  --token YOUR_TOKEN
+```
+
+### Create or move a tag to a manifest
+```bash
+go-quay get tag change \
+  --namespace myorg \
+  --repository myrepo \
+  --tag latest \
   --manifest sha256:abc123... \
   --token YOUR_TOKEN
 ```
@@ -1211,5 +1253,39 @@ go-quay get repotoken delete \
   --repository REPOSITORY \
   --code TOKEN_CODE \
   --confirm \
+  --token YOUR_TOKEN
+```
+
+## Mirror API
+
+Configure a repository to pull tags from an external registry on a schedule.
+
+### Get mirror configuration
+```bash
+go-quay get mirror info \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --token YOUR_TOKEN
+```
+
+### Create mirror configuration
+```bash
+go-quay get mirror create \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --external-ref docker.io/library/nginx \
+  --robot-username myorg+mirrorbot \
+  --sync-interval 86400 \
+  --tag-rule ".*" \
+  --token YOUR_TOKEN
+```
+
+### Update mirror configuration
+```bash
+go-quay get mirror update \
+  --namespace NAMESPACE \
+  --repository REPOSITORY \
+  --enabled \
+  --sync-interval 3600 \
   --token YOUR_TOKEN
 ```

--- a/docs/library-guide.md
+++ b/docs/library-guide.md
@@ -24,11 +24,21 @@ func main() {
     // Get token from environment (recommended)
     token := os.Getenv("QUAY_TOKEN")
 
-    // Create client
+    // Create client (quay.io)
     client, err := lib.NewClient(token)
     if err != nil {
         log.Fatalf("Failed to create client: %v", err)
     }
+
+    // Self-hosted Quay:
+    // client, err := lib.NewClientWithURL(token, "https://quay.example.com/api/v1")
+
+    // Optional retries on 429 and 5xx:
+    // client.Retry = &lib.RetryConfig{
+    //     MaxRetries:     3,
+    //     InitialBackoff: time.Second,
+    //     MaxBackoff:     30 * time.Second,
+    // }
 
     // Use client...
 }
@@ -83,6 +93,11 @@ err := client.DeleteRepository(namespace, name)
 
 // Change visibility
 err := client.ChangeRepositoryVisibility(namespace, name, "public")
+
+// Paginate automatically
+allRepos, err := client.ListAllRepositories(namespace, public, starred, popularity)
+allTags, err := client.ListAllTags(namespace, name, onlyActive)
+page, err := client.ListTagsPage(namespace, name, limit, pageNum, onlyActive)
 ```
 
 ### Tag Operations
@@ -105,6 +120,9 @@ err := client.RestoreTag(namespace, repo, tagName, manifestDigest)
 
 // Revert tag
 tag, err := client.RevertTag(namespace, repo, tagName, manifestDigest)
+
+// Create or move a tag to a digest
+err := client.ChangeTag(namespace, repo, tagName, manifestDigest)
 ```
 
 ### Manifest Operations
@@ -119,7 +137,7 @@ err := client.DeleteManifest(namespace, repo, digest)
 // Labels
 labels, err := client.GetManifestLabels(namespace, repo, digest)
 label, err := client.GetManifestLabel(namespace, repo, digest, labelID)
-err := client.AddManifestLabel(namespace, repo, digest, key, value, mediaType)
+label, err := client.AddManifestLabel(namespace, repo, digest, key, value, mediaType)
 err := client.DeleteManifestLabel(namespace, repo, digest, labelID)
 ```
 
@@ -204,11 +222,17 @@ err := client.RemoveTeamRepositoryPermission(orgname, teamname, repo)
 ### Permission Operations
 
 ```go
+// Combined user/robot permissions (used by CLI `permissions list/set/remove`)
+perms, err := client.GetRepositoryPermissions(namespace, repo)
+err := client.SetRepositoryPermission(namespace, repo, username, role)
+err := client.RemoveRepositoryPermission(namespace, repo, username)
+
 // User permissions
 perms, err := client.ListUserPermissions(namespace, repo)
 perm, err := client.GetUserPermission(namespace, repo, username)
 err := client.SetUserPermission(namespace, repo, username, role)
 err := client.DeleteUserPermission(namespace, repo, username)
+perm, err := client.GetUserTransitivePermission(namespace, repo, username)
 
 // Team permissions
 perms, err := client.ListTeamPermissions(namespace, repo)
@@ -279,7 +303,7 @@ notification, err := client.CreateNotification(namespace, repo, &lib.CreateNotif
     Event:  "repo_push",
     Method: "webhook",
     Title:  "My Notification",
-    Config: lib.NotificationConfig{URL: "https://example.com/webhook"},
+    Config: map[string]interface{}{"url": "https://example.com/webhook"},
 })
 
 // Update notification
@@ -371,8 +395,8 @@ plans, err := client.GetAvailablePlans()
 billing, err := client.GetUserBilling()
 subscription, err := client.GetUserSubscription()
 
-// User invoices
-invoices, err := client.GetUserInvoices()
+// User invoices are not available in the Quay API.
+// GetUserInvoices() always returns an error.
 
 // Organization billing
 billing, err := client.GetOrganizationBilling(orgname)
@@ -499,7 +523,7 @@ err := client.DeleteProxyCacheConfig(orgname)
 
 ```go
 // Get error type details
-errorType, err := client.GetErrorType(errorType)
+details, err := client.GetErrorType("invalid_token")
 ```
 
 ### Repository Tag Listing
@@ -509,56 +533,68 @@ errorType, err := client.GetErrorType(errorType)
 tags, err := client.ListTags(namespace, repo, limit, onlyActive)
 ```
 
-## Error Handling
+### Mirror Operations
 
 ```go
+config, err := client.GetMirrorConfig(namespace, repo)
+config, err := client.CreateMirrorConfig(namespace, repo, &lib.CreateMirrorConfigRequest{
+    ExternalRef:   "docker.io/library/nginx",
+    SyncInterval:  86400,
+    RobotUsername: "myorg+mirrorbot",
+})
+config, err := client.UpdateMirrorConfig(namespace, repo, &lib.UpdateMirrorConfigRequest{
+    ExternalRef: "docker.io/library/nginx",
+})
+```
+
+## Error Handling
+
+API errors that include a Quay JSON body are returned as `*lib.QuayError`:
+
+```go
+import "errors"
+
 result, err := client.GetRepository("namespace", "repo")
 if err != nil {
-    // Check for specific errors
-    errStr := err.Error()
-
-    switch {
-    case strings.Contains(errStr, "404"):
-        // Not found
-    case strings.Contains(errStr, "401"):
-        // Authentication failed
-    case strings.Contains(errStr, "403"):
-        // Permission denied
-    case strings.Contains(errStr, "429"):
-        // Rate limited - implement backoff
-    default:
-        // Other error
+    var qerr *lib.QuayError
+    if errors.As(err, &qerr) {
+        switch qerr.StatusCode() {
+        case 404:
+            // Not found
+        case 401:
+            // Authentication failed
+        case 403:
+            // Permission denied
+        case 429:
+            // Rate limited — set client.Retry or back off
+        }
+        return
     }
+    // Network or other error
 }
 ```
 
 ## Rate Limiting
 
-Quay.io implements rate limiting. Implement exponential backoff:
+Quay.io rate-limits requests. Enable built-in retries instead of wrapping every call:
 
 ```go
-func withRetry(fn func() error, maxRetries int) error {
-    var err error
-    for i := 0; i < maxRetries; i++ {
-        err = fn()
-        if err == nil {
-            return nil
-        }
-        if strings.Contains(err.Error(), "429") {
-            time.Sleep(time.Duration(1<<i) * time.Second)
-            continue
-        }
-        return err
-    }
-    return err
+import "time"
+
+client.Retry = &lib.RetryConfig{
+    MaxRetries:     3,
+    InitialBackoff: time.Second,
+    MaxBackoff:     30 * time.Second,
 }
 ```
+
+Retries apply to HTTP 429 and 5xx. `NewClient` leaves `Retry` nil until you set it.
 
 ## Best Practices
 
 1. **Environment Variables** - Store tokens in environment variables, not code
 2. **Error Handling** - Always check errors and handle appropriately
-3. **Rate Limiting** - Implement backoff for rate limit errors
+3. **Rate Limiting** - Set `client.Retry` for 429/5xx backoff
 4. **Pagination** - Use pagination for large result sets
 5. **Minimal Permissions** - Use tokens with minimal required permissions
 

--- a/docs/tutorials/01-getting-started.md
+++ b/docs/tutorials/01-getting-started.md
@@ -4,7 +4,7 @@ This tutorial walks you through the basics of using the go-quay library to inter
 
 ## Prerequisites
 
-- Go 1.21 or later
+- Go 1.26+
 - A Quay.io account with API access
 - An API token from Quay.io
 
@@ -19,12 +19,13 @@ go get github.com/sebrandon1/go-quay
 ## Step 2: Obtain an API Token
 
 1. Log in to [Quay.io](https://quay.io)
-2. Go to **Account Settings** (click your username → Account Settings)
-3. Navigate to **User Settings** → **CLI Password** or **Generate Encrypted Password**
-4. Create a new token with the permissions you need:
+2. Open **Account Settings** → **Applications** (or create a **Robot Account** under your user or organization)
+3. Create a token with the permissions you need:
    - **Read repositories** - for listing and pulling
    - **Write to repositories** - for pushing images
    - **Administer organization** - for managing teams and settings
+
+Do not use **CLI Password** / **Generate Encrypted Password** — those are for `docker login` only.
 
 Alternatively, create a **Robot Account** for automation:
 1. Go to your organization or user settings
@@ -108,13 +109,15 @@ func main() {
 }
 ```
 
+For a self-hosted registry, use `lib.NewClientWithURL(token, "https://quay.example.com/api/v1")`.
+
 ## Step 5: List Repositories
 
 Now let's list repositories in a namespace:
 
 ```go
 // List repositories in your namespace
-repos, err := client.ListRepositories("your-username", false, false, 1, 10)
+repos, err := client.ListRepositories("your-username", false, false, false, 1, 10)
 if err != nil {
     log.Fatalf("Failed to list repositories: %v", err)
 }
@@ -152,33 +155,44 @@ for _, tag := range repo.Tags.Tags {
 
 ## Error Handling
 
-The go-quay library returns descriptive errors. Here's how to handle common cases:
+The go-quay library returns `*lib.QuayError` when the API sends a JSON error body:
 
 ```go
+import (
+    "errors"
+    "fmt"
+
+    "github.com/sebrandon1/go-quay/lib"
+)
+
 repo, err := client.GetRepository("namespace", "nonexistent-repo")
 if err != nil {
-    // Check for specific error types
-    if strings.Contains(err.Error(), "404") {
-        fmt.Println("Repository not found")
-    } else if strings.Contains(err.Error(), "401") {
-        fmt.Println("Authentication failed - check your token")
-    } else if strings.Contains(err.Error(), "403") {
-        fmt.Println("Access denied - insufficient permissions")
-    } else {
-        fmt.Printf("Unexpected error: %v\n", err)
+    var qerr *lib.QuayError
+    if errors.As(err, &qerr) {
+        switch qerr.StatusCode() {
+        case 404:
+            fmt.Println("Repository not found")
+        case 401:
+            fmt.Println("Authentication failed - check your token")
+        case 403:
+            fmt.Println("Access denied - insufficient permissions")
+        default:
+            fmt.Printf("API error: %v\n", err)
+        }
+        return
     }
+    fmt.Printf("Unexpected error: %v\n", err)
     return
 }
 ```
 
 ## Environment Variables
 
-For production use, store your token securely:
-
-| Variable | Description |
-|----------|-------------|
-| `QUAY_TOKEN` | Your Quay.io API token |
-| `QUAY_NAMESPACE` | Default namespace (optional) |
+| Variable | Used by | Description |
+|----------|---------|-------------|
+| `QUAY_TOKEN` | library, CLI, examples | API token |
+| `QUAY_URL` | CLI | Optional API base URL (self-hosted Quay) |
+| `QUAY_NAMESPACE` | examples and integration tests only | Default namespace; the CLI uses `--namespace` or config `namespace` instead |
 
 ## Complete Example
 

--- a/docs/tutorials/02-repository-management.md
+++ b/docs/tutorials/02-repository-management.md
@@ -50,6 +50,7 @@ repos, err := client.ListRepositories(
     "my-namespace", // namespace (empty for all)
     false,          // include public repos
     false,          // only starred repos
+    false,          // include pull popularity scores
     1,              // page number
     25,             // results per page
 )
@@ -166,7 +167,11 @@ if err != nil {
 
 fmt.Printf("History for tag 'latest':\n")
 for _, entry := range history.Tags {
-    fmt.Printf("  %s -> %s\n", entry.StartTs, entry.ManifestDigest[:16])
+    digest := entry.ManifestDigest
+    if len(digest) > 16 {
+        digest = digest[:16]
+    }
+    fmt.Printf("  %d -> %s\n", entry.StartTs, digest)
 }
 ```
 
@@ -195,6 +200,15 @@ if err != nil {
     log.Fatalf("Failed to restore tag: %v", err)
 }
 fmt.Println("Tag restored")
+```
+
+### Change a tag to a digest
+
+```go
+err := client.ChangeTag("my-namespace", "my-app", "latest", "sha256:abc123...")
+if err != nil {
+    log.Fatalf("Failed to change tag: %v", err)
+}
 ```
 
 ## Deleting a Repository

--- a/docs/tutorials/03-security-scanning.md
+++ b/docs/tutorials/03-security-scanning.md
@@ -162,176 +162,27 @@ if security.Data != nil && security.Data.Layer != nil {
 }
 ```
 
-## Building a Security Dashboard
+## Scanning multiple images
 
-Here's how to build a simple security dashboard for multiple images:
-
-```go
-package main
-
-import (
-    "fmt"
-    "log"
-    "os"
-
-    "github.com/sebrandon1/go-quay/lib"
-)
-
-type ImageSecurity struct {
-    Name     string
-    Tag      string
-    Status   string
-    Critical int
-    High     int
-    Medium   int
-    Low      int
-}
-
-func main() {
-    client, _ := lib.NewClient(os.Getenv("QUAY_TOKEN"))
-    namespace := "my-org"
-
-    // Images to scan
-    images := []struct {
-        repo string
-        tag  string
-    }{
-        {"app-frontend", "latest"},
-        {"app-backend", "latest"},
-        {"app-worker", "latest"},
-    }
-
-    var results []ImageSecurity
-
-    for _, img := range images {
-        result := scanImage(client, namespace, img.repo, img.tag)
-        results = append(results, result)
-    }
-
-    // Print dashboard
-    fmt.Println("Security Dashboard")
-    fmt.Println("==================")
-    fmt.Printf("%-20s %-10s %-10s %8s %8s %8s %8s\n",
-        "Image", "Tag", "Status", "Critical", "High", "Medium", "Low")
-    fmt.Println(strings.Repeat("-", 80))
-
-    for _, r := range results {
-        fmt.Printf("%-20s %-10s %-10s %8d %8d %8d %8d\n",
-            r.Name, r.Tag, r.Status, r.Critical, r.High, r.Medium, r.Low)
-    }
-}
-
-func scanImage(client *lib.Client, namespace, repo, tag string) ImageSecurity {
-    result := ImageSecurity{Name: repo, Tag: tag}
-
-    // Get repository to find manifest digest
-    repoInfo, err := client.GetRepository(namespace, repo)
-    if err != nil {
-        result.Status = "error"
-        return result
-    }
-
-    // Find tag
-    var digest string
-    for _, t := range repoInfo.Tags.Tags {
-        if t.Name == tag {
-            digest = t.ManifestDigest
-            break
-        }
-    }
-
-    if digest == "" {
-        result.Status = "not found"
-        return result
-    }
-
-    // Get security scan
-    security, err := client.GetManifestSecurity(namespace, repo, digest, true)
-    if err != nil {
-        result.Status = "error"
-        return result
-    }
-
-    result.Status = security.Status
-
-    if security.Status == "scanned" && security.Data != nil && security.Data.Layer != nil {
-        for _, feature := range security.Data.Layer.Features {
-            for _, vuln := range feature.Vulnerabilities {
-                switch vuln.Severity {
-                case "Critical":
-                    result.Critical++
-                case "High":
-                    result.High++
-                case "Medium":
-                    result.Medium++
-                case "Low":
-                    result.Low++
-                }
-            }
-        }
-    }
-
-    return result
-}
-```
-
-## Automated Security Alerts
-
-Integrate security scanning into your CI/CD pipeline:
+Loop over repos and tags, calling `GetManifestSecurity` for each digest. A full dashboard (severity counts, CI fail thresholds) is in the [security-scan example](../../examples/security-scan/main.go).
 
 ```go
-package main
-
-import (
-    "fmt"
-    "os"
-
-    "github.com/sebrandon1/go-quay/lib"
-)
-
-func main() {
-    client, _ := lib.NewClient(os.Getenv("QUAY_TOKEN"))
-
-    // Configuration
-    namespace := os.Getenv("QUAY_NAMESPACE")
-    repo := os.Getenv("QUAY_REPOSITORY")
-    tag := os.Getenv("IMAGE_TAG")
-    maxCritical := 0  // Fail if any critical
-    maxHigh := 5      // Fail if more than 5 high
-
-    // Scan the image
-    result := scanImage(client, namespace, repo, tag)
-
-    // Check thresholds
-    exitCode := 0
-
-    if result.Critical > maxCritical {
-        fmt.Printf("FAIL: Found %d critical vulnerabilities (max: %d)\n",
-            result.Critical, maxCritical)
-        exitCode = 1
-    }
-
-    if result.High > maxHigh {
-        fmt.Printf("FAIL: Found %d high vulnerabilities (max: %d)\n",
-            result.High, maxHigh)
-        exitCode = 1
-    }
-
-    if exitCode == 0 {
-        fmt.Println("PASS: Image meets security requirements")
-    }
-
-    os.Exit(exitCode)
+client, _ := lib.NewClient(os.Getenv("QUAY_TOKEN"))
+security, err := client.GetManifestSecurity(namespace, repo, digest, true)
+if err != nil {
+    log.Fatal(err)
 }
+fmt.Printf("%s/%s: %s\n", namespace, repo, security.Status)
 ```
+
+`QUAY_NAMESPACE` and `QUAY_REPOSITORY` are used by that example and by integration tests. The CLI uses `--namespace` / `--repository` (or config `namespace`) instead.
 
 ## Working with Manifest Labels
 
 Add security metadata to your images:
 
 ```go
-// Add a security scan label to a manifest
-err := client.AddManifestLabel(
+label, err := client.AddManifestLabel(
     "my-namespace",
     "my-app",
     manifestDigest,
@@ -341,9 +192,10 @@ err := client.AddManifestLabel(
 )
 if err != nil {
     log.Printf("Failed to add label: %v", err)
+} else {
+    fmt.Printf("Added label %s\n", label.ID)
 }
 
-// List all labels on a manifest
 labels, err := client.GetManifestLabels("my-namespace", "my-app", manifestDigest)
 if err != nil {
     log.Fatalf("Failed to get labels: %v", err)

--- a/docs/tutorials/04-ci-cd-automation.md
+++ b/docs/tutorials/04-ci-cd-automation.md
@@ -34,7 +34,7 @@ func main() {
     orgName := "my-org"
 
     // Create a robot account
-    robot, err := client.CreateOrganizationRobot(
+    robot, err := client.CreateRobotAccount(
         orgName,
         "ci-deploy",                    // short name (becomes org+ci-deploy)
         "CI/CD deployment automation",  // description
@@ -53,7 +53,7 @@ func main() {
 ### Listing Robot Accounts
 
 ```go
-robots, err := client.GetOrganizationRobots("my-org")
+robots, err := client.GetRobotAccounts("my-org")
 if err != nil {
     log.Fatalf("Failed to list robots: %v", err)
 }
@@ -69,7 +69,7 @@ for _, robot := range robots.Robots {
 If a token is compromised:
 
 ```go
-newRobot, err := client.RegenerateOrganizationRobotToken("my-org", "ci-deploy")
+newRobot, err := client.RegenerateRobotToken("my-org", "ci-deploy")
 if err != nil {
     log.Fatalf("Failed to regenerate: %v", err)
 }
@@ -84,10 +84,10 @@ You can also create robots at the user level:
 
 ```go
 // Create user robot
-robot, err := client.CreateUserRobot("my-deploy-bot", "Personal deployment bot")
+robot, err := client.CreateUserRobotAccount("my-deploy-bot", "Personal deployment bot", nil)
 
 // List user robots
-robots, err := client.GetUserRobots()
+robots, err := client.GetUserRobotAccounts()
 
 // Regenerate user robot token
 newRobot, err := client.RegenerateUserRobotToken("my-deploy-bot")
@@ -155,12 +155,12 @@ Set up webhooks to notify external services when events occur:
 notification, err := client.CreateNotification(
     "my-org",
     "my-app",
-    lib.CreateNotificationRequest{
+    &lib.CreateNotificationRequest{
         Event:  "repo_push",          // trigger on image push
         Method: "webhook",            // notification method
         Title:  "Image Push Alert",   // friendly name
-        Config: lib.NotificationConfig{
-            URL: "https://my-ci-server.com/webhook",
+        Config: map[string]interface{}{
+            "url": "https://my-ci-server.com/webhook",
         },
     },
 )
@@ -180,7 +180,7 @@ fmt.Printf("Notification created: %s\n", notification.UUID)
 | `build_start` | Build has started |
 | `build_success` | Build completed successfully |
 | `build_failure` | Build failed |
-| `build_cancelled` | Build was cancelled |
+| `build_canceled` | Build was canceled |
 | `vulnerability_found` | New vulnerability discovered |
 
 ### Supported Methods
@@ -199,12 +199,12 @@ fmt.Printf("Notification created: %s\n", notification.UUID)
 notification, err := client.CreateNotification(
     "my-org",
     "my-app",
-    lib.CreateNotificationRequest{
+    &lib.CreateNotificationRequest{
         Event:  "vulnerability_found",
         Method: "slack",
         Title:  "Security Alert",
-        Config: lib.NotificationConfig{
-            URL: "https://hooks.slack.com/services/XXX/YYY/ZZZ",
+        Config: map[string]interface{}{
+            "url": "https://hooks.slack.com/services/XXX/YYY/ZZZ",
         },
     },
 )
@@ -226,7 +226,7 @@ if err != nil {
 
 ```go
 // List all notifications
-notifications, err := client.ListNotifications("my-org", "my-app")
+notifications, err := client.GetNotifications("my-org", "my-app")
 for _, n := range notifications.Notifications {
     fmt.Printf("- %s: %s (%s)\n", n.UUID[:8], n.Event, n.Method)
 }
@@ -245,7 +245,7 @@ Build triggers automatically build images when code is pushed to a repository.
 ### Listing Triggers
 
 ```go
-triggers, err := client.ListBuildTriggers("my-org", "my-app")
+triggers, err := client.GetTriggers("my-org", "my-app")
 if err != nil {
     log.Fatalf("Failed to list triggers: %v", err)
 }
@@ -262,7 +262,7 @@ for _, t := range triggers.Triggers {
 ### Getting Trigger Details
 
 ```go
-trigger, err := client.GetBuildTrigger("my-org", "my-app", triggerUUID)
+trigger, err := client.GetTrigger("my-org", "my-app", triggerUUID)
 if err != nil {
     log.Fatalf("Failed to get trigger: %v", err)
 }
@@ -276,7 +276,7 @@ fmt.Printf("Enabled: %v\n", trigger.Enabled)
 
 ```go
 // Start a build from a trigger
-build, err := client.StartBuildTrigger("my-org", "my-app", triggerUUID, "")
+build, err := client.StartTriggerBuild("my-org", "my-app", triggerUUID, nil)
 if err != nil {
     log.Fatalf("Failed to start build: %v", err)
 }
@@ -289,105 +289,36 @@ fmt.Printf("Status: %s\n", build.Phase)
 
 ```go
 // Activate a trigger with configuration
-err := client.ActivateBuildTrigger(
+trigger, err := client.ActivateTrigger(
     "my-org",
     "my-app",
     triggerUUID,
-    lib.ActivateTriggerRequest{
+    &lib.ActivateTriggerRequest{
         Config: map[string]interface{}{
             "build_source":    "master",
             "dockerfile_path": "/Dockerfile",
         },
     },
 )
+if err != nil {
+    log.Fatalf("Failed to activate trigger: %v", err)
+}
+fmt.Printf("Trigger activated: %s\n", trigger.ID)
 ```
 
-## Complete CI/CD Setup Example
+## Complete CI/CD Setup
 
-Here's a complete workflow to set up CI/CD for a new repository:
+Typical order: create the repo, create a robot, `SetUserPermission` for `org+robot`, then `CreateNotification` for `repo_push` / `vulnerability_found`. The runnable program is [ci-cd-integration](../../examples/ci-cd-integration/main.go).
 
 ```go
-package main
-
-import (
-    "fmt"
-    "log"
-    "os"
-
-    "github.com/sebrandon1/go-quay/lib"
-)
-
-func main() {
-    client, _ := lib.NewClient(os.Getenv("QUAY_TOKEN"))
-
-    org := "my-org"
-    repo := "my-new-app"
-    robotName := "ci-builder"
-    webhookURL := "https://ci.example.com/webhook"
-
-    // Step 1: Create repository
-    fmt.Println("1. Creating repository...")
-    _, err := client.CreateRepository(org, repo, "private", "My new application")
-    if err != nil {
-        log.Fatalf("Failed to create repo: %v", err)
-    }
-    fmt.Printf("   Created: %s/%s\n\n", org, repo)
-
-    // Step 2: Create robot account
-    fmt.Println("2. Creating robot account...")
-    robot, err := client.CreateOrganizationRobot(org, robotName, "CI/CD builder", nil)
-    if err != nil {
-        // Robot might already exist
-        log.Printf("   Robot exists or error: %v\n", err)
-    } else {
-        fmt.Printf("   Created: %s\n", robot.Name)
-        fmt.Printf("   Token: %s\n\n", robot.Token)
-    }
-
-    // Step 3: Grant robot permissions
-    fmt.Println("3. Setting robot permissions...")
-    fullRobotName := org + "+" + robotName
-    err = client.SetUserPermission(org, repo, fullRobotName, "write")
-    if err != nil {
-        log.Fatalf("Failed to set permission: %v", err)
-    }
-    fmt.Printf("   Granted write access to %s\n\n", fullRobotName)
-
-    // Step 4: Set up push notification
-    fmt.Println("4. Creating push notification...")
-    notification, err := client.CreateNotification(org, repo, lib.CreateNotificationRequest{
-        Event:  "repo_push",
-        Method: "webhook",
-        Title:  "CI Build Trigger",
-        Config: lib.NotificationConfig{URL: webhookURL},
-    })
-    if err != nil {
-        log.Printf("   Failed to create notification: %v\n", err)
-    } else {
-        fmt.Printf("   Created notification: %s\n\n", notification.UUID)
-    }
-
-    // Step 5: Set up vulnerability notification
-    fmt.Println("5. Creating security notification...")
-    secNotification, err := client.CreateNotification(org, repo, lib.CreateNotificationRequest{
-        Event:  "vulnerability_found",
-        Method: "webhook",
-        Title:  "Security Alert",
-        Config: lib.NotificationConfig{URL: webhookURL + "/security"},
-    })
-    if err != nil {
-        log.Printf("   Failed to create notification: %v\n", err)
-    } else {
-        fmt.Printf("   Created notification: %s\n\n", secNotification.UUID)
-    }
-
-    // Summary
-    fmt.Println("=== CI/CD Setup Complete ===")
-    fmt.Printf("\nDocker login:\n")
-    fmt.Printf("  docker login quay.io -u %s -p <token>\n", fullRobotName)
-    fmt.Printf("\nPush image:\n")
-    fmt.Printf("  docker push quay.io/%s/%s:latest\n", org, repo)
-}
+robot, err := client.CreateRobotAccount(org, robotName, "CI/CD builder", nil)
+err = client.SetUserPermission(org, repo, org+"+"+robotName, "write")
+notification, err := client.CreateNotification(org, repo, &lib.CreateNotificationRequest{
+    Event:  "repo_push",
+    Method: "webhook",
+    Title:  "CI Build Trigger",
+    Config: map[string]interface{}{"url": webhookURL},
+})
 ```
 
 ## Best Practices

--- a/docs/tutorials/05-organization-admin.md
+++ b/docs/tutorials/05-organization-admin.md
@@ -31,8 +31,8 @@ func main() {
 
     fmt.Printf("Organization: %s\n", org.Name)
     fmt.Printf("Email: %s\n", org.Email)
-    fmt.Printf("Is Admin: %v\n", org.IsAdmin)
-    fmt.Printf("Is Member: %v\n", org.IsMember)
+    fmt.Printf("Is Admin: %v\n", org.IsOrgAdmin)
+    fmt.Printf("Can Create Repo: %v\n", org.CanCreateRepo)
 }
 ```
 
@@ -67,12 +67,12 @@ fmt.Printf("Created team: %s\n", team.Name)
 ### Listing Teams
 
 ```go
-teams, err := client.GetOrganizationTeams("my-org")
+teams, err := client.GetTeams("my-org")
 if err != nil {
     log.Fatalf("Failed to list teams: %v", err)
 }
 
-for _, team := range teams.Teams {
+for _, team := range teams {
     fmt.Printf("- %s (role: %s, members: %d)\n",
         team.Name, team.Role, team.MemberCount)
 }
@@ -185,18 +185,28 @@ Control storage usage in your organization:
 ### Getting Quota Information
 
 ```go
-quotas, err := client.GetOrganizationQuota("my-org")
+org, err := client.GetOrganization("my-org")
+if err != nil {
+    log.Fatalf("Failed to get organization: %v", err)
+}
+
+if org.QuotaReport != nil {
+    usedGB := float64(org.QuotaReport.RunningTotal) / (1024 * 1024 * 1024)
+    limitGB := float64(org.QuotaReport.ConfiguredQuota) / (1024 * 1024 * 1024)
+    if org.QuotaReport.ConfiguredQuota > 0 {
+        percent := float64(org.QuotaReport.RunningTotal) / float64(org.QuotaReport.ConfiguredQuota) * 100
+        fmt.Printf("Used: %.2f GB / %.2f GB (%.1f%%)\n", usedGB, limitGB, percent)
+    } else {
+        fmt.Printf("Used: %.2f GB\n", usedGB)
+    }
+}
+
+// Get configured quota limits (admin only)
+quota, err := client.GetQuota("my-org")
 if err != nil {
     log.Fatalf("Failed to get quota: %v", err)
 }
-
-for _, q := range quotas.Quotas {
-    usedGB := float64(q.UsedBytes) / (1024 * 1024 * 1024)
-    limitGB := float64(q.LimitBytes) / (1024 * 1024 * 1024)
-    percent := float64(q.UsedBytes) / float64(q.LimitBytes) * 100
-
-    fmt.Printf("Used: %.2f GB / %.2f GB (%.1f%%)\n", usedGB, limitGB, percent)
-}
+fmt.Printf("Limit: %d bytes\n", quota.LimitBytes)
 ```
 
 ### Setting Quota Limits
@@ -204,7 +214,7 @@ for _, q := range quotas.Quotas {
 ```go
 // Set 10 GB limit (requires super user)
 limitBytes := int64(10 * 1024 * 1024 * 1024)
-quota, err := client.CreateOrganizationQuota("my-org", limitBytes)
+quota, err := client.CreateQuota("my-org", limitBytes)
 if err != nil {
     log.Fatalf("Failed to create quota: %v", err)
 }
@@ -217,7 +227,11 @@ fmt.Printf("Quota set: %d bytes\n", quota.LimitBytes)
 ```go
 // Increase to 50 GB
 newLimit := int64(50 * 1024 * 1024 * 1024)
-quota, err := client.UpdateOrganizationQuota("my-org", quotaID, newLimit)
+quota, err := client.UpdateQuota("my-org", newLimit)
+if err != nil {
+    log.Fatalf("Failed to update quota: %v", err)
+}
+fmt.Printf("Updated limit: %d bytes\n", quota.LimitBytes)
 ```
 
 ## Auto-Prune Policies
@@ -228,7 +242,7 @@ Automatically clean up old tags to save storage:
 
 ```go
 // Keep only the last 10 tags
-policy, err := client.CreateOrganizationAutoPrunePolicy(
+policy, err := client.CreateAutoPrunePolicy(
     "my-org",
     "number_of_tags",   // method
     10,                 // value: keep 10 tags
@@ -252,7 +266,7 @@ fmt.Printf("Policy created: %s\n", policy.UUID)
 
 ```go
 // Only prune tags matching pattern
-policy, err := client.CreateOrganizationAutoPrunePolicy(
+policy, err := client.CreateAutoPrunePolicy(
     "my-org",
     "creation_date",
     30,                 // keep tags from last 30 days
@@ -263,7 +277,7 @@ policy, err := client.CreateOrganizationAutoPrunePolicy(
 ### Listing Policies
 
 ```go
-policies, err := client.GetOrganizationAutoPrunePolicies("my-org")
+policies, err := client.GetAutoPrunePolicies("my-org")
 if err != nil {
     log.Fatalf("Failed to get policies: %v", err)
 }
@@ -279,7 +293,7 @@ for _, p := range policies.Policies {
 ### Updating a Policy
 
 ```go
-updatedPolicy, err := client.UpdateOrganizationAutoPrunePolicy(
+updatedPolicy, err := client.UpdateAutoPrunePolicy(
     "my-org",
     policyUUID,
     "number_of_tags",
@@ -291,7 +305,7 @@ updatedPolicy, err := client.UpdateOrganizationAutoPrunePolicy(
 ### Deleting a Policy
 
 ```go
-err := client.DeleteOrganizationAutoPrunePolicy("my-org", policyUUID)
+err := client.DeleteAutoPrunePolicy("my-org", policyUUID)
 ```
 
 ## Default Permissions (Prototypes)
@@ -301,13 +315,13 @@ Automatically apply permissions to new repositories:
 ### Creating a Prototype
 
 ```go
-prototype, err := client.CreateOrganizationPrototype(
-    "my-org",
-    "write",              // role
-    "team",               // delegate kind: user, team, or robot
-    "developers",         // delegate name
-    nil,                  // activating user (optional)
-)
+prototype, err := client.CreatePrototype("my-org", &lib.CreatePrototypeRequest{
+    Role: "write",
+    Delegate: lib.PrototypeDelegateRequest{
+        Kind: "team",
+        Name: "developers",
+    },
+})
 if err != nil {
     log.Fatalf("Failed to create prototype: %v", err)
 }
@@ -318,7 +332,7 @@ fmt.Printf("Prototype created: %s\n", prototype.ID)
 ### Listing Prototypes
 
 ```go
-prototypes, err := client.GetOrganizationPrototypes("my-org")
+prototypes, err := client.GetPrototypes("my-org")
 if err != nil {
     log.Fatalf("Failed to get prototypes: %v", err)
 }
@@ -332,7 +346,7 @@ for _, p := range prototypes.Prototypes {
 ### Deleting a Prototype
 
 ```go
-err := client.DeleteOrganizationPrototype("my-org", prototypeID)
+err := client.DeletePrototype("my-org", prototypeID)
 ```
 
 ## OAuth Applications
@@ -342,7 +356,7 @@ Manage OAuth applications for your organization:
 ### Creating an Application
 
 ```go
-app, err := client.CreateOrganizationApplication(
+app, err := client.CreateApplication(
     "my-org",
     "My CI Tool",                           // name
     "CI/CD integration app",                // description
@@ -361,7 +375,7 @@ fmt.Printf("Client Secret: %s\n", app.ClientSecret)
 ### Listing Applications
 
 ```go
-apps, err := client.GetOrganizationApplications("my-org")
+apps, err := client.GetApplications("my-org")
 if err != nil {
     log.Fatalf("Failed to list apps: %v", err)
 }
@@ -374,7 +388,7 @@ for _, app := range apps.Applications {
 ### Resetting Client Secret
 
 ```go
-app, err := client.ResetOrganizationApplicationClientSecret("my-org", clientID)
+app, err := client.ResetApplicationClientSecret("my-org", clientID)
 if err != nil {
     log.Fatalf("Failed to reset secret: %v", err)
 }
@@ -387,7 +401,7 @@ fmt.Printf("New secret: %s\n", app.ClientSecret)
 Access organization activity logs:
 
 ```go
-logs, err := client.GetOrganizationLogs("my-org", "")
+logs, err := client.GetOrganizationLogs("my-org", "", "", "")
 if err != nil {
     log.Fatalf("Failed to get logs: %v", err)
 }
@@ -400,7 +414,7 @@ for _, entry := range logs.Logs {
 
 // Pagination
 if logs.NextPage != "" {
-    nextLogs, err := client.GetOrganizationLogs("my-org", logs.NextPage)
+    nextLogs, err := client.GetOrganizationLogs("my-org", logs.NextPage, "", "")
     // ... process next page
 }
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,22 @@
+# Examples
+
+Runnable programs demonstrating go-quay library usage. Each example requires `QUAY_TOKEN`.
+
+| Example | Description |
+|---------|-------------|
+| [basic-usage](./basic-usage/) | Client setup, user info, and repository listing |
+| [security-scan](./security-scan/) | Vulnerability scanning and reporting |
+| [ci-cd-integration](./ci-cd-integration/) | Robot accounts, permissions, and webhooks |
+| [organization-management](./organization-management/) | Teams, quotas, and org administration |
+
+## Running an Example
+
+```bash
+export QUAY_TOKEN="your-token"
+cd basic-usage
+go run main.go
+```
+
+`basic-usage` also reads `QUAY_NAMESPACE` (optional; defaults to the authenticated username). That variable is not a CLI flag — the CLI uses `--namespace` or config `namespace`.
+
+Some examples accept flags — run with `-h` for usage.

--- a/examples/basic-usage/main.go
+++ b/examples/basic-usage/main.go
@@ -13,7 +13,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -119,14 +118,4 @@ func main() {
 	}
 
 	fmt.Println("\n=== Example Complete ===")
-}
-
-// prettyPrint outputs a struct as formatted JSON (utility function)
-func prettyPrint(v interface{}) {
-	data, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		log.Printf("Failed to marshal: %v", err)
-		return
-	}
-	fmt.Println(string(data))
 }

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,121 +1,14 @@
 # lib
 
-This folder contains Go source files for Quay.io API endpoints found in: 
+Go client for the [Quay.io REST API](https://docs.quay.io/api/swagger/).
 
-https://docs.quay.io/api/swagger/
+## Installation
 
-## Available Endpoints
+```bash
+go get github.com/sebrandon1/go-quay
+```
 
-### Organization Management
-
-#### Core Organization Operations
-- `CreateOrganization(name, email string) (*Organization, error)` - Create a new organization
-- `GetOrganization(orgname string) (*Organization, error)` - Get organization details
-- `UpdateOrganization(orgname, email string) (*Organization, error)` - Update organization settings
-- `DeleteOrganization(orgname string) error` - Delete an organization
-
-#### Organization Members
-- `GetOrganizationMembers(orgname string) (*OrganizationMembers, error)` - Get organization members
-- `AddOrganizationMember(orgname, membername string) error` - Add member to organization
-- `RemoveOrganizationMember(orgname, membername string) error` - Remove member from organization
-
-#### Organization Repositories
-- `GetOrganizationRepositories(orgname string) (*OrganizationRepositories, error)` - Get organization repositories
-
-#### Organization Billing
-- `GetOrganizationBilling(orgname string) (*BillingInfo, error)` - Get organization billing information
-- `GetOrganizationSubscription(orgname string) (*Subscription, error)` - Get organization subscription details
-- `GetOrganizationInvoices(orgname string) ([]Invoice, error)` - Get organization invoices
-
-#### Organization Logs
-- `GetOrganizationLogs(namespace, nextPage string) (*OrganizationLogs, error)` - Get organization logs
-
-### Team Management
-
-#### Team Operations
-- `GetTeams(orgname string) ([]Team, error)` - Get all teams in organization
-- `CreateTeam(orgname, teamname, description, role string) (*Team, error)` - Create new team
-- `GetTeam(orgname, teamname string) (*Team, error)` - Get team details
-- `UpdateTeam(orgname, teamname, description, role string) (*Team, error)` - Update team settings
-- `DeleteTeam(orgname, teamname string) error` - Delete team
-
-#### Team Members
-- `GetTeamMembers(orgname, teamname string) (*TeamMembers, error)` - Get team members
-- `AddTeamMember(orgname, teamname, membername string) error` - Add member to team
-- `RemoveTeamMember(orgname, teamname, membername string) error` - Remove member from team
-
-#### Team Permissions
-- `GetTeamPermissions(orgname, teamname string) (*TeamPermissions, error)` - Get team repository permissions
-- `SetTeamRepositoryPermission(orgname, teamname, repository, role string) error` - Set repository permission for team
-- `RemoveTeamRepositoryPermission(orgname, teamname, repository string) error` - Remove repository permission from team
-
-### Robot Account Management
-
-#### Robot Account Operations
-- `GetRobotAccounts(orgname string) (*RobotAccounts, error)` - Get all robot accounts
-- `CreateRobotAccount(orgname, robotShortname, description string, unstructured map[string]interface{}) (*RobotAccount, error)` - Create robot account
-- `GetRobotAccount(orgname, robotShortname string) (*RobotAccount, error)` - Get robot account details
-- `DeleteRobotAccount(orgname, robotShortname string) error` - Delete robot account
-- `RegenerateRobotToken(orgname, robotShortname string) (*RobotAccount, error)` - Regenerate robot token
-
-#### Robot Permissions
-- `GetRobotPermissions(orgname, robotShortname string) (*RobotPermissions, error)` - Get robot repository permissions
-- `SetRobotRepositoryPermission(orgname, robotShortname, repository, role string) error` - Set repository permission for robot
-- `RemoveRobotRepositoryPermission(orgname, robotShortname, repository string) error` - Remove repository permission from robot
-
-### Quota Management
-
-- `GetQuota(orgname string) (*Quota, error)` - Get organization quota information
-- `CreateQuota(orgname string, limitBytes int64) (*Quota, error)` - Create quota for organization
-- `UpdateQuota(orgname string, limitBytes int64) (*Quota, error)` - Update quota limits
-- `DeleteQuota(orgname string) error` - Delete organization quota
-
-### Auto-Prune Policy Management
-
-- `GetAutoPrunePolicies(orgname string) (*AutoPrunePolicies, error)` - Get auto-prune policies
-- `CreateAutoPrunePolicy(orgname, method string, value int, tagPattern string) (*AutoPrunePolicy, error)` - Create auto-prune policy
-- `GetAutoPrunePolicy(orgname, policyUUID string) (*AutoPrunePolicy, error)` - Get specific auto-prune policy
-- `UpdateAutoPrunePolicy(orgname, policyUUID, method string, value int, tagPattern string) (*AutoPrunePolicy, error)` - Update auto-prune policy
-- `DeleteAutoPrunePolicy(orgname, policyUUID string) error` - Delete auto-prune policy
-
-### Applications Management
-
-- `GetApplications(orgname string) (*Applications, error)` - Get organization applications
-- `CreateApplication(orgname, name, description, applicationURI, redirectURI string) (*Application, error)` - Create OAuth application
-- `GetApplication(orgname, clientID string) (*Application, error)` - Get application details
-- `UpdateApplication(orgname, clientID, name, description, applicationURI, redirectURI string) (*Application, error)` - Update application
-- `DeleteApplication(orgname, clientID string) error` - Delete application
-- `ResetApplicationClientSecret(orgname, clientID string) (*Application, error)` - Reset application client secret
-
-### Default Permissions Management
-
-- `GetDefaultPermissions(orgname string) (*DefaultPermissions, error)` - Get default repository permissions
-- `CreateDefaultPermission(orgname, role, delegateType, delegateName string) (*DefaultPermission, error)` - Create default permission
-- `DeleteDefaultPermission(orgname, prototypeid string) error` - Delete default permission
-
-### Proxy Cache Configuration
-
-- `GetProxyCacheConfig(orgname string) (*ProxyCacheConfig, error)` - Get proxy cache configuration
-- `CreateProxyCacheConfig(orgname, upstreamRegistry string, insecure bool, expiration int) (*ProxyCacheConfig, error)` - Create proxy cache config
-- `DeleteProxyCacheConfig(orgname string) error` - Delete proxy cache configuration
-
-### Repository Management
-
-- `GetRepository(namespace, repository string) (RepositoryWithTags, error)` - Get repository with tags information
-
-### Logs Management
-
-- `GetAggregatedLogs(namespace, repository, startDate, endDate string) (*AggregatedLogs, error)` - Get aggregated repository logs
-- `GetLogs(namespace, repository, nextPage string) (*Logs, error)` - Get repository logs
-
-### Billing Management
-
-- `GetUserBilling() (*BillingInfo, error)` - Get user billing information
-- `GetUserSubscription() (*Subscription, error)` - Get user subscription details
-- `GetUserInvoices() ([]Invoice, error)` - Get user invoices (Not available in Quay API)
-- `GetAvailablePlans() ([]Subscription, error)` - Get available subscription plans
-
-## Usage
+## Quick Start
 
 ```go
 package main
@@ -123,90 +16,43 @@ package main
 import (
     "fmt"
     "log"
+    "os"
+
     "github.com/sebrandon1/go-quay/lib"
 )
 
 func main() {
-    // Initialize client with bearer token
-    client, err := lib.NewClient("your-bearer-token")
+    client, err := lib.NewClient(os.Getenv("QUAY_TOKEN"))
     if err != nil {
         log.Fatal(err)
     }
 
-    // Organization Management
-    org, err := client.CreateOrganization("my-org", "admin@example.com")
+    user, err := client.GetUser()
     if err != nil {
         log.Fatal(err)
     }
-    fmt.Printf("Created organization: %s\n", org.Name)
-
-    // Team Management
-    team, err := client.CreateTeam("my-org", "developers", "Development team", "member")
-    if err != nil {
-        log.Fatal(err)
-    }
-    fmt.Printf("Created team: %s\n", team.Name)
-
-    // Robot Account Management
-    robot, err := client.CreateRobotAccount("my-org", "ci-bot", "CI/CD robot", nil)
-    if err != nil {
-        log.Fatal(err)
-    }
-    fmt.Printf("Created robot: %s\n", robot.Name)
-
-    // Set permissions
-    err = client.SetTeamRepositoryPermission("my-org", "developers", "my-repo", "write")
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    // Quota Management
-    quota, err := client.CreateQuota("my-org", 1073741824) // 1GB
-    if err != nil {
-        log.Fatal(err)
-    }
-    fmt.Printf("Created quota: %d bytes\n", quota.LimitBytes)
+    fmt.Printf("Logged in as: %s\n", user.Username)
 }
 ```
 
+For a self-hosted registry, use `lib.NewClientWithURL(token, "https://quay.example.com/api/v1")`. Optional retries: set `client.Retry` to a `*lib.RetryConfig`.
+
+## Documentation
+
+- [Library Guide](../docs/library-guide.md) — complete API reference by domain
+- [Tutorials](../docs/tutorials/01-getting-started.md) — step-by-step guides
+- [Examples](../examples/) — runnable programs
+
+## API Domains
+
+Client methods are organized by domain in `lib/<domain>.go` (for example `repository.go`, `organization.go`, `mirror.go`). Each file's doc comment lists the HTTP endpoints it covers. Request and response types live in `structs.go`.
+
+Coverage includes billing, builds, discovery, logs, manifests, notifications, organizations, permissions, prototypes, repositories, repository mirroring, robots, search, security scans, tags, teams, triggers, users, applications, marketplace, proxy cache, quota, auto-prune, messages, error types, and (deprecated) repository tokens.
+
 ## Authentication
 
-All endpoints require authentication via bearer token. You can obtain a token from:
+All endpoints require a bearer token. Set `QUAY_TOKEN` or pass the token to `lib.NewClient(token)`. The default API base is `lib.DefaultQuayURL` (`https://quay.io/api/v1`).
 
-1. **OAuth 2.0 Access Token**: Created via Quay.io UI (10-year lifespan)
-2. **Robot Account Token**: Persistent, non-expiring by default
-3. **OCI Referrers OAuth Access Token**: For OCI operations
+## Testing
 
-## Rate Limiting
-
-Quay.io implements rate limiting (few requests per second per IP) with bursting capabilities. If you exceed limits, endpoints will return HTTP 429 "Too many requests".
-
-## Error Handling
-
-All functions return appropriate errors for:
-- Authentication failures
-- Rate limiting
-- Network issues
-- API errors (400, 404, 500 series)
-
-## Roles and Permissions
-
-### Organization Roles
-- `admin`: Full administrative access
-- `member`: Inherits team permissions
-- `creator`: Member permissions + repository creation
-
-### Repository Roles
-- `admin`: Full repository access + administrative tasks
-- `write`: Read and write access
-- `read`: Read-only access
-- `none`: No access
-
-### Auto-Prune Methods
-- `number_of_tags`: Keep specified number of tags
-- `creation_date`: Keep tags newer than specified days
-- `tag_pattern`: Keep tags matching pattern
-
-## Data Structures
-
-All response structures are defined in `structs.go` and include comprehensive field mappings for JSON serialization/deserialization.
+Unit tests create a client with `NewClientWithURL(token, server.URL+"/api/v1")` against `httptest.NewServer`. See any `lib/*_test.go` file for the pattern.

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -178,13 +178,20 @@ echo "Testing user command help..."
 echo "Testing permissions command help..."
 ./$APP_NAME get permissions --help > /dev/null
 ./$APP_NAME get permissions list --help > /dev/null
-./$APP_NAME get permissions get --help > /dev/null
 ./$APP_NAME get permissions set --help > /dev/null
-./$APP_NAME get permissions delete --help > /dev/null
+./$APP_NAME get permissions remove --help > /dev/null
 
 # Test tag command help
 echo "Testing tag command help..."
 ./$APP_NAME get tag --help > /dev/null
+./$APP_NAME get tag change --help > /dev/null
+
+# Test mirror command help
+echo "Testing mirror command help..."
+./$APP_NAME get mirror --help > /dev/null
+./$APP_NAME get mirror info --help > /dev/null
+./$APP_NAME get mirror create --help > /dev/null
+./$APP_NAME get mirror update --help > /dev/null
 
 # Test error handling
 echo "Testing error handling..."
@@ -200,7 +207,7 @@ if [ -n "$QUAY_TOKEN" ]; then
     
     # Discovery API - returns API information (read-only, safe)
     printf "Testing discovery API... "
-    DISCOVERY_INFO=$(./$APP_NAME get discovery --token "$QUAY_TOKEN" 2>/dev/null)
+    DISCOVERY_INFO=$(./$APP_NAME get discovery api --token "$QUAY_TOKEN" 2>/dev/null)
     if [ $? -eq 0 ]; then
         echo "✓ (API discovery successful)"
     else
@@ -209,7 +216,7 @@ if [ -n "$QUAY_TOKEN" ]; then
     
     # Messages API - returns system messages (read-only, safe)
     printf "Testing messages API... "
-    MESSAGES_INFO=$(./$APP_NAME get messages --token "$QUAY_TOKEN" 2>/dev/null)
+    MESSAGES_INFO=$(./$APP_NAME get messages list --token "$QUAY_TOKEN" 2>/dev/null)
     if [ $? -eq 0 ]; then
         if echo "$MESSAGES_INFO" | grep -q "messages" 2>/dev/null; then
             MSG_COUNT=$(echo "$MESSAGES_INFO" | jq '.messages | length' 2>/dev/null || echo "0")
@@ -602,7 +609,7 @@ if [ -n "$QUAY_TOKEN" ]; then
         
         # Tags API - list tags (read-only)
         printf "Testing tags for $QUAY_NAMESPACE/$QUAY_REPOSITORY... "
-        TAGS_INFO=$(./$APP_NAME get tag list --namespace "$QUAY_NAMESPACE" --repository "$QUAY_REPOSITORY" --token "$QUAY_TOKEN" 2>/dev/null)
+        TAGS_INFO=$(./$APP_NAME get repository info --namespace "$QUAY_NAMESPACE" --repository "$QUAY_REPOSITORY" --token "$QUAY_TOKEN" 2>/dev/null)
         if [ $? -eq 0 ]; then
             if echo "$TAGS_INFO" | grep -q "tags" 2>/dev/null; then
                 TAG_COUNT=$(echo "$TAGS_INFO" | jq '.tags | length' 2>/dev/null || echo "0")

--- a/scripts/test-cli-structure.sh
+++ b/scripts/test-cli-structure.sh
@@ -5,11 +5,14 @@
 
 set -e
 
-BINARY="./go-quay"
+BINARY="./bin/go-quay"
+if [ ! -f "$BINARY" ]; then
+	BINARY="./go-quay"
+fi
 
 # Check if binary exists
 if [ ! -f "$BINARY" ]; then
-    echo "Error: Binary $BINARY not found. Please build the project first (make build)."
+    echo "Error: Binary not found at ./bin/go-quay or ./go-quay. Please build the project first (make build)."
     exit 1
 fi
 

--- a/scripts/test-cli-structure.sh
+++ b/scripts/test-cli-structure.sh
@@ -5,36 +5,33 @@
 
 set -e
 
-BINARY="./bin/go-quay"
+BINARY="./go-quay"
 
 # Check if binary exists
 if [ ! -f "$BINARY" ]; then
-    echo "Error: Binary $BINARY not found. Please build the project first."
+    echo "Error: Binary $BINARY not found. Please build the project first (make build)."
     exit 1
 fi
 
 echo "Testing CLI command structure..."
 
-# Test main commands exist
 echo "Testing main commands..."
 $BINARY get --help
 
-# Test repository commands
 echo "Testing repository commands..."
 $BINARY get repository --help
 $BINARY get repository create --help
 $BINARY get repository update --help
 $BINARY get repository delete --help
 $BINARY get repository info --help
+$BINARY get repository list --help
 
-# Test permissions commands
 echo "Testing permissions commands..."
 $BINARY get permissions --help
 $BINARY get permissions list --help
 $BINARY get permissions set --help
 $BINARY get permissions remove --help
 
-# Test tag commands
 echo "Testing tag commands..."
 $BINARY get tag --help
 $BINARY get tag info --help
@@ -42,8 +39,9 @@ $BINARY get tag update --help
 $BINARY get tag delete --help
 $BINARY get tag history --help
 $BINARY get tag revert --help
+$BINARY get tag change --help
+$BINARY get tag restore --help
 
-# Test user commands
 echo "Testing user commands..."
 $BINARY get user --help
 $BINARY get user info --help
@@ -51,10 +49,12 @@ $BINARY get user starred --help
 $BINARY get user star --help
 $BINARY get user unstar --help
 
-# Test existing commands still work
-echo "Testing existing commands..."
+echo "Testing other command groups..."
 $BINARY get billing --help
 $BINARY get organization --help
-$BINARY get aggregatedlogs --help
+$BINARY get logs --help
+$BINARY get logs repo-aggregated-logs --help
+$BINARY get mirror --help
+$BINARY get mirror info --help
 
 echo "✅ All CLI commands structure tests passed!"

--- a/scripts/validate-readme-examples.sh
+++ b/scripts/validate-readme-examples.sh
@@ -6,11 +6,11 @@
 
 set -e
 
-BINARY="./bin/go-quay"
+BINARY="./go-quay"
 
 # Check if binary exists
 if [ ! -f "$BINARY" ]; then
-    echo "Error: Binary $BINARY not found. Please build the project first."
+    echo "Error: Binary $BINARY not found. Please build the project first (make build)."
     exit 1
 fi
 

--- a/scripts/validate-readme-examples.sh
+++ b/scripts/validate-readme-examples.sh
@@ -6,11 +6,14 @@
 
 set -e
 
-BINARY="./go-quay"
+BINARY="./bin/go-quay"
+if [ ! -f "$BINARY" ]; then
+	BINARY="./go-quay"
+fi
 
 # Check if binary exists
 if [ ! -f "$BINARY" ]; then
-    echo "Error: Binary $BINARY not found. Please build the project first (make build)."
+    echo "Error: Binary not found at ./bin/go-quay or ./go-quay. Please build the project first (make build)."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Bring README, CLI reference, library guide, tutorials, and contributor docs in line with mirror, config file, `--output`, retries, and `NewClientWithURL`.
- Fix stale examples (`--popularity stars`, `AddManifestLabel` return value, `QuayURL` test pattern, token vs Docker password) and document global flags plus `get tag change` / `get mirror`.
- Point CLI help at `go-quay` (root `Use`), ignore example binaries, and correct helper scripts that still called removed commands.

## Test plan
- [x] `go test ./cmd/ ./lib/`
- [ ] Spot-check `go-quay --help` shows `Usage: go-quay`
- [ ] Confirm `docs/cli-reference.md` global flags, mirror, and `tag change` sections look right
- [ ] `make build && ./scripts/test-cli-structure.sh`


Made with [Cursor](https://cursor.com)