### PR TITLE
refactor: standardize remaining URL construction on buildURL()

### DIFF
--- a/lib/billing.go
+++ b/lib/billing.go
@@ -46,7 +46,7 @@ func (c *Client) GetOrganizationBilling(orgname string) (*BillingInfo, error) {
 // GetUserBilling returns billing information for the current user
 func (c *Client) GetUserBilling() (*BillingInfo, error) {
 	// Get new request
-	req, err := newRequest("GET", c.BaseURL+"/user/plan", nil)
+	req, err := newRequest("GET", c.buildURL("/user/plan"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user billing request: %w", err)
 	}
@@ -82,7 +82,7 @@ func (c *Client) GetOrganizationSubscription(orgname string) (*Subscription, err
 // GetUserSubscription returns subscription details for the current user
 func (c *Client) GetUserSubscription() (*Subscription, error) {
 	// Get new request
-	req, err := newRequest("GET", c.BaseURL+"/user/plan", nil)
+	req, err := newRequest("GET", c.buildURL("/user/plan"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user subscription request: %w", err)
 	}
@@ -125,7 +125,7 @@ func (c *Client) GetUserInvoices() ([]Invoice, error) {
 // GetAvailablePlans returns available subscription plans
 func (c *Client) GetAvailablePlans() ([]Subscription, error) {
 	// Get new request
-	req, err := newRequest("GET", c.BaseURL+"/plans", nil)
+	req, err := newRequest("GET", c.buildURL("/plans"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get available plans request: %w", err)
 	}

--- a/lib/organization.go
+++ b/lib/organization.go
@@ -38,7 +38,7 @@ func (c *Client) CreateOrganization(name, email string) (*Organization, error) {
 		return nil, fmt.Errorf("email is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.BaseURL+"/organization/", CreateOrganizationRequest{
+	req, err := newRequestWithBody("POST", c.buildURL("/organization/"), CreateOrganizationRequest{
 		Name:  name,
 		Email: email,
 	})

--- a/lib/repository.go
+++ b/lib/repository.go
@@ -89,7 +89,7 @@ func (c *Client) CreateRepository(namespace, repository, visibility, description
 		return nil, fmt.Errorf("visibility is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.BaseURL+"/repository", CreateRepositoryRequest{
+	req, err := newRequestWithBody("POST", c.buildURL("/repository"), CreateRepositoryRequest{
 		Repository:  repository,
 		Namespace:   namespace,
 		Visibility:  visibility,

--- a/lib/robot.go
+++ b/lib/robot.go
@@ -22,7 +22,7 @@ import (
 
 // GetUserRobotAccounts retrieves all robot accounts for the authenticated user
 func (c *Client) GetUserRobotAccounts() (*RobotAccounts, error) {
-	req, err := newRequest("GET", c.BaseURL+"/user/robots", nil)
+	req, err := newRequest("GET", c.buildURL("/user/robots"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user robots request: %w", err)
 	}

--- a/lib/search.go
+++ b/lib/search.go
@@ -22,7 +22,7 @@ func (c *Client) SearchRepositories(query string, page int) (*SearchRepositoryRe
 		return nil, fmt.Errorf("query is required")
 	}
 
-	req, err := newRequest("GET", c.BaseURL+"/find/repositories", nil)
+	req, err := newRequest("GET", c.buildURL("/find/repositories"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create search repositories request: %w", err)
 	}
@@ -47,7 +47,7 @@ func (c *Client) SearchAll(query string) (*SearchAllResult, error) {
 		return nil, fmt.Errorf("query is required")
 	}
 
-	req, err := newRequest("GET", c.BaseURL+"/find/all", nil)
+	req, err := newRequest("GET", c.buildURL("/find/all"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create search all request: %w", err)
 	}

--- a/lib/user.go
+++ b/lib/user.go
@@ -22,7 +22,7 @@ import (
 
 // GetUser retrieves information about the current authenticated user
 func (c *Client) GetUser() (*UserDetails, error) {
-	req, err := newRequest("GET", c.BaseURL+"/user", nil)
+	req, err := newRequest("GET", c.buildURL("/user"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user request: %w", err)
 	}
@@ -37,7 +37,7 @@ func (c *Client) GetUser() (*UserDetails, error) {
 
 // GetStarredRepositories retrieves repositories starred by the current user
 func (c *Client) GetStarredRepositories() (*StarredRepositories, error) {
-	req, err := newRequest("GET", c.BaseURL+"/user/starred", nil)
+	req, err := newRequest("GET", c.buildURL("/user/starred"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get starred repositories request: %w", err)
 	}

--- a/scripts/check-swagger-alignment.go
+++ b/scripts/check-swagger-alignment.go
@@ -147,9 +147,10 @@ func scanSourceEndpoints(libPath, baseURLVar string) ([]ImplementedEndpoint, err
 	var endpoints []ImplementedEndpoint
 
 	// Patterns to match endpoint definitions
-	// Matches: c.BaseURL + "/path" or fmt.Sprintf("%s/path", c.BaseURL)
+	// Matches: c.BaseURL + "/path", fmt.Sprintf("%s/path", c.BaseURL), or c.buildURL("/path", ...)
 	urlConcatPattern := regexp.MustCompile(baseURLVar + `\s*\+\s*"(/[^"]+)"`)
 	sprintfPattern := regexp.MustCompile(`fmt\.Sprintf\s*\(\s*"%s(/[^"]+)"`)
+	buildURLPattern := regexp.MustCompile(`buildURL\s*\(\s*"(/[^"]+)"`)
 	// Match HTTP method from http.NewRequest or newRequest calls
 	methodPattern := regexp.MustCompile(`(?:http\.NewRequest|newRequest|newRequestWithBody)\s*\(\s*"(GET|POST|PUT|DELETE|PATCH)"`)
 
@@ -191,6 +192,8 @@ func scanSourceEndpoints(libPath, baseURLVar string) ([]ImplementedEndpoint, err
 			if matches := urlConcatPattern.FindStringSubmatch(line); len(matches) > 1 {
 				urlPath = matches[1]
 			} else if matches := sprintfPattern.FindStringSubmatch(line); len(matches) > 1 {
+				urlPath = matches[1]
+			} else if matches := buildURLPattern.FindStringSubmatch(line); len(matches) > 1 {
 				urlPath = matches[1]
 			}
 


### PR DESCRIPTION
## Summary
- Replace the last `c.BaseURL+"/path"` concatenations in billing, user, search, robot, organization, and repository with `c.buildURL()` so path construction is centralized.
- Teach `scripts/check-swagger-alignment.go` to recognize `buildURL()` calls so the scanner still finds implemented endpoints.

## Test plan
- [x] `go test ./lib/`
- [x] `go vet ./lib/ ./scripts/`
- [ ] `make check-swagger-alignment` (needs network to quay.io)

Closes #164

Made with [Cursor](https://cursor.com)