### PR TITLE
refactor: replace request-body maps with typed structs

### DIFF
--- a/lib/org_robot.go
+++ b/lib/org_robot.go
@@ -177,8 +177,8 @@ func (c *Client) SetRobotRepositoryPermission(orgname, robotShortname, repositor
 		return fmt.Errorf("role is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/robots/%s/permissions/%s", orgname, robotShortname, repository), map[string]interface{}{
-		fieldRole: role,
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/robots/%s/permissions/%s", orgname, robotShortname, repository), SetRepositoryPermissionRequest{
+		Role: role,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create set robot repository permission request: %w", err)

--- a/lib/org_robot_test.go
+++ b/lib/org_robot_test.go
@@ -243,6 +243,13 @@ func TestSetRobotRepositoryPermission(t *testing.T) {
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
+		var req SetRepositoryPermissionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("Failed to decode request body: %v", err)
+		}
+		if req.Role != testRoleWrite {
+			t.Errorf("Expected role %s, got %s", testRoleWrite, req.Role)
+		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()

--- a/lib/org_team.go
+++ b/lib/org_team.go
@@ -31,10 +31,6 @@ import (
 	"net/http"
 )
 
-const (
-	fieldRole = "role"
-)
-
 // Team Management
 
 // GetTeams retrieves all teams for an organization
@@ -142,9 +138,9 @@ func (c *Client) UpdateTeam(orgname, teamname, description, role string) (*Team,
 		return nil, fmt.Errorf("role is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/team/%s", orgname, teamname), map[string]interface{}{
-		"description": description,
-		fieldRole:     role,
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/team/%s", orgname, teamname), UpdateTeamRequest{
+		Description: description,
+		Role:        role,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update team request: %w", err)
@@ -269,8 +265,8 @@ func (c *Client) SetTeamRepositoryPermission(orgname, teamname, repository, role
 		return fmt.Errorf("role is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/team/%s/permissions/%s", orgname, teamname, repository), map[string]interface{}{
-		fieldRole: role,
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/team/%s/permissions/%s", orgname, teamname, repository), SetRepositoryPermissionRequest{
+		Role: role,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create set team repository permission request: %w", err)

--- a/lib/org_team_test.go
+++ b/lib/org_team_test.go
@@ -153,6 +153,16 @@ func TestUpdateTeam(t *testing.T) {
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
+		var req UpdateTeamRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("Failed to decode request body: %v", err)
+		}
+		if req.Description != updatedDescription {
+			t.Errorf("Expected description %s, got %s", updatedDescription, req.Description)
+		}
+		if req.Role != roleAdmin {
+			t.Errorf("Expected role %s, got %s", roleAdmin, req.Role)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(mockResponseJSON)
 	}))
@@ -352,6 +362,13 @@ func TestSetTeamRepositoryPermission(t *testing.T) {
 		expectedPath := "/api/v1/organization/" + testOrgName + "/team/" + testTeamName + "/permissions/" + testRepoName
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		var req SetRepositoryPermissionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("Failed to decode request body: %v", err)
+		}
+		if req.Role != testRoleWrite {
+			t.Errorf("Expected role %s, got %s", testRoleWrite, req.Role)
 		}
 		w.WriteHeader(http.StatusOK)
 	}))

--- a/lib/organization.go
+++ b/lib/organization.go
@@ -101,8 +101,8 @@ func (c *Client) UpdateOrganization(orgname, email string) (*Organization, error
 		return nil, fmt.Errorf("email is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s", orgname), map[string]interface{}{
-		"email": email,
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s", orgname), UpdateOrganizationRequest{
+		Email: email,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update organization request: %w", err)

--- a/lib/organization_test.go
+++ b/lib/organization_test.go
@@ -129,6 +129,13 @@ func TestUpdateOrganization(t *testing.T) {
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
+		var req UpdateOrganizationRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("Failed to decode request body: %v", err)
+		}
+		if req.Email != updatedEmail {
+			t.Errorf("Expected email %s, got %s", updatedEmail, req.Email)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(mockResponseJSON)
 	}))

--- a/lib/proxy_cache.go
+++ b/lib/proxy_cache.go
@@ -43,10 +43,10 @@ func (c *Client) CreateProxyCacheConfig(orgname, upstreamRegistry string, insecu
 		return nil, fmt.Errorf("upstreamRegistry is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/proxycache", orgname), map[string]interface{}{
-		"upstream_registry": upstreamRegistry,
-		"insecure":          insecure,
-		"expiration":        expiration,
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/proxycache", orgname), CreateProxyCacheConfigRequest{
+		UpstreamRegistry: upstreamRegistry,
+		Insecure:         insecure,
+		Expiration:       expiration,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create proxy cache config request: %w", err)

--- a/lib/proxy_cache_test.go
+++ b/lib/proxy_cache_test.go
@@ -64,6 +64,19 @@ func TestCreateProxyCacheConfig(t *testing.T) {
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
+		var req CreateProxyCacheConfigRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("Failed to decode request body: %v", err)
+		}
+		if req.UpstreamRegistry != testUpstreamReg {
+			t.Errorf("Expected upstream registry %s, got %s", testUpstreamReg, req.UpstreamRegistry)
+		}
+		if !req.Insecure {
+			t.Errorf("Expected Insecure to be true")
+		}
+		if req.Expiration != 3600 {
+			t.Errorf("Expected expiration 3600, got %d", req.Expiration)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		w.Write(mockResponseJSON)

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -54,7 +54,7 @@ Error Types:
   - QuayError - API error responses
 
 Request Types:
-  - CreateOrganizationRequest, CreateTeamRequest, CreateRobotRequest, CreateApplicationRequest, CreateQuotaRequest, CreateAutoPruneRequest
+  - CreateOrganizationRequest, UpdateOrganizationRequest, CreateTeamRequest, UpdateTeamRequest, CreateRobotRequest, CreateApplicationRequest, CreateQuotaRequest, CreateAutoPruneRequest
 
 All structs include appropriate JSON tags for API serialization/deserialization.
 */
@@ -376,6 +376,13 @@ type ProxyCacheConfig struct {
 	Expiration       int    `json:"expiration,omitempty"`
 }
 
+// CreateProxyCacheConfigRequest represents the request to create proxy cache configuration
+type CreateProxyCacheConfigRequest struct {
+	UpstreamRegistry string `json:"upstream_registry"`
+	Insecure         bool   `json:"insecure"`
+	Expiration       int    `json:"expiration"`
+}
+
 // User represents a user account
 type User struct {
 	Name        string `json:"name,omitempty"`
@@ -417,11 +424,22 @@ type CreateOrganizationRequest struct {
 	Email string `json:"email"`
 }
 
+// UpdateOrganizationRequest represents the request to update an organization
+type UpdateOrganizationRequest struct {
+	Email string `json:"email"`
+}
+
 // CreateTeamRequest represents the request to create a team
 type CreateTeamRequest struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 	Role        string `json:"role,omitempty"`
+}
+
+// UpdateTeamRequest represents the request to update a team
+type UpdateTeamRequest struct {
+	Description string `json:"description"`
+	Role        string `json:"role"`
 }
 
 // CreateRobotRequest represents the request to create a robot account
@@ -514,6 +532,11 @@ type TagHistory struct {
 // UpdateTagRequest represents the request to update a tag
 type UpdateTagRequest struct {
 	Expiration string `json:"expiration,omitempty"`
+}
+
+// RevertTagRequest represents the request to revert a tag to a manifest digest
+type RevertTagRequest struct {
+	ManifestDigest string `json:"manifest_digest"`
 }
 
 // User Account Structures
@@ -736,6 +759,11 @@ type BuildTriggers struct {
 type ActivateTriggerRequest struct {
 	Config    map[string]any `json:"config,omitempty"`
 	PullRobot string         `json:"pull_robot,omitempty"`
+}
+
+// UpdateTriggerRequest represents the request to enable or disable a build trigger
+type UpdateTriggerRequest struct {
+	Enabled bool `json:"enabled"`
 }
 
 // ManualTriggerRequest represents the request to manually start a build trigger

--- a/lib/tag.go
+++ b/lib/tag.go
@@ -140,8 +140,8 @@ func (c *Client) RevertTag(namespace, repository, tag, manifestDigest string) (*
 		return nil, fmt.Errorf("manifestDigest is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/tag/%s/revert", namespace, repository, tag), map[string]interface{}{
-		"manifest_digest": manifestDigest,
+	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/tag/%s/revert", namespace, repository, tag), RevertTagRequest{
+		ManifestDigest: manifestDigest,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create revert tag request: %w", err)

--- a/lib/tag_test.go
+++ b/lib/tag_test.go
@@ -215,13 +215,13 @@ func TestRevertTag(t *testing.T) {
 		}
 
 		// Verify request body
-		var req map[string]interface{}
+		var req RevertTagRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Errorf("Failed to decode request body: %v", err)
 		}
 
-		if req["manifest_digest"] != testManifestDigest {
-			t.Errorf("Expected manifest_digest 'sha256:def456', got '%v'", req["manifest_digest"])
+		if req.ManifestDigest != testManifestDigest {
+			t.Errorf("Expected manifest_digest 'sha256:def456', got '%v'", req.ManifestDigest)
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/lib/trigger.go
+++ b/lib/trigger.go
@@ -110,11 +110,9 @@ func (c *Client) UpdateTrigger(namespace, repository, triggerUUID string, enable
 		return nil, fmt.Errorf("triggerUUID is required")
 	}
 
-	body := map[string]interface{}{
-		"enabled": enabled,
-	}
-
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), body)
+	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), UpdateTriggerRequest{
+		Enabled: enabled,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update trigger request: %w", err)
 	}

--- a/lib/trigger_test.go
+++ b/lib/trigger_test.go
@@ -142,6 +142,13 @@ func TestUpdateTrigger(t *testing.T) {
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
+		var req UpdateTriggerRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("Failed to decode request body: %v", err)
+		}
+		if req.Enabled {
+			t.Errorf("Expected enabled false, got true")
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(mockResponseJSON)
 	}))


### PR DESCRIPTION
## Summary
- Replace remaining `map[string]interface{}` request bodies with typed structs (`UpdateOrganizationRequest`, `UpdateTeamRequest`, `CreateProxyCacheConfigRequest`, `RevertTagRequest`, `UpdateTriggerRequest`).
- Reuse `SetRepositoryPermissionRequest` for team and robot repository permissions, and drop the unused `fieldRole` constant.
- Assert request JSON in the existing tests that exercise these methods.

## Test plan
- [x] `go test ./lib/`
- [x] `go vet ./lib/`

Stacked on #198. Merge after #197 and #198.

Closes #165

Made with [Cursor](https://cursor.com)