### PR TITLE
refactor: use http.Method* constants instead of HTTP method strings

### DIFF
--- a/lib/application.go
+++ b/lib/application.go
@@ -15,6 +15,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetApplications retrieves applications for an organization
@@ -23,7 +24,7 @@ func (c *Client) GetApplications(orgname string) (*Applications, error) {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/applications", orgname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/applications", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get applications request: %w", err)
 	}
@@ -45,7 +46,7 @@ func (c *Client) CreateApplication(orgname, name, description, applicationURI, r
 		return nil, fmt.Errorf("name is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/applications", orgname), CreateApplicationRequest{
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/applications", orgname), CreateApplicationRequest{
 		Name:           name,
 		Description:    description,
 		ApplicationURI: applicationURI,
@@ -72,7 +73,7 @@ func (c *Client) GetApplication(orgname, clientID string) (*Application, error) 
 		return nil, fmt.Errorf("clientID is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/applications/%s", orgname, clientID), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/applications/%s", orgname, clientID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get application request: %w", err)
 	}
@@ -94,7 +95,7 @@ func (c *Client) UpdateApplication(orgname, clientID, name, description, applica
 		return nil, fmt.Errorf("clientID is required")
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/applications/%s", orgname, clientID), CreateApplicationRequest{
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/applications/%s", orgname, clientID), CreateApplicationRequest{
 		Name:           name,
 		Description:    description,
 		ApplicationURI: applicationURI,
@@ -121,7 +122,7 @@ func (c *Client) DeleteApplication(orgname, clientID string) error {
 		return fmt.Errorf("clientID is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/organization/%s/applications/%s", orgname, clientID), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/applications/%s", orgname, clientID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete application request: %w", err)
 	}
@@ -142,7 +143,7 @@ func (c *Client) ResetApplicationClientSecret(orgname, clientID string) (*Applic
 		return nil, fmt.Errorf("clientID is required")
 	}
 
-	req, err := newRequest("POST", c.buildURL("/organization/%s/applications/%s/resetclientsecret", orgname, clientID), nil)
+	req, err := newRequest(http.MethodPost, c.buildURL("/organization/%s/applications/%s/resetclientsecret", orgname, clientID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create reset application client secret request: %w", err)
 	}

--- a/lib/auto_prune.go
+++ b/lib/auto_prune.go
@@ -14,6 +14,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetAutoPrunePolicies retrieves auto-prune policies for an organization
@@ -22,7 +23,7 @@ func (c *Client) GetAutoPrunePolicies(orgname string) (*AutoPrunePolicies, error
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/autoprunepolicy", orgname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/autoprunepolicy", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get auto-prune policies request: %w", err)
 	}
@@ -44,7 +45,7 @@ func (c *Client) CreateAutoPrunePolicy(orgname, method string, value int, tagPat
 		return nil, fmt.Errorf("method is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/autoprunepolicy", orgname), CreateAutoPruneRequest{
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/autoprunepolicy", orgname), CreateAutoPruneRequest{
 		Method:     method,
 		Value:      value,
 		TagPattern: tagPattern,
@@ -70,7 +71,7 @@ func (c *Client) GetAutoPrunePolicy(orgname, policyUUID string) (*AutoPrunePolic
 		return nil, fmt.Errorf("policyUUID is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get auto-prune policy request: %w", err)
 	}
@@ -95,7 +96,7 @@ func (c *Client) UpdateAutoPrunePolicy(orgname, policyUUID, method string, value
 		return nil, fmt.Errorf("method is required")
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), CreateAutoPruneRequest{
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), CreateAutoPruneRequest{
 		Method:     method,
 		Value:      value,
 		TagPattern: tagPattern,
@@ -121,7 +122,7 @@ func (c *Client) DeleteAutoPrunePolicy(orgname, policyUUID string) error {
 		return fmt.Errorf("policyUUID is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete auto-prune policy request: %w", err)
 	}

--- a/lib/billing.go
+++ b/lib/billing.go
@@ -21,6 +21,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetOrganizationBilling returns billing information for an organization
@@ -30,7 +31,7 @@ func (c *Client) GetOrganizationBilling(orgname string) (*BillingInfo, error) {
 	}
 
 	// Get new request
-	req, err := newRequest("GET", c.buildURL("/organization/%s/plan", orgname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/plan", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization billing request: %w", err)
 	}
@@ -46,7 +47,7 @@ func (c *Client) GetOrganizationBilling(orgname string) (*BillingInfo, error) {
 // GetUserBilling returns billing information for the current user
 func (c *Client) GetUserBilling() (*BillingInfo, error) {
 	// Get new request
-	req, err := newRequest("GET", c.buildURL("/user/plan"), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/user/plan"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user billing request: %w", err)
 	}
@@ -66,7 +67,7 @@ func (c *Client) GetOrganizationSubscription(orgname string) (*Subscription, err
 	}
 
 	// Get new request
-	req, err := newRequest("GET", c.buildURL("/organization/%s/plan", orgname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/plan", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization subscription request: %w", err)
 	}
@@ -82,7 +83,7 @@ func (c *Client) GetOrganizationSubscription(orgname string) (*Subscription, err
 // GetUserSubscription returns subscription details for the current user
 func (c *Client) GetUserSubscription() (*Subscription, error) {
 	// Get new request
-	req, err := newRequest("GET", c.buildURL("/user/plan"), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/user/plan"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user subscription request: %w", err)
 	}
@@ -102,7 +103,7 @@ func (c *Client) GetOrganizationInvoices(orgname string) ([]Invoice, error) {
 	}
 
 	// Get new request
-	req, err := newRequest("GET", c.buildURL("/organization/%s/invoices", orgname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/invoices", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization invoices request: %w", err)
 	}
@@ -125,7 +126,7 @@ func (c *Client) GetUserInvoices() ([]Invoice, error) {
 // GetAvailablePlans returns available subscription plans
 func (c *Client) GetAvailablePlans() ([]Subscription, error) {
 	// Get new request
-	req, err := newRequest("GET", c.buildURL("/plans"), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/plans"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get available plans request: %w", err)
 	}

--- a/lib/build.go
+++ b/lib/build.go
@@ -17,6 +17,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetBuilds retrieves a list of builds for a repository
@@ -33,7 +34,7 @@ func (c *Client) GetBuilds(namespace, repository string, limit int) (*Builds, er
 		url = fmt.Sprintf("%s?limit=%d", url, limit)
 	}
 
-	req, err := newRequest("GET", url, nil)
+	req, err := newRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get builds request: %w", err)
 	}
@@ -58,7 +59,7 @@ func (c *Client) GetBuild(namespace, repository, buildUUID string) (*Build, erro
 		return nil, fmt.Errorf("buildUUID is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/build/%s", namespace, repository, buildUUID), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/build/%s", namespace, repository, buildUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get build request: %w", err)
 	}
@@ -83,7 +84,7 @@ func (c *Client) GetBuildLogs(namespace, repository, buildUUID string) (*BuildLo
 		return nil, fmt.Errorf("buildUUID is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/build/%s/logs", namespace, repository, buildUUID), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/build/%s/logs", namespace, repository, buildUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get build logs request: %w", err)
 	}
@@ -105,7 +106,7 @@ func (c *Client) RequestBuild(namespace, repository string, buildRequest *Reques
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/build/", namespace, repository), buildRequest)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/build/", namespace, repository), buildRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request build request: %w", err)
 	}
@@ -130,7 +131,7 @@ func (c *Client) CancelBuild(namespace, repository, buildUUID string) error {
 		return fmt.Errorf("buildUUID is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/build/%s", namespace, repository, buildUUID), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/build/%s", namespace, repository, buildUUID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create cancel build request: %w", err)
 	}
@@ -154,7 +155,7 @@ func (c *Client) GetBuildStatus(namespace, repository, buildUUID string) (*Build
 		return nil, fmt.Errorf("buildUUID is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/build/%s/status", namespace, repository, buildUUID), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/build/%s/status", namespace, repository, buildUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get build status request: %w", err)
 	}

--- a/lib/discovery.go
+++ b/lib/discovery.go
@@ -13,11 +13,12 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetDiscovery retrieves API discovery information
 func (c *Client) GetDiscovery() (*Discovery, error) {
-	req, err := newRequest("GET", c.buildURL("/discovery"), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/discovery"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discovery request: %w", err)
 	}
@@ -32,7 +33,7 @@ func (c *Client) GetDiscovery() (*Discovery, error) {
 
 // GetRegistryCapabilities retrieves the registry capabilities including sparse manifest support and mirror architectures
 func (c *Client) GetRegistryCapabilities() (*RegistryCapabilities, error) {
-	req, err := newRequest("GET", c.buildURL("/registry/capabilities"), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/registry/capabilities"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create registry capabilities request: %w", err)
 	}
@@ -51,7 +52,7 @@ func (c *Client) GetAppInfo(clientID string) (*Application, error) {
 		return nil, fmt.Errorf("clientID is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/app/%s", clientID), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/app/%s", clientID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get app info request: %w", err)
 	}
@@ -70,7 +71,7 @@ func (c *Client) GetEntities(prefix string, includeOrgs, includeTeams bool) (*En
 		return nil, fmt.Errorf("prefix is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/entities/%s", prefix), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/entities/%s", prefix), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get entities request: %w", err)
 	}

--- a/lib/error.go
+++ b/lib/error.go
@@ -13,6 +13,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetErrorType retrieves details about a specific error type
@@ -21,7 +22,7 @@ func (c *Client) GetErrorType(errorType string) (*ErrorType, error) {
 		return nil, fmt.Errorf("errorType is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/error/%s", errorType), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/error/%s", errorType), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create error type request: %w", err)
 	}

--- a/lib/logs.go
+++ b/lib/logs.go
@@ -51,7 +51,7 @@ func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate str
 	}
 
 	// Get new request
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/aggregatelogs", namespace, repository), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/aggregatelogs", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repository aggregate logs request: %w", err)
 	}
@@ -79,7 +79,7 @@ func (c *Client) GetLogs(namespace, repository, nextPage, startDate, endDate str
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/logs", namespace, repository), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/logs", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repository logs request: %w", err)
 	}
@@ -100,7 +100,7 @@ func (c *Client) GetOrganizationLogs(orgname, nextPage, startDate, endDate strin
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/logs", orgname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/logs", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization logs request: %w", err)
 	}
@@ -121,7 +121,7 @@ func (c *Client) GetOrganizationAggregatedLogs(orgname, startDate, endDate strin
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/aggregatelogs", orgname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/aggregatelogs", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization aggregate logs request: %w", err)
 	}
@@ -145,7 +145,7 @@ func (c *Client) ExportOrganizationLogs(orgname string, request *ExportLogsReque
 		return fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/exportlogs", orgname), request)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/exportlogs", orgname), request)
 	if err != nil {
 		return fmt.Errorf("failed to create export organization logs request: %w", err)
 	}
@@ -159,7 +159,7 @@ func (c *Client) ExportOrganizationLogs(orgname string, request *ExportLogsReque
 
 // GetUserLogs returns the logs for the current user
 func (c *Client) GetUserLogs(nextPage, startDate, endDate string) (*Logs, error) {
-	req, err := newRequest("GET", c.buildURL("/user/logs"), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/user/logs"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user logs request: %w", err)
 	}
@@ -176,7 +176,7 @@ func (c *Client) GetUserLogs(nextPage, startDate, endDate string) (*Logs, error)
 
 // GetUserAggregatedLogs returns the aggregated logs for the current user
 func (c *Client) GetUserAggregatedLogs(startDate, endDate string) (*AggregatedLogs, error) {
-	req, err := newRequest("GET", c.buildURL("/user/aggregatelogs"), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/user/aggregatelogs"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user aggregate logs request: %w", err)
 	}
@@ -196,7 +196,7 @@ func (c *Client) GetUserAggregatedLogs(startDate, endDate string) (*AggregatedLo
 
 // ExportUserLogs exports the logs for the current user
 func (c *Client) ExportUserLogs(request *ExportLogsRequest) error {
-	req, err := newRequestWithBody("POST", c.buildURL("/user/exportlogs"), request)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/user/exportlogs"), request)
 	if err != nil {
 		return fmt.Errorf("failed to create export user logs request: %w", err)
 	}
@@ -217,7 +217,7 @@ func (c *Client) ExportRepositoryLogs(namespace, repository string, request *Exp
 		return fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/exportlogs", namespace, repository), request)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/exportlogs", namespace, repository), request)
 	if err != nil {
 		return fmt.Errorf("failed to create export repository logs request: %w", err)
 	}

--- a/lib/manifest.go
+++ b/lib/manifest.go
@@ -20,6 +20,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetManifest retrieves detailed information about a specific manifest
@@ -34,7 +35,7 @@ func (c *Client) GetManifest(namespace, repository, manifestRef string) (*Manife
 		return nil, fmt.Errorf("manifestRef is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/manifest/%s", namespace, repository, manifestRef), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/manifest/%s", namespace, repository, manifestRef), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest request: %w", err)
 	}
@@ -59,7 +60,7 @@ func (c *Client) DeleteManifest(namespace, repository, manifestRef string) error
 		return fmt.Errorf("manifestRef is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/manifest/%s", namespace, repository, manifestRef), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/manifest/%s", namespace, repository, manifestRef), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete manifest request: %w", err)
 	}
@@ -83,7 +84,7 @@ func (c *Client) GetManifestLabels(namespace, repository, manifestRef string) (*
 		return nil, fmt.Errorf("manifestRef is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/manifest/%s/labels", namespace, repository, manifestRef), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/manifest/%s/labels", namespace, repository, manifestRef), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest labels request: %w", err)
 	}
@@ -123,7 +124,7 @@ func (c *Client) AddManifestLabel(namespace, repository, manifestRef, key, value
 		addReq.MediaType = mediaType
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/manifest/%s/labels", namespace, repository, manifestRef), addReq)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/manifest/%s/labels", namespace, repository, manifestRef), addReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create add manifest label request: %w", err)
 	}
@@ -151,7 +152,7 @@ func (c *Client) GetManifestLabel(namespace, repository, manifestRef, labelID st
 		return nil, fmt.Errorf("labelID is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/manifest/%s/labels/%s", namespace, repository, manifestRef, labelID), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/manifest/%s/labels/%s", namespace, repository, manifestRef, labelID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest label request: %w", err)
 	}
@@ -179,7 +180,7 @@ func (c *Client) DeleteManifestLabel(namespace, repository, manifestRef, labelID
 		return fmt.Errorf("labelID is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/manifest/%s/labels/%s", namespace, repository, manifestRef, labelID), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/manifest/%s/labels/%s", namespace, repository, manifestRef, labelID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete manifest label request: %w", err)
 	}

--- a/lib/messages.go
+++ b/lib/messages.go
@@ -13,11 +13,12 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetMessages retrieves system messages for the user
 func (c *Client) GetMessages() (*Messages, error) {
-	req, err := newRequest("GET", c.buildURL("/messages"), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/messages"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create messages request: %w", err)
 	}
@@ -57,7 +58,7 @@ func (c *Client) CreateMessage(content, severity, mediaType string) (*Message, e
 		},
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/messages"), body)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/messages"), body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create message request: %w", err)
 	}

--- a/lib/mirror.go
+++ b/lib/mirror.go
@@ -12,6 +12,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetMirrorConfig retrieves mirror configuration for a repository
@@ -23,7 +24,7 @@ func (c *Client) GetMirrorConfig(namespace, repository string) (*MirrorConfig, e
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/mirror", namespace, repository), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/mirror", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get mirror config request: %w", err)
 	}
@@ -45,7 +46,7 @@ func (c *Client) CreateMirrorConfig(namespace, repository string, config *Create
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/mirror", namespace, repository), config)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/mirror", namespace, repository), config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create mirror config request: %w", err)
 	}
@@ -67,7 +68,7 @@ func (c *Client) UpdateMirrorConfig(namespace, repository string, config *Update
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/mirror", namespace, repository), config)
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s/mirror", namespace, repository), config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update mirror config request: %w", err)
 	}

--- a/lib/notification.go
+++ b/lib/notification.go
@@ -34,6 +34,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetNotifications retrieves all notifications for a repository
@@ -45,7 +46,7 @@ func (c *Client) GetNotifications(namespace, repository string) (*RepositoryNoti
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/notification/", namespace, repository), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/notification/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get notifications request: %w", err)
 	}
@@ -70,7 +71,7 @@ func (c *Client) GetNotification(namespace, repository, uuid string) (*Repositor
 		return nil, fmt.Errorf("uuid is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/notification/%s", namespace, repository, uuid), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/notification/%s", namespace, repository, uuid), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get notification request: %w", err)
 	}
@@ -92,7 +93,7 @@ func (c *Client) CreateNotification(namespace, repository string, notificationRe
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/notification/", namespace, repository), notificationReq)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/notification/", namespace, repository), notificationReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create notification request: %w", err)
 	}
@@ -117,7 +118,7 @@ func (c *Client) DeleteNotification(namespace, repository, uuid string) error {
 		return fmt.Errorf("uuid is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/notification/%s", namespace, repository, uuid), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/notification/%s", namespace, repository, uuid), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete notification request: %w", err)
 	}
@@ -141,7 +142,7 @@ func (c *Client) TestNotification(namespace, repository, uuid string) error {
 		return fmt.Errorf("uuid is required")
 	}
 
-	req, err := newRequest("POST", c.buildURL("/repository/%s/%s/notification/%s/test", namespace, repository, uuid), nil)
+	req, err := newRequest(http.MethodPost, c.buildURL("/repository/%s/%s/notification/%s/test", namespace, repository, uuid), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create test notification request: %w", err)
 	}
@@ -165,7 +166,7 @@ func (c *Client) ResetNotification(namespace, repository, uuid string) error {
 		return fmt.Errorf("uuid is required")
 	}
 
-	req, err := newRequest("POST", c.buildURL("/repository/%s/%s/notification/%s/reset", namespace, repository, uuid), nil)
+	req, err := newRequest(http.MethodPost, c.buildURL("/repository/%s/%s/notification/%s/reset", namespace, repository, uuid), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create reset notification request: %w", err)
 	}
@@ -189,7 +190,7 @@ func (c *Client) UpdateNotification(namespace, repository, uuid string, notifica
 		return nil, fmt.Errorf("uuid is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/notification/%s", namespace, repository, uuid), notificationReq)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/notification/%s", namespace, repository, uuid), notificationReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update notification request: %w", err)
 	}

--- a/lib/org_marketplace.go
+++ b/lib/org_marketplace.go
@@ -13,6 +13,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetOrganizationMarketplace gets marketplace information for an organization
@@ -21,7 +22,7 @@ func (c *Client) GetOrganizationMarketplace(orgname string) (*MarketplaceInfo, e
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/marketplace", orgname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/marketplace", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization marketplace request: %w", err)
 	}
@@ -40,7 +41,7 @@ func (c *Client) CreateOrganizationMarketplaceSubscription(orgname string, subsc
 		return fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/marketplace", orgname), subscription)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/marketplace", orgname), subscription)
 	if err != nil {
 		return fmt.Errorf("failed to create marketplace subscription request: %w", err)
 	}
@@ -63,7 +64,7 @@ func (c *Client) BatchRemoveOrganizationMarketplaceSubscriptions(orgname string,
 	}{
 		SubscriptionIDs: subscriptionIDs,
 	}
-	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/marketplace/batchremove", orgname), body)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/marketplace/batchremove", orgname), body)
 	if err != nil {
 		return fmt.Errorf("failed to create batch remove marketplace subscriptions request: %w", err)
 	}
@@ -84,7 +85,7 @@ func (c *Client) DeleteOrganizationMarketplaceSubscription(orgname, subscription
 		return fmt.Errorf("subscriptionID is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/organization/%s/marketplace/%s", orgname, subscriptionID), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/marketplace/%s", orgname, subscriptionID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete marketplace subscription request: %w", err)
 	}

--- a/lib/org_robot.go
+++ b/lib/org_robot.go
@@ -24,6 +24,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // Robot Account Management
@@ -34,7 +35,7 @@ func (c *Client) GetRobotAccounts(orgname string) (*RobotAccounts, error) {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/robots", orgname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/robots", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get robot accounts request: %w", err)
 	}
@@ -56,7 +57,7 @@ func (c *Client) CreateRobotAccount(orgname, robotShortname, description string,
 		return nil, fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), CreateRobotRequest{
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), CreateRobotRequest{
 		Description:  description,
 		Unstructured: unstructured,
 	})
@@ -81,7 +82,7 @@ func (c *Client) GetRobotAccount(orgname, robotShortname string) (*RobotAccount,
 		return nil, fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get robot account request: %w", err)
 	}
@@ -103,7 +104,7 @@ func (c *Client) DeleteRobotAccount(orgname, robotShortname string) error {
 		return fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete robot account request: %w", err)
 	}
@@ -124,7 +125,7 @@ func (c *Client) RegenerateRobotToken(orgname, robotShortname string) (*RobotAcc
 		return nil, fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest("POST", c.buildURL("/organization/%s/robots/%s/regenerate", orgname, robotShortname), nil)
+	req, err := newRequest(http.MethodPost, c.buildURL("/organization/%s/robots/%s/regenerate", orgname, robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create regenerate robot token request: %w", err)
 	}
@@ -148,7 +149,7 @@ func (c *Client) GetRobotPermissions(orgname, robotShortname string) (*RobotPerm
 		return nil, fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/robots/%s/permissions", orgname, robotShortname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/robots/%s/permissions", orgname, robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get robot permissions request: %w", err)
 	}
@@ -176,7 +177,7 @@ func (c *Client) SetRobotRepositoryPermission(orgname, robotShortname, repositor
 		return fmt.Errorf("role is required")
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/robots/%s/permissions/%s", orgname, robotShortname, repository), map[string]interface{}{
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/robots/%s/permissions/%s", orgname, robotShortname, repository), map[string]interface{}{
 		fieldRole: role,
 	})
 	if err != nil {
@@ -202,7 +203,7 @@ func (c *Client) RemoveRobotRepositoryPermission(orgname, robotShortname, reposi
 		return fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/organization/%s/robots/%s/permissions/%s", orgname, robotShortname, repository), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/robots/%s/permissions/%s", orgname, robotShortname, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create remove robot repository permission request: %w", err)
 	}
@@ -225,7 +226,7 @@ func (c *Client) GetRobotFederation(orgname, robotShortname string) (*RobotFeder
 		return nil, fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/robots/%s/federation", orgname, robotShortname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/robots/%s/federation", orgname, robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get robot federation request: %w", err)
 	}
@@ -247,7 +248,7 @@ func (c *Client) CreateRobotFederation(orgname, robotShortname string, configs [
 		return fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/robots/%s/federation", orgname, robotShortname), configs)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/robots/%s/federation", orgname, robotShortname), configs)
 	if err != nil {
 		return fmt.Errorf("failed to create robot federation request: %w", err)
 	}
@@ -268,7 +269,7 @@ func (c *Client) DeleteRobotFederation(orgname, robotShortname string) error {
 		return fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/organization/%s/robots/%s/federation", orgname, robotShortname), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/robots/%s/federation", orgname, robotShortname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete robot federation request: %w", err)
 	}

--- a/lib/org_team.go
+++ b/lib/org_team.go
@@ -28,6 +28,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 const (
@@ -42,7 +43,7 @@ func (c *Client) GetTeams(orgname string) ([]Team, error) {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/teams", orgname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/teams", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get teams request: %w", err)
 	}
@@ -69,7 +70,7 @@ func (c *Client) CreateTeam(orgname, teamname, description, role string) (*Team,
 		return nil, fmt.Errorf("role is required")
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/team/%s", orgname, teamname), CreateTeamRequest{
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/team/%s", orgname, teamname), CreateTeamRequest{
 		Name:        teamname,
 		Description: description,
 		Role:        role,
@@ -95,7 +96,7 @@ func (c *Client) GetTeam(orgname, teamname string) (*Team, error) {
 		return nil, fmt.Errorf("teamname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/team/%s", orgname, teamname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/team/%s", orgname, teamname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get team request: %w", err)
 	}
@@ -117,7 +118,7 @@ func (c *Client) DeleteTeam(orgname, teamname string) error {
 		return fmt.Errorf("teamname is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/organization/%s/team/%s", orgname, teamname), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/team/%s", orgname, teamname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete team request: %w", err)
 	}
@@ -141,7 +142,7 @@ func (c *Client) UpdateTeam(orgname, teamname, description, role string) (*Team,
 		return nil, fmt.Errorf("role is required")
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/team/%s", orgname, teamname), map[string]interface{}{
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/team/%s", orgname, teamname), map[string]interface{}{
 		"description": description,
 		fieldRole:     role,
 	})
@@ -168,7 +169,7 @@ func (c *Client) GetTeamMembers(orgname, teamname string) (*TeamMembers, error) 
 		return nil, fmt.Errorf("teamname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/team/%s/members", orgname, teamname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/team/%s/members", orgname, teamname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get team members request: %w", err)
 	}
@@ -193,7 +194,7 @@ func (c *Client) AddTeamMember(orgname, teamname, membername string) error {
 		return fmt.Errorf("membername is required")
 	}
 
-	req, err := newRequest("PUT", c.buildURL("/organization/%s/team/%s/members/%s", orgname, teamname, membername), nil)
+	req, err := newRequest(http.MethodPut, c.buildURL("/organization/%s/team/%s/members/%s", orgname, teamname, membername), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create add team member request: %w", err)
 	}
@@ -217,7 +218,7 @@ func (c *Client) RemoveTeamMember(orgname, teamname, membername string) error {
 		return fmt.Errorf("membername is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/organization/%s/team/%s/members/%s", orgname, teamname, membername), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/team/%s/members/%s", orgname, teamname, membername), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create remove team member request: %w", err)
 	}
@@ -240,7 +241,7 @@ func (c *Client) GetTeamPermissions(orgname, teamname string) (*TeamPermissions,
 		return nil, fmt.Errorf("teamname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/team/%s/permissions", orgname, teamname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/team/%s/permissions", orgname, teamname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get team permissions request: %w", err)
 	}
@@ -268,7 +269,7 @@ func (c *Client) SetTeamRepositoryPermission(orgname, teamname, repository, role
 		return fmt.Errorf("role is required")
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/team/%s/permissions/%s", orgname, teamname, repository), map[string]interface{}{
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/team/%s/permissions/%s", orgname, teamname, repository), map[string]interface{}{
 		fieldRole: role,
 	})
 	if err != nil {
@@ -294,7 +295,7 @@ func (c *Client) RemoveTeamRepositoryPermission(orgname, teamname, repository st
 		return fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/organization/%s/team/%s/permissions/%s", orgname, teamname, repository), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/team/%s/permissions/%s", orgname, teamname, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create remove team repository permission request: %w", err)
 	}
@@ -320,7 +321,7 @@ func (c *Client) InviteTeamMember(orgname, teamname, email string) error {
 		return fmt.Errorf("email is required")
 	}
 
-	req, err := newRequest("PUT", c.buildURL("/organization/%s/team/%s/invite/%s", orgname, teamname, email), nil)
+	req, err := newRequest(http.MethodPut, c.buildURL("/organization/%s/team/%s/invite/%s", orgname, teamname, email), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create invite team member request: %w", err)
 	}
@@ -344,7 +345,7 @@ func (c *Client) DeleteTeamInvite(orgname, teamname, email string) error {
 		return fmt.Errorf("email is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/organization/%s/team/%s/invite/%s", orgname, teamname, email), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/team/%s/invite/%s", orgname, teamname, email), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete team invite request: %w", err)
 	}

--- a/lib/organization.go
+++ b/lib/organization.go
@@ -25,6 +25,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // Organization Management
@@ -38,7 +39,7 @@ func (c *Client) CreateOrganization(name, email string) (*Organization, error) {
 		return nil, fmt.Errorf("email is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/organization/"), CreateOrganizationRequest{
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/"), CreateOrganizationRequest{
 		Name:  name,
 		Email: email,
 	})
@@ -60,7 +61,7 @@ func (c *Client) GetOrganization(orgname string) (*Organization, error) {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s", orgname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization request: %w", err)
 	}
@@ -79,7 +80,7 @@ func (c *Client) DeleteOrganization(orgname string) error {
 		return fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/organization/%s", orgname), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s", orgname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete organization request: %w", err)
 	}
@@ -100,7 +101,7 @@ func (c *Client) UpdateOrganization(orgname, email string) (*Organization, error
 		return nil, fmt.Errorf("email is required")
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s", orgname), map[string]interface{}{
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s", orgname), map[string]interface{}{
 		"email": email,
 	})
 	if err != nil {
@@ -123,7 +124,7 @@ func (c *Client) GetOrganizationMembers(orgname string) (*OrganizationMembers, e
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/members", orgname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/members", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization members request: %w", err)
 	}
@@ -145,7 +146,7 @@ func (c *Client) GetOrganizationMember(orgname, membername string) (*Organizatio
 		return nil, fmt.Errorf("membername is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization member request: %w", err)
 	}
@@ -167,7 +168,7 @@ func (c *Client) AddOrganizationMember(orgname, membername string) error {
 		return fmt.Errorf("membername is required")
 	}
 
-	req, err := newRequest("PUT", c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
+	req, err := newRequest(http.MethodPut, c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create add organization member request: %w", err)
 	}
@@ -188,7 +189,7 @@ func (c *Client) RemoveOrganizationMember(orgname, membername string) error {
 		return fmt.Errorf("membername is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create remove organization member request: %w", err)
 	}
@@ -208,7 +209,7 @@ func (c *Client) GetOrganizationRepositories(orgname string) (*OrganizationRepos
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/repositories", orgname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/repositories", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization repositories request: %w", err)
 	}
@@ -229,7 +230,7 @@ func (c *Client) GetOrganizationCollaborators(orgname string) (*Collaborators, e
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/collaborators", orgname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/collaborators", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization collaborators request: %w", err)
 	}

--- a/lib/permissions.go
+++ b/lib/permissions.go
@@ -15,6 +15,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetRepositoryPermissions retrieves permissions for a repository
@@ -26,7 +27,7 @@ func (c *Client) GetRepositoryPermissions(namespace, repository string) (*Reposi
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/permissions", namespace, repository), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/permissions", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repository permissions request: %w", err)
 	}
@@ -55,7 +56,7 @@ func (c *Client) SetRepositoryPermission(namespace, repository, username, role s
 		return fmt.Errorf("role is required")
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/permissions/%s", namespace, repository, username), SetRepositoryPermissionRequest{
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s/permissions/%s", namespace, repository, username), SetRepositoryPermissionRequest{
 		Role: role,
 	})
 	if err != nil {
@@ -81,7 +82,7 @@ func (c *Client) RemoveRepositoryPermission(namespace, repository, username stri
 		return fmt.Errorf("username is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/permissions/%s", namespace, repository, username), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/permissions/%s", namespace, repository, username), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create remove repository permission request: %w", err)
 	}
@@ -104,7 +105,7 @@ func (c *Client) ListUserPermissions(namespace, repository string) (*RepositoryP
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/permissions/user/", namespace, repository), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/permissions/user/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list user permissions request: %w", err)
 	}
@@ -129,7 +130,7 @@ func (c *Client) GetUserPermission(namespace, repository, username string) (*Rep
 		return nil, fmt.Errorf("username is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/permissions/user/%s", namespace, repository, username), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/permissions/user/%s", namespace, repository, username), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user permission request: %w", err)
 	}
@@ -158,7 +159,7 @@ func (c *Client) SetUserPermission(namespace, repository, username, role string)
 		return fmt.Errorf("role is required")
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/permissions/user/%s", namespace, repository, username), SetRepositoryPermissionRequest{
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s/permissions/user/%s", namespace, repository, username), SetRepositoryPermissionRequest{
 		Role: role,
 	})
 	if err != nil {
@@ -184,7 +185,7 @@ func (c *Client) DeleteUserPermission(namespace, repository, username string) er
 		return fmt.Errorf("username is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/permissions/user/%s", namespace, repository, username), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/permissions/user/%s", namespace, repository, username), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete user permission request: %w", err)
 	}
@@ -208,7 +209,7 @@ func (c *Client) GetUserTransitivePermission(namespace, repository, username str
 		return nil, fmt.Errorf("username is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/permissions/user/%s/transitive", namespace, repository, username), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/permissions/user/%s/transitive", namespace, repository, username), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user transitive permission request: %w", err)
 	}
@@ -232,7 +233,7 @@ func (c *Client) ListTeamPermissions(namespace, repository string) (*RepositoryP
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/permissions/team/", namespace, repository), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/permissions/team/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list team permissions request: %w", err)
 	}
@@ -257,7 +258,7 @@ func (c *Client) GetTeamPermission(namespace, repository, teamname string) (*Rep
 		return nil, fmt.Errorf("teamname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/permissions/team/%s", namespace, repository, teamname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/permissions/team/%s", namespace, repository, teamname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get team permission request: %w", err)
 	}
@@ -286,7 +287,7 @@ func (c *Client) SetTeamPermission(namespace, repository, teamname, role string)
 		return fmt.Errorf("role is required")
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/permissions/team/%s", namespace, repository, teamname), SetRepositoryPermissionRequest{
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s/permissions/team/%s", namespace, repository, teamname), SetRepositoryPermissionRequest{
 		Role: role,
 	})
 	if err != nil {
@@ -312,7 +313,7 @@ func (c *Client) DeleteTeamPermission(namespace, repository, teamname string) er
 		return fmt.Errorf("teamname is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/permissions/team/%s", namespace, repository, teamname), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/permissions/team/%s", namespace, repository, teamname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete team permission request: %w", err)
 	}

--- a/lib/prototype.go
+++ b/lib/prototype.go
@@ -23,6 +23,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetPrototypes retrieves all permission prototypes for an organization
@@ -31,7 +32,7 @@ func (c *Client) GetPrototypes(orgname string) (*Prototypes, error) {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/prototypes", orgname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/prototypes", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get prototypes request: %w", err)
 	}
@@ -50,7 +51,7 @@ func (c *Client) CreatePrototype(orgname string, createReq *CreatePrototypeReque
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/prototypes", orgname), createReq)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/prototypes", orgname), createReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create prototype request: %w", err)
 	}
@@ -72,7 +73,7 @@ func (c *Client) GetPrototype(orgname, prototypeUUID string) (*Prototype, error)
 		return nil, fmt.Errorf("prototypeUUID is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeUUID), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get prototype request: %w", err)
 	}
@@ -94,7 +95,7 @@ func (c *Client) UpdatePrototype(orgname, prototypeUUID string, updateReq *Updat
 		return nil, fmt.Errorf("prototypeUUID is required")
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeUUID), updateReq)
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeUUID), updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update prototype request: %w", err)
 	}
@@ -116,7 +117,7 @@ func (c *Client) DeletePrototype(orgname, prototypeUUID string) error {
 		return fmt.Errorf("prototypeUUID is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeUUID), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeUUID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete prototype request: %w", err)
 	}

--- a/lib/proxy_cache.go
+++ b/lib/proxy_cache.go
@@ -12,6 +12,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetProxyCacheConfig retrieves proxy cache configuration for an organization
@@ -20,7 +21,7 @@ func (c *Client) GetProxyCacheConfig(orgname string) (*ProxyCacheConfig, error) 
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/proxycache", orgname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/proxycache", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get proxy cache config request: %w", err)
 	}
@@ -42,7 +43,7 @@ func (c *Client) CreateProxyCacheConfig(orgname, upstreamRegistry string, insecu
 		return nil, fmt.Errorf("upstreamRegistry is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/proxycache", orgname), map[string]interface{}{
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/proxycache", orgname), map[string]interface{}{
 		"upstream_registry": upstreamRegistry,
 		"insecure":          insecure,
 		"expiration":        expiration,
@@ -65,7 +66,7 @@ func (c *Client) DeleteProxyCacheConfig(orgname string) error {
 		return fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/organization/%s/proxycache", orgname), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/proxycache", orgname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete proxy cache config request: %w", err)
 	}

--- a/lib/quota.go
+++ b/lib/quota.go
@@ -13,6 +13,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetQuota retrieves quota information for an organization
@@ -21,7 +22,7 @@ func (c *Client) GetQuota(orgname string) (*Quota, error) {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/organization/%s/quota", orgname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/quota", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get quota request: %w", err)
 	}
@@ -40,7 +41,7 @@ func (c *Client) CreateQuota(orgname string, limitBytes int64) (*Quota, error) {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/organization/%s/quota", orgname), CreateQuotaRequest{
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/quota", orgname), CreateQuotaRequest{
 		LimitBytes: limitBytes,
 	})
 	if err != nil {
@@ -61,7 +62,7 @@ func (c *Client) UpdateQuota(orgname string, limitBytes int64) (*Quota, error) {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/organization/%s/quota", orgname), CreateQuotaRequest{
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/quota", orgname), CreateQuotaRequest{
 		LimitBytes: limitBytes,
 	})
 	if err != nil {
@@ -82,7 +83,7 @@ func (c *Client) DeleteQuota(orgname string) error {
 		return fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/organization/%s/quota", orgname), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/quota", orgname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete quota request: %w", err)
 	}

--- a/lib/repository.go
+++ b/lib/repository.go
@@ -16,7 +16,10 @@ ListRepositories() supports a popularity flag for pull count data.
 */
 package lib
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 type RepositoryTags struct {
 	Tags          []Tag `json:"tags,omitempty"`
@@ -56,7 +59,7 @@ func (c *Client) GetRepository(namespace, repository string) (RepositoryWithTags
 	}
 
 	repoURL := c.buildURL("/repository/%s/%s", namespace, repository)
-	req, err := newRequest("GET", repoURL, nil)
+	req, err := newRequest(http.MethodGet, repoURL, nil)
 	if err != nil {
 		return RepositoryWithTags{}, fmt.Errorf("failed to create request for repository: %w", err)
 	}
@@ -89,7 +92,7 @@ func (c *Client) CreateRepository(namespace, repository, visibility, description
 		return nil, fmt.Errorf("visibility is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/repository"), CreateRepositoryRequest{
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository"), CreateRepositoryRequest{
 		Repository:  repository,
 		Namespace:   namespace,
 		Visibility:  visibility,
@@ -126,7 +129,7 @@ func (c *Client) UpdateRepository(namespace, repository, description, visibility
 		updateReq.Visibility = visibility
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s", namespace, repository), updateReq)
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s", namespace, repository), updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update repository request: %w", err)
 	}
@@ -148,7 +151,7 @@ func (c *Client) DeleteRepository(namespace, repository string) error {
 		return fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s", namespace, repository), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s", namespace, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete repository request: %w", err)
 	}
@@ -162,7 +165,7 @@ func (c *Client) DeleteRepository(namespace, repository string) error {
 
 // ListRepositories lists all repositories visible to the user
 func (c *Client) ListRepositories(namespace string, public, starred, popularity bool, page, limit int) (*RepositoryList, error) {
-	req, err := newRequest("GET", c.buildURL("/repository"), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list repositories request: %w", err)
 	}
@@ -266,7 +269,7 @@ func (c *Client) ChangeRepositoryVisibility(namespace, repository, visibility st
 	}{
 		Visibility: visibility,
 	}
-	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/changevisibility", namespace, repository), body)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/changevisibility", namespace, repository), body)
 	if err != nil {
 		return fmt.Errorf("failed to create change visibility request: %w", err)
 	}
@@ -287,7 +290,7 @@ func (c *Client) ListTagsPage(namespace, repository string, limit, page int, onl
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/tag/", namespace, repository), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/tag/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list tags request: %w", err)
 	}
@@ -321,7 +324,7 @@ func (c *Client) ListTags(namespace, repository string, limit int, onlyActive bo
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/tag/", namespace, repository), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/tag/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list tags request: %w", err)
 	}

--- a/lib/repotoken.go
+++ b/lib/repotoken.go
@@ -17,6 +17,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetRepoTokens retrieves all tokens for a repository.
@@ -30,7 +31,7 @@ func (c *Client) GetRepoTokens(namespace, repository string) (*RepoTokens, error
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/tokens", namespace, repository), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/tokens", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repo tokens request: %w", err)
 	}
@@ -54,7 +55,7 @@ func (c *Client) CreateRepoToken(namespace, repository string, createReq *Create
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/tokens", namespace, repository), createReq)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/tokens", namespace, repository), createReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create repo token request: %w", err)
 	}
@@ -81,7 +82,7 @@ func (c *Client) GetRepoToken(namespace, repository, code string) (*RepoToken, e
 		return nil, fmt.Errorf("code is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/tokens/%s", namespace, repository, code), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/tokens/%s", namespace, repository, code), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repo token request: %w", err)
 	}
@@ -108,7 +109,7 @@ func (c *Client) UpdateRepoToken(namespace, repository, code string, updateReq *
 		return nil, fmt.Errorf("code is required")
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/tokens/%s", namespace, repository, code), updateReq)
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s/tokens/%s", namespace, repository, code), updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update repo token request: %w", err)
 	}
@@ -135,7 +136,7 @@ func (c *Client) DeleteRepoToken(namespace, repository, code string) error {
 		return fmt.Errorf("code is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/tokens/%s", namespace, repository, code), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/tokens/%s", namespace, repository, code), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete repo token request: %w", err)
 	}

--- a/lib/robot.go
+++ b/lib/robot.go
@@ -18,11 +18,12 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetUserRobotAccounts retrieves all robot accounts for the authenticated user
 func (c *Client) GetUserRobotAccounts() (*RobotAccounts, error) {
-	req, err := newRequest("GET", c.buildURL("/user/robots"), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/user/robots"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user robots request: %w", err)
 	}
@@ -41,7 +42,7 @@ func (c *Client) GetUserRobotAccount(robotShortname string) (*RobotAccount, erro
 		return nil, fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/user/robots/%s", robotShortname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/user/robots/%s", robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user robot request: %w", err)
 	}
@@ -65,7 +66,7 @@ func (c *Client) CreateUserRobotAccount(robotShortname, description string, unst
 		Unstructured: unstructured,
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/user/robots/%s", robotShortname), createReq)
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/user/robots/%s", robotShortname), createReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user robot request: %w", err)
 	}
@@ -84,7 +85,7 @@ func (c *Client) DeleteUserRobotAccount(robotShortname string) error {
 		return fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/user/robots/%s", robotShortname), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/user/robots/%s", robotShortname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete user robot request: %w", err)
 	}
@@ -102,7 +103,7 @@ func (c *Client) RegenerateUserRobotToken(robotShortname string) (*RobotAccount,
 		return nil, fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest("POST", c.buildURL("/user/robots/%s/regenerate", robotShortname), nil)
+	req, err := newRequest(http.MethodPost, c.buildURL("/user/robots/%s/regenerate", robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create regenerate user robot token request: %w", err)
 	}
@@ -121,7 +122,7 @@ func (c *Client) GetUserRobotPermissions(robotShortname string) (*RobotPermissio
 		return nil, fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/user/robots/%s/permissions", robotShortname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/user/robots/%s/permissions", robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user robot permissions request: %w", err)
 	}
@@ -140,7 +141,7 @@ func (c *Client) GetUserRobotFederation(robotShortname string) (*RobotFederation
 		return nil, fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/user/robots/%s/federation", robotShortname), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/user/robots/%s/federation", robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user robot federation request: %w", err)
 	}
@@ -159,7 +160,7 @@ func (c *Client) CreateUserRobotFederation(robotShortname string, configs []Robo
 		return fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/user/robots/%s/federation", robotShortname), configs)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/user/robots/%s/federation", robotShortname), configs)
 	if err != nil {
 		return fmt.Errorf("failed to create user robot federation request: %w", err)
 	}
@@ -177,7 +178,7 @@ func (c *Client) DeleteUserRobotFederation(robotShortname string) error {
 		return fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/user/robots/%s/federation", robotShortname), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/user/robots/%s/federation", robotShortname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete user robot federation request: %w", err)
 	}

--- a/lib/search.go
+++ b/lib/search.go
@@ -14,6 +14,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // SearchRepositories searches for repositories matching the query
@@ -22,7 +23,7 @@ func (c *Client) SearchRepositories(query string, page int) (*SearchRepositoryRe
 		return nil, fmt.Errorf("query is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/find/repositories"), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/find/repositories"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create search repositories request: %w", err)
 	}
@@ -47,7 +48,7 @@ func (c *Client) SearchAll(query string) (*SearchAllResult, error) {
 		return nil, fmt.Errorf("query is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/find/all"), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/find/all"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create search all request: %w", err)
 	}

--- a/lib/secscan.go
+++ b/lib/secscan.go
@@ -13,6 +13,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetManifestSecurity retrieves security scan information for a specific manifest
@@ -27,7 +28,7 @@ func (c *Client) GetManifestSecurity(namespace, repository, manifestRef string, 
 		return nil, fmt.Errorf("manifestRef is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/manifest/%s/security", namespace, repository, manifestRef), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/manifest/%s/security", namespace, repository, manifestRef), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest security request: %w", err)
 	}

--- a/lib/tag.go
+++ b/lib/tag.go
@@ -17,6 +17,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetTag retrieves detailed information about a specific tag
@@ -31,7 +32,7 @@ func (c *Client) GetTag(namespace, repository, tag string) (*Tag, error) {
 		return nil, fmt.Errorf("tag is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get tag request: %w", err)
 	}
@@ -62,7 +63,7 @@ func (c *Client) UpdateTag(namespace, repository, tag, expiration string) (*Tag,
 		updateReq.Expiration = expiration
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), updateReq)
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update tag request: %w", err)
 	}
@@ -87,7 +88,7 @@ func (c *Client) DeleteTag(namespace, repository, tag string) error {
 		return fmt.Errorf("tag is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete tag request: %w", err)
 	}
@@ -111,7 +112,7 @@ func (c *Client) GetTagHistory(namespace, repository, tag string) (*TagHistory, 
 		return nil, fmt.Errorf("tag is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/tag/%s/history", namespace, repository, tag), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/tag/%s/history", namespace, repository, tag), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get tag history request: %w", err)
 	}
@@ -139,7 +140,7 @@ func (c *Client) RevertTag(namespace, repository, tag, manifestDigest string) (*
 		return nil, fmt.Errorf("manifestDigest is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/tag/%s/revert", namespace, repository, tag), map[string]interface{}{
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/tag/%s/revert", namespace, repository, tag), map[string]interface{}{
 		"manifest_digest": manifestDigest,
 	})
 	if err != nil {
@@ -174,7 +175,7 @@ func (c *Client) ChangeTag(namespace, repository, tag, manifestDigest string) er
 	}{
 		ManifestDigest: manifestDigest,
 	}
-	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), body)
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), body)
 	if err != nil {
 		return fmt.Errorf("failed to create change tag request: %w", err)
 	}
@@ -206,7 +207,7 @@ func (c *Client) RestoreTag(namespace, repository, tag, manifestDigest string) e
 	}{
 		ManifestDigest: manifestDigest,
 	}
-	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/tag/%s/restore", namespace, repository, tag), body)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/tag/%s/restore", namespace, repository, tag), body)
 	if err != nil {
 		return fmt.Errorf("failed to create restore tag request: %w", err)
 	}

--- a/lib/trigger.go
+++ b/lib/trigger.go
@@ -24,6 +24,7 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetTriggers retrieves all build triggers for a repository
@@ -35,7 +36,7 @@ func (c *Client) GetTriggers(namespace, repository string) (*BuildTriggers, erro
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/trigger/", namespace, repository), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/trigger/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get triggers request: %w", err)
 	}
@@ -60,7 +61,7 @@ func (c *Client) GetTrigger(namespace, repository, triggerUUID string) (*BuildTr
 		return nil, fmt.Errorf("triggerUUID is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get trigger request: %w", err)
 	}
@@ -85,7 +86,7 @@ func (c *Client) DeleteTrigger(namespace, repository, triggerUUID string) error 
 		return fmt.Errorf("triggerUUID is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete trigger request: %w", err)
 	}
@@ -113,7 +114,7 @@ func (c *Client) UpdateTrigger(namespace, repository, triggerUUID string, enable
 		"enabled": enabled,
 	}
 
-	req, err := newRequestWithBody("PUT", c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), body)
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update trigger request: %w", err)
 	}
@@ -143,7 +144,7 @@ func (c *Client) StartTriggerBuild(namespace, repository, triggerUUID string, tr
 		body = triggerReq
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/trigger/%s/start", namespace, repository, triggerUUID), body)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/trigger/%s/start", namespace, repository, triggerUUID), body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create start trigger build request: %w", err)
 	}
@@ -168,7 +169,7 @@ func (c *Client) ActivateTrigger(namespace, repository, triggerUUID string, acti
 		return nil, fmt.Errorf("triggerUUID is required")
 	}
 
-	req, err := newRequestWithBody("POST", c.buildURL("/repository/%s/%s/trigger/%s/activate", namespace, repository, triggerUUID), activateReq)
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/trigger/%s/activate", namespace, repository, triggerUUID), activateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create activate trigger request: %w", err)
 	}
@@ -193,7 +194,7 @@ func (c *Client) GetTriggerBuilds(namespace, repository, triggerUUID string, lim
 		return nil, fmt.Errorf("triggerUUID is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/repository/%s/%s/trigger/%s/builds", namespace, repository, triggerUUID), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/trigger/%s/builds", namespace, repository, triggerUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get trigger builds request: %w", err)
 	}

--- a/lib/user.go
+++ b/lib/user.go
@@ -18,11 +18,12 @@ package lib
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // GetUser retrieves information about the current authenticated user
 func (c *Client) GetUser() (*UserDetails, error) {
-	req, err := newRequest("GET", c.buildURL("/user"), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/user"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user request: %w", err)
 	}
@@ -37,7 +38,7 @@ func (c *Client) GetUser() (*UserDetails, error) {
 
 // GetStarredRepositories retrieves repositories starred by the current user
 func (c *Client) GetStarredRepositories() (*StarredRepositories, error) {
-	req, err := newRequest("GET", c.buildURL("/user/starred"), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/user/starred"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get starred repositories request: %w", err)
 	}
@@ -59,7 +60,7 @@ func (c *Client) StarRepository(namespace, repository string) error {
 		return fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest("PUT", c.buildURL("/repository/%s/%s/star", namespace, repository), nil)
+	req, err := newRequest(http.MethodPut, c.buildURL("/repository/%s/%s/star", namespace, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create star repository request: %w", err)
 	}
@@ -80,7 +81,7 @@ func (c *Client) UnstarRepository(namespace, repository string) error {
 		return fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest("DELETE", c.buildURL("/repository/%s/%s/star", namespace, repository), nil)
+	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/star", namespace, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create unstar repository request: %w", err)
 	}
@@ -98,7 +99,7 @@ func (c *Client) GetUserByUsername(username string) (*UserDetails, error) {
 		return nil, fmt.Errorf("username is required")
 	}
 
-	req, err := newRequest("GET", c.buildURL("/users/%s", username), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/users/%s", username), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user by username request: %w", err)
 	}
@@ -113,7 +114,7 @@ func (c *Client) GetUserByUsername(username string) (*UserDetails, error) {
 
 // GetUserMarketplace retrieves marketplace information for the current user
 func (c *Client) GetUserMarketplace() (*MarketplaceInfo, error) {
-	req, err := newRequest("GET", c.buildURL("/user/marketplace"), nil)
+	req, err := newRequest(http.MethodGet, c.buildURL("/user/marketplace"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user marketplace request: %w", err)
 	}

--- a/scripts/check-swagger-alignment.go
+++ b/scripts/check-swagger-alignment.go
@@ -152,7 +152,8 @@ func scanSourceEndpoints(libPath, baseURLVar string) ([]ImplementedEndpoint, err
 	sprintfPattern := regexp.MustCompile(`fmt\.Sprintf\s*\(\s*"%s(/[^"]+)"`)
 	buildURLPattern := regexp.MustCompile(`buildURL\s*\(\s*"(/[^"]+)"`)
 	// Match HTTP method from http.NewRequest or newRequest calls
-	methodPattern := regexp.MustCompile(`(?:http\.NewRequest|newRequest|newRequestWithBody)\s*\(\s*"(GET|POST|PUT|DELETE|PATCH)"`)
+	// (string literals or net/http Method* constants)
+	methodPattern := regexp.MustCompile(`(?:http\.NewRequest|newRequest|newRequestWithBody)\s*\(\s*(?:"(GET|POST|PUT|DELETE|PATCH)"|http\.Method(Get|Post|Put|Delete|Patch))`)
 
 	err := filepath.Walk(libPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -184,7 +185,12 @@ func scanSourceEndpoints(libPath, baseURLVar string) ([]ImplementedEndpoint, err
 
 			// Look for HTTP method
 			if methodMatch := methodPattern.FindStringSubmatch(line); len(methodMatch) > 1 {
-				currentMethod = methodMatch[1]
+				switch {
+				case methodMatch[1] != "":
+					currentMethod = methodMatch[1]
+				case len(methodMatch) > 2 && methodMatch[2] != "":
+					currentMethod = strings.ToUpper(methodMatch[2])
+				}
 			}
 
 			// Look for URL patterns

--- a/scripts/check-swagger-alignment.go
+++ b/scripts/check-swagger-alignment.go
@@ -143,17 +143,38 @@ func fetchSwaggerEndpoints(url string) ([]Endpoint, error) {
 	return endpoints, nil
 }
 
+func firstSubmatch(line string, patterns ...*regexp.Regexp) string {
+	for _, p := range patterns {
+		if m := p.FindStringSubmatch(line); len(m) > 1 {
+			return m[1]
+		}
+	}
+	return ""
+}
+
+func httpMethodFromLine(pattern *regexp.Regexp, line string) string {
+	m := pattern.FindStringSubmatch(line)
+	if len(m) < 2 {
+		return ""
+	}
+	if m[1] != "" {
+		return m[1]
+	}
+	if len(m) > 2 && m[2] != "" {
+		return strings.ToUpper(m[2])
+	}
+	return ""
+}
+
 func scanSourceEndpoints(libPath, baseURLVar string) ([]ImplementedEndpoint, error) {
 	var endpoints []ImplementedEndpoint
 
-	// Patterns to match endpoint definitions
 	// Matches: c.BaseURL + "/path", fmt.Sprintf("%s/path", c.BaseURL), or c.buildURL("/path", ...)
 	urlConcatPattern := regexp.MustCompile(baseURLVar + `\s*\+\s*"(/[^"]+)"`)
 	sprintfPattern := regexp.MustCompile(`fmt\.Sprintf\s*\(\s*"%s(/[^"]+)"`)
 	buildURLPattern := regexp.MustCompile(`buildURL\s*\(\s*"(/[^"]+)"`)
-	// Match HTTP method from http.NewRequest or newRequest calls
-	// (string literals or net/http Method* constants)
 	methodPattern := regexp.MustCompile(`(?:http\.NewRequest|newRequest|newRequestWithBody)\s*\(\s*(?:"(GET|POST|PUT|DELETE|PATCH)"|http\.Method(Get|Post|Put|Delete|Patch))`)
+	funcPattern := regexp.MustCompile(`func\s+(?:\([^)]+\)\s+)?(\w+)`)
 
 	err := filepath.Walk(libPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -171,53 +192,31 @@ func scanSourceEndpoints(libPath, baseURLVar string) ([]ImplementedEndpoint, err
 
 		scanner := bufio.NewScanner(file)
 		var currentMethod string
-		lineNum := 0
 		var currentFunc string
 
 		for scanner.Scan() {
-			lineNum++
 			line := scanner.Text()
-
-			// Track current function name
-			if funcMatch := regexp.MustCompile(`func\s+(?:\([^)]+\)\s+)?(\w+)`).FindStringSubmatch(line); len(funcMatch) > 1 {
-				currentFunc = funcMatch[1]
+			if name := firstSubmatch(line, funcPattern); name != "" {
+				currentFunc = name
+			}
+			if method := httpMethodFromLine(methodPattern, line); method != "" {
+				currentMethod = method
+			}
+			urlPath := firstSubmatch(line, urlConcatPattern, sprintfPattern, buildURLPattern)
+			if urlPath == "" {
+				continue
 			}
 
-			// Look for HTTP method
-			if methodMatch := methodPattern.FindStringSubmatch(line); len(methodMatch) > 1 {
-				switch {
-				case methodMatch[1] != "":
-					currentMethod = methodMatch[1]
-				case len(methodMatch) > 2 && methodMatch[2] != "":
-					currentMethod = strings.ToUpper(methodMatch[2])
-				}
+			method := currentMethod
+			if method == "" {
+				method = "GET"
 			}
-
-			// Look for URL patterns
-			var urlPath string
-			if matches := urlConcatPattern.FindStringSubmatch(line); len(matches) > 1 {
-				urlPath = matches[1]
-			} else if matches := sprintfPattern.FindStringSubmatch(line); len(matches) > 1 {
-				urlPath = matches[1]
-			} else if matches := buildURLPattern.FindStringSubmatch(line); len(matches) > 1 {
-				urlPath = matches[1]
-			}
-
-			if urlPath != "" {
-				// Normalize the path (replace %s, %d with {})
-				normalizedPath := normalizePath(urlPath)
-				method := currentMethod
-				if method == "" {
-					method = "GET" // Default assumption
-				}
-
-				endpoints = append(endpoints, ImplementedEndpoint{
-					Method:     method,
-					Path:       normalizedPath,
-					SourceFile: filepath.Base(path),
-					Function:   currentFunc,
-				})
-			}
+			endpoints = append(endpoints, ImplementedEndpoint{
+				Method:     method,
+				Path:       normalizePath(urlPath),
+				SourceFile: filepath.Base(path),
+				Function:   currentFunc,
+			})
 		}
 
 		return scanner.Err()


### PR DESCRIPTION
## Summary
- Replace `"GET"`/`"POST"`/`"PUT"`/`"DELETE"` literals in `newRequest`/`newRequestWithBody` call sites with `http.Method*` constants.
- Update `scripts/check-swagger-alignment.go` so it still detects HTTP methods after the constant switch.

## Test plan
- [x] `go test ./lib/ ./cmd/`
- [x] `go vet ./lib/ ./scripts/`

Stacked on #197. Merge after #197.

Closes #166

Made with [Cursor](https://cursor.com)