### PR TITLE
refactor: remove unused TestNotificationResponse type

### DIFF
--- a/lib/structs.go
+++ b/lib/structs.go
@@ -843,12 +843,6 @@ type CreateNotificationRequest struct {
 	Title       string         `json:"title,omitempty"`
 }
 
-// TestNotificationResponse represents the response from testing a notification
-type TestNotificationResponse struct {
-	Success bool   `json:"success,omitempty"`
-	Message string `json:"message,omitempty"`
-}
-
 // Mirror Configuration Structures
 
 // MirrorConfig represents the mirror configuration for a repository


### PR DESCRIPTION
## Summary
- Audited all exported types in `lib/structs.go`. Nested JSON types with no external references (`ResolvedIP`, `Performer`, `QuotaReport`, `BuildPullRobot`, `BuildRepository`) are still used as fields and were kept.
- Removed `TestNotificationResponse`, the only type with zero nested uses and zero references outside its definition. `TestNotification()` returns `error` and never decodes a body.

## Test plan
- [x] `go test ./lib/`
- [x] `go vet ./lib/`

Stacked on #199. Merge after #197, #198, and #199.

Closes #175

Made with [Cursor](https://cursor.com)