### PR TITLE
feat: add context.Context to all library HTTP methods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,8 @@ Every API domain follows the same pattern:
 
 - **`lib.DefaultQuayURL`** is a package-level `const` (`https://quay.io/api/v1`) in `lib/client.go`. Each `Client` has its own `BaseURL`.
 - **`lib.NewClient(bearerToken)`** creates a client against `DefaultQuayURL`. **`lib.NewClientWithURL(bearerToken, baseURL)`** is used by the CLI and by unit tests (point `baseURL` at `httptest.NewServer`).
-- **`Client.Retry`** (`*RetryConfig`) is optional. When set, HTTP calls retry on 429 and 5xx. `NewClient` leaves it nil.
+- All exported `Client` methods take `context.Context` as the first argument. CLI commands pass `cmd.Context()`.
+- **`Client.Retry`** (`*RetryConfig`) is optional. When set, HTTP calls retry on 429 and 5xx. Retry backoff honors the request context. `NewClient` leaves it nil.
 - API errors that include a Quay JSON body are returned as `*lib.QuayError` (implements `error`; use `errors.As` and `StatusCode()`).
 - CLI authentication: `--token` / `-t`, else `$QUAY_TOKEN`, else the config file. API base URL: `--quay-url`, else `$QUAY_URL`, else config `quay-url`, else `DefaultQuayURL`. Output: `--output` / `-O` (`json`, `yaml`, or `table`).
 - Config file (optional defaults): `token`, `namespace`, `quay-url` in platform config dir (`~/.config/go-quay/config.yaml` on Linux). Flags and env vars override the file.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ cd go-quay && make build
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "os"
@@ -66,13 +67,14 @@ func main() {
         log.Fatal(err)
     }
 
-    user, err := client.GetUser()
+    ctx := context.Background()
+    user, err := client.GetUser(ctx)
     if err != nil {
         log.Fatal(err)
     }
     fmt.Printf("Logged in as: %s\n", user.Username)
 
-    repos, err := client.ListRepositories("my-namespace", false, false, false, 1, 10)
+    repos, err := client.ListRepositories(ctx, "my-namespace", false, false, false, 1, 10)
     if err != nil {
         log.Fatal(err)
     }

--- a/cmd/auto_prune.go
+++ b/cmd/auto_prune.go
@@ -17,7 +17,7 @@ var autoPruneCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		policies, err := client.GetAutoPrunePolicies(orgName)
+		policies, err := client.GetAutoPrunePolicies(cmd.Context(), orgName)
 		if err != nil {
 			return fmt.Errorf("getting auto-prune policies: %w", err)
 		}
@@ -35,7 +35,7 @@ var autoPrunePolicyCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		policy, err := client.GetAutoPrunePolicy(orgName, policyUUID)
+		policy, err := client.GetAutoPrunePolicy(cmd.Context(), orgName, policyUUID)
 		if err != nil {
 			return fmt.Errorf("getting auto-prune policy: %w", err)
 		}
@@ -53,7 +53,7 @@ var createAutoPruneCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		policy, err := client.CreateAutoPrunePolicy(orgName, method, pruneValue, tagPattern)
+		policy, err := client.CreateAutoPrunePolicy(cmd.Context(), orgName, method, pruneValue, tagPattern)
 		if err != nil {
 			return fmt.Errorf("creating auto-prune policy: %w", err)
 		}
@@ -71,7 +71,7 @@ var updateAutoPruneCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		policy, err := client.UpdateAutoPrunePolicy(orgName, policyUUID, method, pruneValue, tagPattern)
+		policy, err := client.UpdateAutoPrunePolicy(cmd.Context(), orgName, policyUUID, method, pruneValue, tagPattern)
 		if err != nil {
 			return fmt.Errorf("updating auto-prune policy: %w", err)
 		}
@@ -92,7 +92,7 @@ var deleteAutoPruneCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		err = client.DeleteAutoPrunePolicy(orgName, policyUUID)
+		err = client.DeleteAutoPrunePolicy(cmd.Context(), orgName, policyUUID)
 		if err != nil {
 			return fmt.Errorf("deleting auto-prune policy: %w", err)
 		}

--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -25,7 +25,7 @@ var orgBillingCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		billing, err := client.GetOrganizationBilling(billingOrgName)
+		billing, err := client.GetOrganizationBilling(cmd.Context(), billingOrgName)
 		if err != nil {
 			return fmt.Errorf("getting organization billing: %w", err)
 		}
@@ -43,7 +43,7 @@ var userBillingCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		billing, err := client.GetUserBilling()
+		billing, err := client.GetUserBilling(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("getting user billing: %w", err)
 		}
@@ -61,7 +61,7 @@ var orgSubscriptionCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		subscription, err := client.GetOrganizationSubscription(billingOrgName)
+		subscription, err := client.GetOrganizationSubscription(cmd.Context(), billingOrgName)
 		if err != nil {
 			return fmt.Errorf("getting organization subscription: %w", err)
 		}
@@ -79,7 +79,7 @@ var userSubscriptionCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		subscription, err := client.GetUserSubscription()
+		subscription, err := client.GetUserSubscription(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("getting user subscription: %w", err)
 		}
@@ -97,7 +97,7 @@ var orgInvoicesCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		invoices, err := client.GetOrganizationInvoices(billingOrgName)
+		invoices, err := client.GetOrganizationInvoices(cmd.Context(), billingOrgName)
 		if err != nil {
 			return fmt.Errorf("getting organization invoices: %w", err)
 		}
@@ -115,7 +115,7 @@ var userInvoicesCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		invoices, err := client.GetUserInvoices()
+		invoices, err := client.GetUserInvoices(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("getting user invoices: %w", err)
 		}
@@ -133,7 +133,7 @@ var plansCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		plans, err := client.GetAvailablePlans()
+		plans, err := client.GetAvailablePlans(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("getting available plans: %w", err)
 		}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -48,7 +48,7 @@ var buildListCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		builds, err := client.GetBuilds(buildNamespace, buildRepository, buildLimit)
+		builds, err := client.GetBuilds(cmd.Context(), buildNamespace, buildRepository, buildLimit)
 		if err != nil {
 			return fmt.Errorf("getting builds: %w", err)
 		}
@@ -69,7 +69,7 @@ var buildInfoCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		build, err := client.GetBuild(buildNamespace, buildRepository, buildUUID)
+		build, err := client.GetBuild(cmd.Context(), buildNamespace, buildRepository, buildUUID)
 		if err != nil {
 			return fmt.Errorf("getting build: %w", err)
 		}
@@ -90,7 +90,7 @@ var buildLogsCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		logs, err := client.GetBuildLogs(buildNamespace, buildRepository, buildUUID)
+		logs, err := client.GetBuildLogs(cmd.Context(), buildNamespace, buildRepository, buildUUID)
 		if err != nil {
 			return fmt.Errorf("getting build logs: %w", err)
 		}
@@ -120,7 +120,7 @@ The archive should be a tar.gz file containing a Dockerfile and any necessary bu
 			Tags:           buildTags,
 		}
 
-		build, err := client.RequestBuild(buildNamespace, buildRepository, buildReq)
+		build, err := client.RequestBuild(cmd.Context(), buildNamespace, buildRepository, buildReq)
 		if err != nil {
 			return fmt.Errorf("requesting build: %w", err)
 		}
@@ -145,7 +145,7 @@ var buildCancelCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.CancelBuild(buildNamespace, buildRepository, buildUUID)
+		err = client.CancelBuild(cmd.Context(), buildNamespace, buildRepository, buildUUID)
 		if err != nil {
 			return fmt.Errorf("canceling build: %w", err)
 		}
@@ -165,7 +165,7 @@ var buildStatusCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		status, err := client.GetBuildStatus(buildNamespace, buildRepository, buildUUID)
+		status, err := client.GetBuildStatus(cmd.Context(), buildNamespace, buildRepository, buildUUID)
 		if err != nil {
 			return fmt.Errorf("getting build status: %w", err)
 		}

--- a/cmd/discovery.go
+++ b/cmd/discovery.go
@@ -22,13 +22,13 @@ var discoveryAPICmd = &cobra.Command{
 	Use:   "api",
 	Short: "Get API discovery information",
 	Long:  `Get API discovery information from Quay.io including available endpoints and versions.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		discovery, err := client.GetDiscovery()
+		discovery, err := client.GetDiscovery(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("getting discovery: %w", err)
 		}
@@ -41,13 +41,13 @@ var discoveryCapabilitiesCmd = &cobra.Command{
 	Use:   "capabilities",
 	Short: "Get registry capabilities",
 	Long:  `Get registry capabilities including sparse manifest support and available mirror architectures.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		capabilities, err := client.GetRegistryCapabilities()
+		capabilities, err := client.GetRegistryCapabilities(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("getting registry capabilities: %w", err)
 		}
@@ -60,13 +60,13 @@ var discoveryAppInfoCmd = &cobra.Command{
 	Use:   "app-info",
 	Short: "Get application information by client ID",
 	Long:  `Get detailed information about an OAuth application by its client ID.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		app, err := client.GetAppInfo(discoveryClientID)
+		app, err := client.GetAppInfo(cmd.Context(), discoveryClientID)
 		if err != nil {
 			return fmt.Errorf("getting app info: %w", err)
 		}
@@ -79,13 +79,13 @@ var discoveryEntitiesCmd = &cobra.Command{
 	Use:   "entities",
 	Short: "Search for entities by prefix",
 	Long:  `Search for users, organizations, and teams by name prefix.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		entities, err := client.GetEntities(entityPrefix, includeOrgs, includeTeams)
+		entities, err := client.GetEntities(cmd.Context(), entityPrefix, includeOrgs, includeTeams)
 		if err != nil {
 			return fmt.Errorf("getting entities: %w", err)
 		}

--- a/cmd/errortype.go
+++ b/cmd/errortype.go
@@ -23,13 +23,13 @@ var errorTypeCmd = &cobra.Command{
 	Long: `Get detailed information about a specific error type.
 
 This endpoint provides details about error types that can be returned by the Quay.io API.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		errType, err := client.GetErrorType(errorTypeName)
+		errType, err := client.GetErrorType(cmd.Context(), errorTypeName)
 		if err != nil {
 			return fmt.Errorf("getting error type: %w", err)
 		}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -37,7 +37,7 @@ var repoLogsCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		logs, err := client.GetLogs(namespace, repository, nextPage, startdate, enddate)
+		logs, err := client.GetLogs(cmd.Context(), namespace, repository, nextPage, startdate, enddate)
 		if err != nil {
 			return fmt.Errorf("getting repository logs: %w", err)
 		}
@@ -56,7 +56,7 @@ var repoAggregatedLogsCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		logs, err := client.GetAggregatedLogs(namespace, repository, startdate, enddate)
+		logs, err := client.GetAggregatedLogs(cmd.Context(), namespace, repository, startdate, enddate)
 		if err != nil {
 			return fmt.Errorf("getting repository aggregated logs: %w", err)
 		}
@@ -75,7 +75,7 @@ var orgLogsCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		logs, err := client.GetOrganizationLogs(orgName, nextPage, startdate, enddate)
+		logs, err := client.GetOrganizationLogs(cmd.Context(), orgName, nextPage, startdate, enddate)
 		if err != nil {
 			return fmt.Errorf("getting organization logs: %w", err)
 		}
@@ -94,7 +94,7 @@ var orgAggregatedLogsCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		logs, err := client.GetOrganizationAggregatedLogs(orgName, startdate, enddate)
+		logs, err := client.GetOrganizationAggregatedLogs(cmd.Context(), orgName, startdate, enddate)
 		if err != nil {
 			return fmt.Errorf("getting organization aggregated logs: %w", err)
 		}
@@ -113,7 +113,7 @@ var userLogsCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		logs, err := client.GetUserLogs(nextPage, startdate, enddate)
+		logs, err := client.GetUserLogs(cmd.Context(), nextPage, startdate, enddate)
 		if err != nil {
 			return fmt.Errorf("getting user logs: %w", err)
 		}
@@ -132,7 +132,7 @@ var userAggregatedLogsCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		logs, err := client.GetUserAggregatedLogs(startdate, enddate)
+		logs, err := client.GetUserAggregatedLogs(cmd.Context(), startdate, enddate)
 		if err != nil {
 			return fmt.Errorf("getting user aggregated logs: %w", err)
 		}
@@ -151,7 +151,7 @@ var exportOrgLogsCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.ExportOrganizationLogs(orgName, &lib.ExportLogsRequest{
+		err = client.ExportOrganizationLogs(cmd.Context(), orgName, &lib.ExportLogsRequest{
 			StartTime:   starttime,
 			EndTime:     endtime,
 			CallbackURL: callbackURL,
@@ -176,7 +176,7 @@ var exportUserLogsCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.ExportUserLogs(&lib.ExportLogsRequest{
+		err = client.ExportUserLogs(cmd.Context(), &lib.ExportLogsRequest{
 			StartTime:   starttime,
 			EndTime:     endtime,
 			CallbackURL: callbackURL,
@@ -201,7 +201,7 @@ var exportRepoLogsCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.ExportRepositoryLogs(namespace, repository, &lib.ExportLogsRequest{
+		err = client.ExportRepositoryLogs(cmd.Context(), namespace, repository, &lib.ExportLogsRequest{
 			StartTime:   starttime,
 			EndTime:     endtime,
 			CallbackURL: callbackURL,

--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -42,7 +42,7 @@ var manifestInfoCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		manifest, err := client.GetManifest(namespace, repository, manifestRef)
+		manifest, err := client.GetManifest(cmd.Context(), namespace, repository, manifestRef)
 		if err != nil {
 			return fmt.Errorf("getting manifest information: %w", err)
 		}
@@ -67,7 +67,7 @@ var manifestDeleteCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.DeleteManifest(namespace, repository, manifestRef)
+		err = client.DeleteManifest(cmd.Context(), namespace, repository, manifestRef)
 		if err != nil {
 			return fmt.Errorf("deleting manifest: %w", err)
 		}
@@ -88,7 +88,7 @@ var manifestLabelsCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		labels, err := client.GetManifestLabels(namespace, repository, manifestRef)
+		labels, err := client.GetManifestLabels(cmd.Context(), namespace, repository, manifestRef)
 		if err != nil {
 			return fmt.Errorf("getting manifest labels: %w", err)
 		}
@@ -109,7 +109,7 @@ var manifestLabelCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		label, err := client.GetManifestLabel(namespace, repository, manifestRef, labelID)
+		label, err := client.GetManifestLabel(cmd.Context(), namespace, repository, manifestRef, labelID)
 		if err != nil {
 			return fmt.Errorf("getting manifest label: %w", err)
 		}
@@ -130,7 +130,7 @@ var manifestAddLabelCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		label, err := client.AddManifestLabel(namespace, repository, manifestRef, labelKey, labelValue, labelMediaType)
+		label, err := client.AddManifestLabel(cmd.Context(), namespace, repository, manifestRef, labelKey, labelValue, labelMediaType)
 		if err != nil {
 			return fmt.Errorf("adding manifest label: %w", err)
 		}
@@ -151,7 +151,7 @@ var manifestRemoveLabelCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.DeleteManifestLabel(namespace, repository, manifestRef, labelID)
+		err = client.DeleteManifestLabel(cmd.Context(), namespace, repository, manifestRef, labelID)
 		if err != nil {
 			return fmt.Errorf("removing manifest label: %w", err)
 		}

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -22,13 +22,13 @@ var messagesListCmd = &cobra.Command{
 	Use:   subcmdList,
 	Short: "Get system messages",
 	Long:  `Get system-wide messages including maintenance notifications and announcements.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		messages, err := client.GetMessages()
+		messages, err := client.GetMessages(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("getting messages: %w", err)
 		}
@@ -41,13 +41,13 @@ var messagesCreateCmd = &cobra.Command{
 	Use:   subcmdCreate,
 	Short: "Create a system message",
 	Long:  `Create a new system-wide message.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		message, err := client.CreateMessage(messageContent, messageSeverity, messageMediaType)
+		message, err := client.CreateMessage(cmd.Context(), messageContent, messageSeverity, messageMediaType)
 		if err != nil {
 			return fmt.Errorf("creating message: %w", err)
 		}

--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -30,13 +30,13 @@ var mirrorInfoCmd = &cobra.Command{
 	Use:   subcmdInfo,
 	Short: "Get mirror configuration",
 	Long:  `Get the mirror configuration for a repository.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		config, err := client.GetMirrorConfig(namespace, repository)
+		config, err := client.GetMirrorConfig(cmd.Context(), namespace, repository)
 		if err != nil {
 			return fmt.Errorf("getting mirror config: %w", err)
 		}
@@ -49,7 +49,7 @@ var mirrorCreateCmd = &cobra.Command{
 	Use:   subcmdCreate,
 	Short: "Create mirror configuration",
 	Long:  `Create mirror configuration for a repository to sync from an external registry.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -66,7 +66,7 @@ var mirrorCreateCmd = &cobra.Command{
 		createReq.RootRule.Rule = mirrorTagRule
 		createReq.RootRule.RuleKind = mirrorTagRuleKind
 
-		config, err := client.CreateMirrorConfig(namespace, repository, createReq)
+		config, err := client.CreateMirrorConfig(cmd.Context(), namespace, repository, createReq)
 		if err != nil {
 			return fmt.Errorf("creating mirror config: %w", err)
 		}
@@ -80,7 +80,7 @@ var mirrorUpdateCmd = &cobra.Command{
 	Use:   subcmdUpdate,
 	Short: "Update mirror configuration",
 	Long:  `Update mirror configuration for a repository.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -102,7 +102,7 @@ var mirrorUpdateCmd = &cobra.Command{
 			updateReq.RobotUsername = mirrorRobotUsername
 		}
 
-		config, err := client.UpdateMirrorConfig(namespace, repository, updateReq)
+		config, err := client.UpdateMirrorConfig(cmd.Context(), namespace, repository, updateReq)
 		if err != nil {
 			return fmt.Errorf("updating mirror config: %w", err)
 		}

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -62,7 +62,7 @@ var notificationListCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		notifications, err := client.GetNotifications(notificationNamespace, notificationRepository)
+		notifications, err := client.GetNotifications(cmd.Context(), notificationNamespace, notificationRepository)
 		if err != nil {
 			return fmt.Errorf("getting notifications: %w", err)
 		}
@@ -83,7 +83,7 @@ var notificationInfoCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		notification, err := client.GetNotification(notificationNamespace, notificationRepository, notificationUUID)
+		notification, err := client.GetNotification(cmd.Context(), notificationNamespace, notificationRepository, notificationUUID)
 		if err != nil {
 			return fmt.Errorf("getting notification: %w", err)
 		}
@@ -125,7 +125,7 @@ For slack method, provide the --url flag with the Slack webhook URL.`,
 			Title:  notificationTitle,
 		}
 
-		notification, err := client.CreateNotification(notificationNamespace, notificationRepository, notificationReq)
+		notification, err := client.CreateNotification(cmd.Context(), notificationNamespace, notificationRepository, notificationReq)
 		if err != nil {
 			return fmt.Errorf("creating notification: %w", err)
 		}
@@ -150,7 +150,7 @@ var notificationDeleteCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.DeleteNotification(notificationNamespace, notificationRepository, notificationUUID)
+		err = client.DeleteNotification(cmd.Context(), notificationNamespace, notificationRepository, notificationUUID)
 		if err != nil {
 			return fmt.Errorf("deleting notification: %w", err)
 		}
@@ -171,7 +171,7 @@ var notificationTestCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.TestNotification(notificationNamespace, notificationRepository, notificationUUID)
+		err = client.TestNotification(cmd.Context(), notificationNamespace, notificationRepository, notificationUUID)
 		if err != nil {
 			return fmt.Errorf("testing notification: %w", err)
 		}
@@ -192,7 +192,7 @@ var notificationResetCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.ResetNotification(notificationNamespace, notificationRepository, notificationUUID)
+		err = client.ResetNotification(cmd.Context(), notificationNamespace, notificationRepository, notificationUUID)
 		if err != nil {
 			return fmt.Errorf("resetting notification: %w", err)
 		}
@@ -229,7 +229,7 @@ var notificationUpdateCmd = &cobra.Command{
 			Title:  notificationTitle,
 		}
 
-		notification, err := client.UpdateNotification(notificationNamespace, notificationRepository, notificationUUID, notificationReq)
+		notification, err := client.UpdateNotification(cmd.Context(), notificationNamespace, notificationRepository, notificationUUID, notificationReq)
 		if err != nil {
 			return fmt.Errorf("updating notification: %w", err)
 		}

--- a/cmd/org_application.go
+++ b/cmd/org_application.go
@@ -17,7 +17,7 @@ var orgApplicationsCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		applications, err := client.GetApplications(orgName)
+		applications, err := client.GetApplications(cmd.Context(), orgName)
 		if err != nil {
 			return fmt.Errorf("getting organization applications: %w", err)
 		}
@@ -35,7 +35,7 @@ var applicationCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		app, err := client.GetApplication(orgName, clientID)
+		app, err := client.GetApplication(cmd.Context(), orgName, clientID)
 		if err != nil {
 			return fmt.Errorf("getting application: %w", err)
 		}
@@ -53,7 +53,7 @@ var createApplicationCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		app, err := client.CreateApplication(orgName, appName, description, applicationURI, redirectURI)
+		app, err := client.CreateApplication(cmd.Context(), orgName, appName, description, applicationURI, redirectURI)
 		if err != nil {
 			return fmt.Errorf("creating application: %w", err)
 		}
@@ -71,7 +71,7 @@ var updateApplicationCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		app, err := client.UpdateApplication(orgName, clientID, appName, description, applicationURI, redirectURI)
+		app, err := client.UpdateApplication(cmd.Context(), orgName, clientID, appName, description, applicationURI, redirectURI)
 		if err != nil {
 			return fmt.Errorf("updating application: %w", err)
 		}
@@ -92,7 +92,7 @@ var deleteApplicationCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		err = client.DeleteApplication(orgName, clientID)
+		err = client.DeleteApplication(cmd.Context(), orgName, clientID)
 		if err != nil {
 			return fmt.Errorf("deleting application: %w", err)
 		}
@@ -111,7 +111,7 @@ var resetApplicationSecretCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		app, err := client.ResetApplicationClientSecret(orgName, clientID)
+		app, err := client.ResetApplicationClientSecret(cmd.Context(), orgName, clientID)
 		if err != nil {
 			return fmt.Errorf("resetting application secret: %w", err)
 		}

--- a/cmd/org_marketplace.go
+++ b/cmd/org_marketplace.go
@@ -18,7 +18,7 @@ var marketplaceCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		marketplace, err := client.GetOrganizationMarketplace(orgName)
+		marketplace, err := client.GetOrganizationMarketplace(cmd.Context(), orgName)
 		if err != nil {
 			return fmt.Errorf("getting marketplace info: %w", err)
 		}
@@ -36,7 +36,7 @@ var createMarketplaceSubscriptionCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		err = client.CreateOrganizationMarketplaceSubscription(orgName, &lib.MarketplaceSubscriptionRequest{SKU: sku, Quantity: quantity})
+		err = client.CreateOrganizationMarketplaceSubscription(cmd.Context(), orgName, &lib.MarketplaceSubscriptionRequest{SKU: sku, Quantity: quantity})
 		if err != nil {
 			return fmt.Errorf("creating marketplace subscription: %w", err)
 		}
@@ -58,7 +58,7 @@ var deleteMarketplaceSubscriptionCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		err = client.DeleteOrganizationMarketplaceSubscription(orgName, subscriptionID)
+		err = client.DeleteOrganizationMarketplaceSubscription(cmd.Context(), orgName, subscriptionID)
 		if err != nil {
 			return fmt.Errorf("deleting marketplace subscription: %w", err)
 		}
@@ -80,7 +80,7 @@ var batchRemoveSubscriptionsCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		err = client.BatchRemoveOrganizationMarketplaceSubscriptions(orgName, subscriptionIDs)
+		err = client.BatchRemoveOrganizationMarketplaceSubscriptions(cmd.Context(), orgName, subscriptionIDs)
 		if err != nil {
 			return fmt.Errorf("batch removing subscriptions: %w", err)
 		}

--- a/cmd/org_robot.go
+++ b/cmd/org_robot.go
@@ -18,7 +18,7 @@ var orgRobotsCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		robots, err := client.GetRobotAccounts(orgName)
+		robots, err := client.GetRobotAccounts(cmd.Context(), orgName)
 		if err != nil {
 			return fmt.Errorf("getting organization robots: %w", err)
 		}
@@ -36,7 +36,7 @@ var orgRobotCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		robot, err := client.GetRobotAccount(orgName, robotShortname)
+		robot, err := client.GetRobotAccount(cmd.Context(), orgName, robotShortname)
 		if err != nil {
 			return fmt.Errorf("getting robot account: %w", err)
 		}
@@ -54,7 +54,7 @@ var createRobotCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		robot, err := client.CreateRobotAccount(orgName, robotShortname, description, nil)
+		robot, err := client.CreateRobotAccount(cmd.Context(), orgName, robotShortname, description, nil)
 		if err != nil {
 			return fmt.Errorf("creating robot account: %w", err)
 		}
@@ -75,7 +75,7 @@ var deleteRobotCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		err = client.DeleteRobotAccount(orgName, robotShortname)
+		err = client.DeleteRobotAccount(cmd.Context(), orgName, robotShortname)
 		if err != nil {
 			return fmt.Errorf("deleting robot account: %w", err)
 		}
@@ -94,7 +94,7 @@ var regenerateRobotCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		robot, err := client.RegenerateRobotToken(orgName, robotShortname)
+		robot, err := client.RegenerateRobotToken(cmd.Context(), orgName, robotShortname)
 		if err != nil {
 			return fmt.Errorf("regenerating robot token: %w", err)
 		}
@@ -112,7 +112,7 @@ var orgRobotPermissionsCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		perms, err := client.GetRobotPermissions(orgName, robotShortname)
+		perms, err := client.GetRobotPermissions(cmd.Context(), orgName, robotShortname)
 		if err != nil {
 			return fmt.Errorf("getting robot permissions: %w", err)
 		}
@@ -130,7 +130,7 @@ var setRobotPermissionCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		err = client.SetRobotRepositoryPermission(orgName, robotShortname, repository, role)
+		err = client.SetRobotRepositoryPermission(cmd.Context(), orgName, robotShortname, repository, role)
 		if err != nil {
 			return fmt.Errorf("setting robot permission: %w", err)
 		}
@@ -152,7 +152,7 @@ var removeRobotPermissionCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		err = client.RemoveRobotRepositoryPermission(orgName, robotShortname, repository)
+		err = client.RemoveRobotRepositoryPermission(cmd.Context(), orgName, robotShortname, repository)
 		if err != nil {
 			return fmt.Errorf("removing robot permission: %w", err)
 		}
@@ -171,7 +171,7 @@ var orgRobotFederationGetCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		federation, err := client.GetRobotFederation(orgName, robotShortname)
+		federation, err := client.GetRobotFederation(cmd.Context(), orgName, robotShortname)
 		if err != nil {
 			return fmt.Errorf("getting robot federation: %w", err)
 		}
@@ -194,7 +194,7 @@ var orgRobotFederationCreateCmd = &cobra.Command{
 			{Issuer: federationIssuer, Subject: federationSubject},
 		}
 
-		err = client.CreateRobotFederation(orgName, robotShortname, configs)
+		err = client.CreateRobotFederation(cmd.Context(), orgName, robotShortname, configs)
 		if err != nil {
 			return fmt.Errorf("creating robot federation: %w", err)
 		}
@@ -214,7 +214,7 @@ var orgRobotFederationDeleteCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.DeleteRobotFederation(orgName, robotShortname)
+		err = client.DeleteRobotFederation(cmd.Context(), orgName, robotShortname)
 		if err != nil {
 			return fmt.Errorf("deleting robot federation: %w", err)
 		}

--- a/cmd/org_team.go
+++ b/cmd/org_team.go
@@ -17,7 +17,7 @@ var orgTeamsCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		teams, err := client.GetTeams(orgName)
+		teams, err := client.GetTeams(cmd.Context(), orgName)
 		if err != nil {
 			return fmt.Errorf("getting organization teams: %w", err)
 		}
@@ -35,7 +35,7 @@ var teamInfoCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		team, err := client.GetTeam(orgName, teamName)
+		team, err := client.GetTeam(cmd.Context(), orgName, teamName)
 		if err != nil {
 			return fmt.Errorf("getting team: %w", err)
 		}
@@ -53,7 +53,7 @@ var teamMembersCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		members, err := client.GetTeamMembers(orgName, teamName)
+		members, err := client.GetTeamMembers(cmd.Context(), orgName, teamName)
 		if err != nil {
 			return fmt.Errorf("getting team members: %w", err)
 		}
@@ -71,7 +71,7 @@ var inviteMemberCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		err = client.InviteTeamMember(orgName, teamName, email)
+		err = client.InviteTeamMember(cmd.Context(), orgName, teamName, email)
 		if err != nil {
 			return fmt.Errorf("inviting team member: %w", err)
 		}
@@ -93,7 +93,7 @@ var cancelInviteCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		err = client.DeleteTeamInvite(orgName, teamName, email)
+		err = client.DeleteTeamInvite(cmd.Context(), orgName, teamName, email)
 		if err != nil {
 			return fmt.Errorf("canceling team invite: %w", err)
 		}

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -61,7 +61,7 @@ var orgInfoCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		org, err := client.GetOrganization(orgName)
+		org, err := client.GetOrganization(cmd.Context(), orgName)
 		if err != nil {
 			return fmt.Errorf("getting organization: %w", err)
 		}
@@ -79,7 +79,7 @@ var orgMembersCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		members, err := client.GetOrganizationMembers(orgName)
+		members, err := client.GetOrganizationMembers(cmd.Context(), orgName)
 		if err != nil {
 			return fmt.Errorf("getting organization members: %w", err)
 		}
@@ -97,7 +97,7 @@ var createOrgCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		org, err := client.CreateOrganization(orgName, email)
+		org, err := client.CreateOrganization(cmd.Context(), orgName, email)
 		if err != nil {
 			return fmt.Errorf("creating organization: %w", err)
 		}
@@ -115,7 +115,7 @@ var updateOrgCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		org, err := client.UpdateOrganization(orgName, email)
+		org, err := client.UpdateOrganization(cmd.Context(), orgName, email)
 		if err != nil {
 			return fmt.Errorf("updating organization: %w", err)
 		}
@@ -136,7 +136,7 @@ var deleteOrgCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		err = client.DeleteOrganization(orgName)
+		err = client.DeleteOrganization(cmd.Context(), orgName)
 		if err != nil {
 			return fmt.Errorf("deleting organization: %w", err)
 		}
@@ -155,7 +155,7 @@ var addMemberCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		err = client.AddOrganizationMember(orgName, memberName)
+		err = client.AddOrganizationMember(cmd.Context(), orgName, memberName)
 		if err != nil {
 			return fmt.Errorf("adding organization member: %w", err)
 		}
@@ -177,7 +177,7 @@ var removeMemberCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		err = client.RemoveOrganizationMember(orgName, memberName)
+		err = client.RemoveOrganizationMember(cmd.Context(), orgName, memberName)
 		if err != nil {
 			return fmt.Errorf("removing organization member: %w", err)
 		}
@@ -196,7 +196,7 @@ var getMemberCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		member, err := client.GetOrganizationMember(orgName, memberName)
+		member, err := client.GetOrganizationMember(cmd.Context(), orgName, memberName)
 		if err != nil {
 			return fmt.Errorf("getting organization member: %w", err)
 		}
@@ -214,7 +214,7 @@ var collaboratorsCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		collaborators, err := client.GetOrganizationCollaborators(orgName)
+		collaborators, err := client.GetOrganizationCollaborators(cmd.Context(), orgName)
 		if err != nil {
 			return fmt.Errorf("getting organization collaborators: %w", err)
 		}
@@ -232,7 +232,7 @@ var orgRepositoriesCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		repos, err := client.GetOrganizationRepositories(orgName)
+		repos, err := client.GetOrganizationRepositories(cmd.Context(), orgName)
 		if err != nil {
 			return fmt.Errorf("getting organization repositories: %w", err)
 		}

--- a/cmd/permissions.go
+++ b/cmd/permissions.go
@@ -39,7 +39,7 @@ var permListCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		permissions, err := client.GetRepositoryPermissions(namespace, repository)
+		permissions, err := client.GetRepositoryPermissions(cmd.Context(), namespace, repository)
 		if err != nil {
 			return fmt.Errorf("getting repository permissions: %w", err)
 		}
@@ -60,7 +60,7 @@ var permSetCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.SetRepositoryPermission(namespace, repository, permissionUser, permissionRole)
+		err = client.SetRepositoryPermission(cmd.Context(), namespace, repository, permissionUser, permissionRole)
 		if err != nil {
 			return fmt.Errorf("setting repository permission: %w", err)
 		}
@@ -82,7 +82,7 @@ var permRemoveCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.RemoveRepositoryPermission(namespace, repository, permissionUser)
+		err = client.RemoveRepositoryPermission(cmd.Context(), namespace, repository, permissionUser)
 		if err != nil {
 			return fmt.Errorf("removing repository permission: %w", err)
 		}
@@ -102,7 +102,7 @@ var permUserPermissionsCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		permissions, err := client.ListUserPermissions(namespace, repository)
+		permissions, err := client.ListUserPermissions(cmd.Context(), namespace, repository)
 		if err != nil {
 			return fmt.Errorf("getting user permissions: %w", err)
 		}
@@ -120,7 +120,7 @@ var permUserPermissionCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		permission, err := client.GetUserPermission(namespace, repository, permissionUser)
+		permission, err := client.GetUserPermission(cmd.Context(), namespace, repository, permissionUser)
 		if err != nil {
 			return fmt.Errorf("getting user permission: %w", err)
 		}
@@ -138,7 +138,7 @@ var permSetUserPermCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.SetUserPermission(namespace, repository, permissionUser, permissionRole)
+		err = client.SetUserPermission(cmd.Context(), namespace, repository, permissionUser, permissionRole)
 		if err != nil {
 			return fmt.Errorf("setting user permission: %w", err)
 		}
@@ -163,7 +163,7 @@ var permDeleteUserPermCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.DeleteUserPermission(namespace, repository, permissionUser)
+		err = client.DeleteUserPermission(cmd.Context(), namespace, repository, permissionUser)
 		if err != nil {
 			return fmt.Errorf("deleting user permission: %w", err)
 		}
@@ -183,7 +183,7 @@ var permUserTransitiveCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		permission, err := client.GetUserTransitivePermission(namespace, repository, permissionUser)
+		permission, err := client.GetUserTransitivePermission(cmd.Context(), namespace, repository, permissionUser)
 		if err != nil {
 			return fmt.Errorf("getting user transitive permission: %w", err)
 		}
@@ -201,7 +201,7 @@ var permTeamPermissionsCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		permissions, err := client.ListTeamPermissions(namespace, repository)
+		permissions, err := client.ListTeamPermissions(cmd.Context(), namespace, repository)
 		if err != nil {
 			return fmt.Errorf("getting team permissions: %w", err)
 		}
@@ -219,7 +219,7 @@ var permTeamPermissionCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		permission, err := client.GetTeamPermission(namespace, repository, permissionTeamName)
+		permission, err := client.GetTeamPermission(cmd.Context(), namespace, repository, permissionTeamName)
 		if err != nil {
 			return fmt.Errorf("getting team permission: %w", err)
 		}
@@ -237,7 +237,7 @@ var permSetTeamPermCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.SetTeamPermission(namespace, repository, permissionTeamName, permissionRole)
+		err = client.SetTeamPermission(cmd.Context(), namespace, repository, permissionTeamName, permissionRole)
 		if err != nil {
 			return fmt.Errorf("setting team permission: %w", err)
 		}
@@ -262,7 +262,7 @@ var permDeleteTeamPermCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.DeleteTeamPermission(namespace, repository, permissionTeamName)
+		err = client.DeleteTeamPermission(cmd.Context(), namespace, repository, permissionTeamName)
 		if err != nil {
 			return fmt.Errorf("deleting team permission: %w", err)
 		}

--- a/cmd/prototype.go
+++ b/cmd/prototype.go
@@ -43,13 +43,13 @@ var prototypeListCmd = &cobra.Command{
 	Use:   subcmdList,
 	Short: "List all permission prototypes",
 	Long:  `List all permission prototypes for an organization.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		prototypes, err := client.GetPrototypes(prototypeOrg)
+		prototypes, err := client.GetPrototypes(cmd.Context(), prototypeOrg)
 		if err != nil {
 			return fmt.Errorf("getting prototypes: %w", err)
 		}
@@ -63,13 +63,13 @@ var prototypeInfoCmd = &cobra.Command{
 	Use:   subcmdInfo,
 	Short: "Get a specific prototype",
 	Long:  `Get detailed information about a specific permission prototype.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		prototype, err := client.GetPrototype(prototypeOrg, prototypeUUID)
+		prototype, err := client.GetPrototype(cmd.Context(), prototypeOrg, prototypeUUID)
 		if err != nil {
 			return fmt.Errorf("getting prototype: %w", err)
 		}
@@ -93,7 +93,7 @@ Roles:
   - read: Pull images
   - write: Pull and push images
   - admin: Full administrative access`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -107,7 +107,7 @@ Roles:
 			Role: prototypeRole,
 		}
 
-		prototype, err := client.CreatePrototype(prototypeOrg, createReq)
+		prototype, err := client.CreatePrototype(cmd.Context(), prototypeOrg, createReq)
 		if err != nil {
 			return fmt.Errorf("creating prototype: %w", err)
 		}
@@ -121,7 +121,7 @@ var prototypeUpdateCmd = &cobra.Command{
 	Use:   subcmdUpdate,
 	Short: "Update a prototype",
 	Long:  `Update an existing permission prototype's role.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -131,7 +131,7 @@ var prototypeUpdateCmd = &cobra.Command{
 			Role: prototypeRole,
 		}
 
-		prototype, err := client.UpdatePrototype(prototypeOrg, prototypeUUID, updateReq)
+		prototype, err := client.UpdatePrototype(cmd.Context(), prototypeOrg, prototypeUUID, updateReq)
 		if err != nil {
 			return fmt.Errorf("updating prototype: %w", err)
 		}
@@ -145,7 +145,7 @@ var prototypeDeleteCmd = &cobra.Command{
 	Use:   subcmdDelete,
 	Short: "Delete a prototype",
 	Long:  `Delete a permission prototype from an organization.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		if !confirmProtoDelete {
 			return fmt.Errorf("--confirm is required to delete a prototype")
 		}
@@ -155,7 +155,7 @@ var prototypeDeleteCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.DeletePrototype(prototypeOrg, prototypeUUID)
+		err = client.DeletePrototype(cmd.Context(), prototypeOrg, prototypeUUID)
 		if err != nil {
 			return fmt.Errorf("deleting prototype: %w", err)
 		}

--- a/cmd/proxy_cache.go
+++ b/cmd/proxy_cache.go
@@ -17,7 +17,7 @@ var proxyCacheCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		config, err := client.GetProxyCacheConfig(orgName)
+		config, err := client.GetProxyCacheConfig(cmd.Context(), orgName)
 		if err != nil {
 			return fmt.Errorf("getting proxy cache config: %w", err)
 		}
@@ -35,7 +35,7 @@ var createProxyCacheCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		config, err := client.CreateProxyCacheConfig(orgName, upstreamRegistry, insecure, expiration)
+		config, err := client.CreateProxyCacheConfig(cmd.Context(), orgName, upstreamRegistry, insecure, expiration)
 		if err != nil {
 			return fmt.Errorf("creating proxy cache config: %w", err)
 		}
@@ -56,7 +56,7 @@ var deleteProxyCacheCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		err = client.DeleteProxyCacheConfig(orgName)
+		err = client.DeleteProxyCacheConfig(cmd.Context(), orgName)
 		if err != nil {
 			return fmt.Errorf("deleting proxy cache config: %w", err)
 		}

--- a/cmd/quota.go
+++ b/cmd/quota.go
@@ -17,7 +17,7 @@ var orgQuotaCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		quota, err := client.GetQuota(orgName)
+		quota, err := client.GetQuota(cmd.Context(), orgName)
 		if err != nil {
 			return fmt.Errorf("getting organization quota: %w", err)
 		}
@@ -35,7 +35,7 @@ var createQuotaCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		quota, err := client.CreateQuota(orgName, limitBytes)
+		quota, err := client.CreateQuota(cmd.Context(), orgName, limitBytes)
 		if err != nil {
 			return fmt.Errorf("creating quota: %w", err)
 		}
@@ -53,7 +53,7 @@ var updateQuotaCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		quota, err := client.UpdateQuota(orgName, limitBytes)
+		quota, err := client.UpdateQuota(cmd.Context(), orgName, limitBytes)
 		if err != nil {
 			return fmt.Errorf("updating quota: %w", err)
 		}
@@ -74,7 +74,7 @@ var deleteQuotaCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
-		err = client.DeleteQuota(orgName)
+		err = client.DeleteQuota(cmd.Context(), orgName)
 		if err != nil {
 			return fmt.Errorf("deleting quota: %w", err)
 		}

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -46,7 +46,7 @@ var repoInfoCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		repo, err := client.GetRepository(namespace, repository)
+		repo, err := client.GetRepository(cmd.Context(), namespace, repository)
 		if err != nil {
 			return fmt.Errorf("getting repository: %w", err)
 		}
@@ -66,7 +66,7 @@ var repoCreateCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		repo, err := client.CreateRepository(namespace, repository, repoVisibility, repoDescription)
+		repo, err := client.CreateRepository(cmd.Context(), namespace, repository, repoVisibility, repoDescription)
 		if err != nil {
 			return fmt.Errorf("creating repository: %w", err)
 		}
@@ -87,7 +87,7 @@ var repoUpdateCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		repo, err := client.UpdateRepository(namespace, repository, repoDescription, repoVisibility)
+		repo, err := client.UpdateRepository(cmd.Context(), namespace, repository, repoDescription, repoVisibility)
 		if err != nil {
 			return fmt.Errorf("updating repository: %w", err)
 		}
@@ -112,7 +112,7 @@ var repoDeleteCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.DeleteRepository(namespace, repository)
+		err = client.DeleteRepository(cmd.Context(), namespace, repository)
 		if err != nil {
 			return fmt.Errorf("deleting repository: %w", err)
 		}
@@ -143,7 +143,7 @@ Use --table with --popularity for an enriched dashboard sorted by pull count:
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		repos, err := client.ListRepositories(namespace, repoPublic, repoStarred, repoPopularity, repoPage, repoLimit)
+		repos, err := client.ListRepositories(cmd.Context(), namespace, repoPublic, repoStarred, repoPopularity, repoPage, repoLimit)
 		if err != nil {
 			return fmt.Errorf("listing repositories: %w", err)
 		}
@@ -168,7 +168,7 @@ Use --table with --popularity for an enriched dashboard sorted by pull count:
 			tagDisplay := "0"
 			recentPushes := 0
 
-			tags, err := client.ListTags(namespace, repo.Name, 100, true)
+			tags, err := client.ListTags(cmd.Context(), namespace, repo.Name, 100, true)
 			if err == nil && len(tags.Tags) > 0 {
 				for _, tag := range tags.Tags {
 					if strings.HasPrefix(tag.Name, "sha256-") || strings.HasSuffix(tag.Name, ".sig") || strings.HasSuffix(tag.Name, ".att") || strings.HasSuffix(tag.Name, ".sbom") {
@@ -217,7 +217,7 @@ var repoChangeVisibilityCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.ChangeRepositoryVisibility(namespace, repository, repoVisibility)
+		err = client.ChangeRepositoryVisibility(cmd.Context(), namespace, repository, repoVisibility)
 		if err != nil {
 			return fmt.Errorf("changing repository visibility: %w", err)
 		}

--- a/cmd/repotoken.go
+++ b/cmd/repotoken.go
@@ -44,13 +44,13 @@ var repotokenListCmd = &cobra.Command{
 	Use:   subcmdList,
 	Short: "List all repository tokens",
 	Long:  `List all tokens for a repository. (DEPRECATED - use robot accounts)`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		tokens, err := client.GetRepoTokens(repoTokenNamespace, repoTokenRepository) //nolint:staticcheck // Intentionally using deprecated API
+		tokens, err := client.GetRepoTokens(cmd.Context(), repoTokenNamespace, repoTokenRepository) //nolint:staticcheck // Intentionally using deprecated API
 		if err != nil {
 			return fmt.Errorf("getting tokens: %w", err)
 		}
@@ -64,13 +64,13 @@ var repotokenInfoCmd = &cobra.Command{
 	Use:   subcmdInfo,
 	Short: "Get a specific token",
 	Long:  `Get detailed information about a specific repository token. (DEPRECATED - use robot accounts)`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		repoToken, err := client.GetRepoToken(repoTokenNamespace, repoTokenRepository, repoTokenCode) //nolint:staticcheck // Intentionally using deprecated API
+		repoToken, err := client.GetRepoToken(cmd.Context(), repoTokenNamespace, repoTokenRepository, repoTokenCode) //nolint:staticcheck // Intentionally using deprecated API
 		if err != nil {
 			return fmt.Errorf("getting token: %w", err)
 		}
@@ -84,7 +84,7 @@ var repotokenCreateCmd = &cobra.Command{
 	Use:   subcmdCreate,
 	Short: "Create a new token",
 	Long:  `Create a new repository token. (DEPRECATED - use robot accounts)`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -94,7 +94,7 @@ var repotokenCreateCmd = &cobra.Command{
 			FriendlyName: repoTokenName,
 		}
 
-		repoToken, err := client.CreateRepoToken(repoTokenNamespace, repoTokenRepository, createReq) //nolint:staticcheck // Intentionally using deprecated API
+		repoToken, err := client.CreateRepoToken(cmd.Context(), repoTokenNamespace, repoTokenRepository, createReq) //nolint:staticcheck // Intentionally using deprecated API
 		if err != nil {
 			return fmt.Errorf("creating token: %w", err)
 		}
@@ -108,7 +108,7 @@ var repotokenUpdateCmd = &cobra.Command{
 	Use:   subcmdUpdate,
 	Short: "Update a token",
 	Long:  `Update a repository token's role. (DEPRECATED - use robot accounts)`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -118,7 +118,7 @@ var repotokenUpdateCmd = &cobra.Command{
 			Role: repoTokenRole,
 		}
 
-		repoToken, err := client.UpdateRepoToken(repoTokenNamespace, repoTokenRepository, repoTokenCode, updateReq) //nolint:staticcheck // Intentionally using deprecated API
+		repoToken, err := client.UpdateRepoToken(cmd.Context(), repoTokenNamespace, repoTokenRepository, repoTokenCode, updateReq) //nolint:staticcheck // Intentionally using deprecated API
 		if err != nil {
 			return fmt.Errorf("updating token: %w", err)
 		}
@@ -132,7 +132,7 @@ var repotokenDeleteCmd = &cobra.Command{
 	Use:   subcmdDelete,
 	Short: "Delete a token",
 	Long:  `Delete a repository token. (DEPRECATED - use robot accounts)`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		if !confirmTokenDelete {
 			return fmt.Errorf("--confirm is required to delete a token")
 		}
@@ -142,7 +142,7 @@ var repotokenDeleteCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.DeleteRepoToken(repoTokenNamespace, repoTokenRepository, repoTokenCode) //nolint:staticcheck // Intentionally using deprecated API
+		err = client.DeleteRepoToken(cmd.Context(), repoTokenNamespace, repoTokenRepository, repoTokenCode) //nolint:staticcheck // Intentionally using deprecated API
 		if err != nil {
 			return fmt.Errorf("deleting token: %w", err)
 		}

--- a/cmd/robot.go
+++ b/cmd/robot.go
@@ -45,7 +45,7 @@ var robotListCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		robots, err := client.GetUserRobotAccounts()
+		robots, err := client.GetUserRobotAccounts(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("getting robot accounts: %w", err)
 		}
@@ -66,7 +66,7 @@ var robotInfoCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		robot, err := client.GetUserRobotAccount(robotShortname)
+		robot, err := client.GetUserRobotAccount(cmd.Context(), robotShortname)
 		if err != nil {
 			return fmt.Errorf("getting robot account: %w", err)
 		}
@@ -87,7 +87,7 @@ var robotCreateCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		robot, err := client.CreateUserRobotAccount(robotShortname, robotDescription, nil)
+		robot, err := client.CreateUserRobotAccount(cmd.Context(), robotShortname, robotDescription, nil)
 		if err != nil {
 			return fmt.Errorf("creating robot account: %w", err)
 		}
@@ -113,7 +113,7 @@ var robotDeleteCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.DeleteUserRobotAccount(robotShortname)
+		err = client.DeleteUserRobotAccount(cmd.Context(), robotShortname)
 		if err != nil {
 			return fmt.Errorf("deleting robot account: %w", err)
 		}
@@ -134,7 +134,7 @@ var robotRegenerateCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		robot, err := client.RegenerateUserRobotToken(robotShortname)
+		robot, err := client.RegenerateUserRobotToken(cmd.Context(), robotShortname)
 		if err != nil {
 			return fmt.Errorf("regenerating robot token: %w", err)
 		}
@@ -156,7 +156,7 @@ var robotPermissionsCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		permissions, err := client.GetUserRobotPermissions(robotShortname)
+		permissions, err := client.GetUserRobotPermissions(cmd.Context(), robotShortname)
 		if err != nil {
 			return fmt.Errorf("getting robot permissions: %w", err)
 		}
@@ -176,7 +176,7 @@ var robotFederationGetCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		federation, err := client.GetUserRobotFederation(robotShortname)
+		federation, err := client.GetUserRobotFederation(cmd.Context(), robotShortname)
 		if err != nil {
 			return fmt.Errorf("getting robot federation: %w", err)
 		}
@@ -199,7 +199,7 @@ var robotFederationCreateCmd = &cobra.Command{
 			{Issuer: federationIssuer, Subject: federationSubject},
 		}
 
-		err = client.CreateUserRobotFederation(robotShortname, configs)
+		err = client.CreateUserRobotFederation(cmd.Context(), robotShortname, configs)
 		if err != nil {
 			return fmt.Errorf("creating robot federation: %w", err)
 		}
@@ -219,7 +219,7 @@ var robotFederationDeleteCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.DeleteUserRobotFederation(robotShortname)
+		err = client.DeleteUserRobotFederation(cmd.Context(), robotShortname)
 		if err != nil {
 			return fmt.Errorf("deleting robot federation: %w", err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/sebrandon1/go-quay/lib"
 	"github.com/spf13/cobra"
@@ -95,7 +98,9 @@ func init() {
 	getCmd.AddCommand(mirrorCmd)
 }
 
-// Execute executes the root command.
+// Execute executes the root command, canceling in-flight HTTP on interrupt.
 func Execute() error {
-	return rootCmd.Execute()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return rootCmd.ExecuteContext(ctx)
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -34,7 +34,7 @@ var searchReposCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		result, err := client.SearchRepositories(searchQuery, searchPage)
+		result, err := client.SearchRepositories(cmd.Context(), searchQuery, searchPage)
 		if err != nil {
 			return fmt.Errorf("searching repositories: %w", err)
 		}
@@ -62,7 +62,7 @@ Results include a 'kind' field indicating the entity type:
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		result, err := client.SearchAll(searchQuery)
+		result, err := client.SearchAll(cmd.Context(), searchQuery)
 		if err != nil {
 			return fmt.Errorf("searching: %w", err)
 		}

--- a/cmd/secscan.go
+++ b/cmd/secscan.go
@@ -43,7 +43,7 @@ The scan status can be:
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		security, err := client.GetManifestSecurity(namespace, repository, secScanManifestRef, includeVulnerabilities)
+		security, err := client.GetManifestSecurity(cmd.Context(), namespace, repository, secScanManifestRef, includeVulnerabilities)
 		if err != nil {
 			return fmt.Errorf("getting security scan: %w", err)
 		}

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -39,7 +39,7 @@ var tagInfoCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		tag, err := client.GetTag(namespace, repository, tagName)
+		tag, err := client.GetTag(cmd.Context(), namespace, repository, tagName)
 		if err != nil {
 			return fmt.Errorf("getting tag information: %w", err)
 		}
@@ -60,7 +60,7 @@ var tagUpdateCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		tag, err := client.UpdateTag(namespace, repository, tagName, tagExpiration)
+		tag, err := client.UpdateTag(cmd.Context(), namespace, repository, tagName, tagExpiration)
 		if err != nil {
 			return fmt.Errorf("updating tag: %w", err)
 		}
@@ -85,7 +85,7 @@ var tagDeleteCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.DeleteTag(namespace, repository, tagName)
+		err = client.DeleteTag(cmd.Context(), namespace, repository, tagName)
 		if err != nil {
 			return fmt.Errorf("deleting tag: %w", err)
 		}
@@ -106,7 +106,7 @@ var tagHistoryCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		history, err := client.GetTagHistory(namespace, repository, tagName)
+		history, err := client.GetTagHistory(cmd.Context(), namespace, repository, tagName)
 		if err != nil {
 			return fmt.Errorf("getting tag history: %w", err)
 		}
@@ -127,7 +127,7 @@ var tagRevertCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		tag, err := client.RevertTag(namespace, repository, tagName, manifestDigest)
+		tag, err := client.RevertTag(cmd.Context(), namespace, repository, tagName, manifestDigest)
 		if err != nil {
 			return fmt.Errorf("reverting tag: %w", err)
 		}
@@ -148,7 +148,7 @@ var tagChangeCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.ChangeTag(namespace, repository, tagName, manifestDigest)
+		err = client.ChangeTag(cmd.Context(), namespace, repository, tagName, manifestDigest)
 		if err != nil {
 			return fmt.Errorf("changing tag: %w", err)
 		}
@@ -168,7 +168,7 @@ var tagRestoreCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.RestoreTag(namespace, repository, tagName, manifestDigest)
+		err = client.RestoreTag(cmd.Context(), namespace, repository, tagName, manifestDigest)
 		if err != nil {
 			return fmt.Errorf("restoring tag: %w", err)
 		}

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -53,7 +53,7 @@ var teamListCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		teams, err := client.GetTeams(teamCmdOrgname)
+		teams, err := client.GetTeams(cmd.Context(), teamCmdOrgname)
 		if err != nil {
 			return fmt.Errorf("getting teams: %w", err)
 		}
@@ -74,7 +74,7 @@ var teamCmdInfoCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		team, err := client.GetTeam(teamCmdOrgname, teamCmdName)
+		team, err := client.GetTeam(cmd.Context(), teamCmdOrgname, teamCmdName)
 		if err != nil {
 			return fmt.Errorf("getting team: %w", err)
 		}
@@ -100,7 +100,7 @@ Roles:
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		team, err := client.CreateTeam(teamCmdOrgname, teamCmdName, teamCmdDescription, teamCmdRole)
+		team, err := client.CreateTeam(cmd.Context(), teamCmdOrgname, teamCmdName, teamCmdDescription, teamCmdRole)
 		if err != nil {
 			return fmt.Errorf("creating team: %w", err)
 		}
@@ -121,7 +121,7 @@ var teamUpdateCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		team, err := client.UpdateTeam(teamCmdOrgname, teamCmdName, teamCmdDescription, teamCmdRole)
+		team, err := client.UpdateTeam(cmd.Context(), teamCmdOrgname, teamCmdName, teamCmdDescription, teamCmdRole)
 		if err != nil {
 			return fmt.Errorf("updating team: %w", err)
 		}
@@ -146,7 +146,7 @@ var teamDeleteCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.DeleteTeam(teamCmdOrgname, teamCmdName)
+		err = client.DeleteTeam(cmd.Context(), teamCmdOrgname, teamCmdName)
 		if err != nil {
 			return fmt.Errorf("deleting team: %w", err)
 		}
@@ -167,7 +167,7 @@ var teamCmdMembersCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		members, err := client.GetTeamMembers(teamCmdOrgname, teamCmdName)
+		members, err := client.GetTeamMembers(cmd.Context(), teamCmdOrgname, teamCmdName)
 		if err != nil {
 			return fmt.Errorf("getting team members: %w", err)
 		}
@@ -188,7 +188,7 @@ var teamAddMemberCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.AddTeamMember(teamCmdOrgname, teamCmdName, teamCmdMemberName)
+		err = client.AddTeamMember(cmd.Context(), teamCmdOrgname, teamCmdName, teamCmdMemberName)
 		if err != nil {
 			return fmt.Errorf("adding team member: %w", err)
 		}
@@ -213,7 +213,7 @@ var teamRemoveMemberCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.RemoveTeamMember(teamCmdOrgname, teamCmdName, teamCmdMemberName)
+		err = client.RemoveTeamMember(cmd.Context(), teamCmdOrgname, teamCmdName, teamCmdMemberName)
 		if err != nil {
 			return fmt.Errorf("removing team member: %w", err)
 		}
@@ -234,7 +234,7 @@ var teamPermissionsCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		permissions, err := client.GetTeamPermissions(teamCmdOrgname, teamCmdName)
+		permissions, err := client.GetTeamPermissions(cmd.Context(), teamCmdOrgname, teamCmdName)
 		if err != nil {
 			return fmt.Errorf("getting team permissions: %w", err)
 		}
@@ -260,7 +260,7 @@ Permission roles:
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.SetTeamRepositoryPermission(teamCmdOrgname, teamCmdName, teamCmdRepository, teamCmdPermissionRole)
+		err = client.SetTeamRepositoryPermission(cmd.Context(), teamCmdOrgname, teamCmdName, teamCmdRepository, teamCmdPermissionRole)
 		if err != nil {
 			return fmt.Errorf("setting team permission: %w", err)
 		}
@@ -287,7 +287,7 @@ var teamRemovePermissionCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.RemoveTeamRepositoryPermission(teamCmdOrgname, teamCmdName, teamCmdRepository)
+		err = client.RemoveTeamRepositoryPermission(cmd.Context(), teamCmdOrgname, teamCmdName, teamCmdRepository)
 		if err != nil {
 			return fmt.Errorf("removing team permission: %w", err)
 		}

--- a/cmd/trigger.go
+++ b/cmd/trigger.go
@@ -44,13 +44,13 @@ var triggerListCmd = &cobra.Command{
 	Use:   subcmdList,
 	Short: "List all build triggers for a repository",
 	Long:  `List all build triggers configured for a repository.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		triggers, err := client.GetTriggers(triggerNamespace, triggerRepository)
+		triggers, err := client.GetTriggers(cmd.Context(), triggerNamespace, triggerRepository)
 		if err != nil {
 			return fmt.Errorf("getting triggers: %w", err)
 		}
@@ -64,13 +64,13 @@ var triggerInfoCmd = &cobra.Command{
 	Use:   subcmdInfo,
 	Short: "Get details of a specific build trigger",
 	Long:  `Get detailed information about a specific build trigger by its UUID.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		trigger, err := client.GetTrigger(triggerNamespace, triggerRepository, triggerUUID)
+		trigger, err := client.GetTrigger(cmd.Context(), triggerNamespace, triggerRepository, triggerUUID)
 		if err != nil {
 			return fmt.Errorf("getting trigger: %w", err)
 		}
@@ -84,13 +84,13 @@ var triggerDeleteCmd = &cobra.Command{
 	Use:   subcmdDelete,
 	Short: "Delete a build trigger",
 	Long:  `Delete a build trigger from a repository.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.DeleteTrigger(triggerNamespace, triggerRepository, triggerUUID)
+		err = client.DeleteTrigger(cmd.Context(), triggerNamespace, triggerRepository, triggerUUID)
 		if err != nil {
 			return fmt.Errorf("deleting trigger: %w", err)
 		}
@@ -105,13 +105,13 @@ var triggerEnableCmd = &cobra.Command{
 	Use:   "enable",
 	Short: "Enable a build trigger",
 	Long:  `Enable a build trigger for a repository.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		trigger, err := client.UpdateTrigger(triggerNamespace, triggerRepository, triggerUUID, true)
+		trigger, err := client.UpdateTrigger(cmd.Context(), triggerNamespace, triggerRepository, triggerUUID, true)
 		if err != nil {
 			return fmt.Errorf("enabling trigger: %w", err)
 		}
@@ -125,13 +125,13 @@ var triggerDisableCmd = &cobra.Command{
 	Use:   "disable",
 	Short: "Disable a build trigger",
 	Long:  `Disable a build trigger for a repository.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		trigger, err := client.UpdateTrigger(triggerNamespace, triggerRepository, triggerUUID, false)
+		trigger, err := client.UpdateTrigger(cmd.Context(), triggerNamespace, triggerRepository, triggerUUID, false)
 		if err != nil {
 			return fmt.Errorf("disabling trigger: %w", err)
 		}
@@ -145,7 +145,7 @@ var triggerStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Manually start a build from a trigger",
 	Long:  `Manually start a build using a configured trigger.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -158,7 +158,7 @@ var triggerStartCmd = &cobra.Command{
 			}
 		}
 
-		build, err := client.StartTriggerBuild(triggerNamespace, triggerRepository, triggerUUID, triggerReq)
+		build, err := client.StartTriggerBuild(cmd.Context(), triggerNamespace, triggerRepository, triggerUUID, triggerReq)
 		if err != nil {
 			return fmt.Errorf("starting trigger build: %w", err)
 		}
@@ -172,7 +172,7 @@ var triggerActivateCmd = &cobra.Command{
 	Use:   "activate",
 	Short: "Activate a build trigger with configuration",
 	Long:  `Activate a build trigger with the specified configuration.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
@@ -183,7 +183,7 @@ var triggerActivateCmd = &cobra.Command{
 			activateReq.PullRobot = triggerPullRobot
 		}
 
-		trigger, err := client.ActivateTrigger(triggerNamespace, triggerRepository, triggerUUID, activateReq)
+		trigger, err := client.ActivateTrigger(cmd.Context(), triggerNamespace, triggerRepository, triggerUUID, activateReq)
 		if err != nil {
 			return fmt.Errorf("activating trigger: %w", err)
 		}
@@ -196,13 +196,13 @@ var triggerBuildsCmd = &cobra.Command{
 	Use:   "builds",
 	Short: "List builds for a trigger",
 	Long:  `List builds that were started by a specific trigger.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := getClient()
 		if err != nil {
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		builds, err := client.GetTriggerBuilds(triggerNamespace, triggerRepository, triggerUUID, triggerBuildLimit)
+		builds, err := client.GetTriggerBuilds(cmd.Context(), triggerNamespace, triggerRepository, triggerUUID, triggerBuildLimit)
 		if err != nil {
 			return fmt.Errorf("getting trigger builds: %w", err)
 		}

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -33,7 +33,7 @@ var userInfoCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		user, err := client.GetUser()
+		user, err := client.GetUser(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("getting user information: %w", err)
 		}
@@ -54,7 +54,7 @@ var userStarredCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		starred, err := client.GetStarredRepositories()
+		starred, err := client.GetStarredRepositories(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("getting starred repositories: %w", err)
 		}
@@ -75,7 +75,7 @@ var starRepoCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.StarRepository(namespace, repository)
+		err = client.StarRepository(cmd.Context(), namespace, repository)
 		if err != nil {
 			return fmt.Errorf("starring repository: %w", err)
 		}
@@ -96,7 +96,7 @@ var unstarRepoCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		err = client.UnstarRepository(namespace, repository)
+		err = client.UnstarRepository(cmd.Context(), namespace, repository)
 		if err != nil {
 			return fmt.Errorf("unstarring repository: %w", err)
 		}
@@ -118,7 +118,7 @@ var userLookupCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		user, err := client.GetUserByUsername(lookupUsername)
+		user, err := client.GetUserByUsername(cmd.Context(), lookupUsername)
 		if err != nil {
 			return fmt.Errorf("looking up user: %w", err)
 		}
@@ -137,7 +137,7 @@ var userMarketplaceCmd = &cobra.Command{
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		marketplace, err := client.GetUserMarketplace()
+		marketplace, err := client.GetUserMarketplace(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("getting user marketplace info: %w", err)
 		}

--- a/docs/library-guide.md
+++ b/docs/library-guide.md
@@ -44,108 +44,112 @@ func main() {
 }
 ```
 
+Every API method takes `context.Context` as its first argument. Use `context.Background()`, `context.WithTimeout`, or a request-scoped context from your caller. Canceling the context aborts in-flight HTTP requests and retry backoff.
+
+The snippets below use `ctx` for that argument.
+
 ## API Categories
 
 ### User Operations
 
 ```go
 // Get current user
-user, err := client.GetUser()
+user, err := client.GetUser(ctx)
 
 // Get user by username
-user, err := client.GetUserByUsername("johndoe")
+user, err := client.GetUserByUsername(ctx, "johndoe")
 
 // Get starred repositories
-starred, err := client.GetStarredRepositories()
+starred, err := client.GetStarredRepositories(ctx)
 
 // Star/unstar repositories
-err := client.StarRepository("namespace", "repo")
-err := client.UnstarRepository("namespace", "repo")
+err := client.StarRepository(ctx, "namespace", "repo")
+err := client.UnstarRepository(ctx, "namespace", "repo")
 
 // User robots
-robots, err := client.GetUserRobotAccounts()
-robot, err := client.CreateUserRobotAccount("name", "description", nil)
-robot, err := client.GetUserRobotAccount("name")
-robot, err := client.RegenerateUserRobotToken("name")
-err := client.DeleteUserRobotAccount("name")
-perms, err := client.GetUserRobotPermissions("name")
+robots, err := client.GetUserRobotAccounts(ctx)
+robot, err := client.CreateUserRobotAccount(ctx, "name", "description", nil)
+robot, err := client.GetUserRobotAccount(ctx, "name")
+robot, err := client.RegenerateUserRobotToken(ctx, "name")
+err := client.DeleteUserRobotAccount(ctx, "name")
+perms, err := client.GetUserRobotPermissions(ctx, "name")
 
 // User robot federation
-federation, err := client.GetUserRobotFederation("name")
-err := client.CreateUserRobotFederation("name", []lib.RobotFederationConfig{{Issuer: "issuer", Subject: "subject"}})
-err := client.DeleteUserRobotFederation("name")
+federation, err := client.GetUserRobotFederation(ctx, "name")
+err := client.CreateUserRobotFederation(ctx, "name", []lib.RobotFederationConfig{{Issuer: "issuer", Subject: "subject"}})
+err := client.DeleteUserRobotFederation(ctx, "name")
 
 // User marketplace
-marketplace, err := client.GetUserMarketplace()
+marketplace, err := client.GetUserMarketplace(ctx)
 ```
 
 ### Repository Operations
 
 ```go
 // List repositories
-repos, err := client.ListRepositories(namespace, public, starred, popularity, page, limit)
+repos, err := client.ListRepositories(ctx, namespace, public, starred, popularity, page, limit)
 
 // CRUD operations
-repo, err := client.CreateRepository(namespace, name, visibility, description)
-repo, err := client.GetRepository(namespace, name)
-repo, err := client.UpdateRepository(namespace, name, description, visibility)
-err := client.DeleteRepository(namespace, name)
+repo, err := client.CreateRepository(ctx, namespace, name, visibility, description)
+repo, err := client.GetRepository(ctx, namespace, name)
+repo, err := client.UpdateRepository(ctx, namespace, name, description, visibility)
+err := client.DeleteRepository(ctx, namespace, name)
 
 // Change visibility
-err := client.ChangeRepositoryVisibility(namespace, name, "public")
+err := client.ChangeRepositoryVisibility(ctx, namespace, name, "public")
 
 // Paginate automatically
-allRepos, err := client.ListAllRepositories(namespace, public, starred, popularity)
-allTags, err := client.ListAllTags(namespace, name, onlyActive)
-page, err := client.ListTagsPage(namespace, name, limit, pageNum, onlyActive)
+allRepos, err := client.ListAllRepositories(ctx, namespace, public, starred, popularity)
+allTags, err := client.ListAllTags(ctx, namespace, name, onlyActive)
+page, err := client.ListTagsPage(ctx, namespace, name, limit, pageNum, onlyActive)
 ```
 
 ### Tag Operations
 
 ```go
 // Get tag info
-tag, err := client.GetTag(namespace, repo, tagName)
+tag, err := client.GetTag(ctx, namespace, repo, tagName)
 
 // Update tag (set expiration)
-tag, err := client.UpdateTag(namespace, repo, tagName, expiration)
+tag, err := client.UpdateTag(ctx, namespace, repo, tagName, expiration)
 
 // Delete tag
-err := client.DeleteTag(namespace, repo, tagName)
+err := client.DeleteTag(ctx, namespace, repo, tagName)
 
 // Tag history
-history, err := client.GetTagHistory(namespace, repo, tagName)
+history, err := client.GetTagHistory(ctx, namespace, repo, tagName)
 
 // Restore tag
-err := client.RestoreTag(namespace, repo, tagName, manifestDigest)
+err := client.RestoreTag(ctx, namespace, repo, tagName, manifestDigest)
 
 // Revert tag
-tag, err := client.RevertTag(namespace, repo, tagName, manifestDigest)
+tag, err := client.RevertTag(ctx, namespace, repo, tagName, manifestDigest)
 
 // Create or move a tag to a digest
-err := client.ChangeTag(namespace, repo, tagName, manifestDigest)
+err := client.ChangeTag(ctx, namespace, repo, tagName, manifestDigest)
 ```
 
 ### Manifest Operations
 
 ```go
 // Get manifest
-manifest, err := client.GetManifest(namespace, repo, digest)
+manifest, err := client.GetManifest(ctx, namespace, repo, digest)
 
 // Delete manifest
-err := client.DeleteManifest(namespace, repo, digest)
+err := client.DeleteManifest(ctx, namespace, repo, digest)
 
 // Labels
-labels, err := client.GetManifestLabels(namespace, repo, digest)
-label, err := client.GetManifestLabel(namespace, repo, digest, labelID)
-label, err := client.AddManifestLabel(namespace, repo, digest, key, value, mediaType)
-err := client.DeleteManifestLabel(namespace, repo, digest, labelID)
+labels, err := client.GetManifestLabels(ctx, namespace, repo, digest)
+label, err := client.GetManifestLabel(ctx, namespace, repo, digest, labelID)
+label, err := client.AddManifestLabel(ctx, namespace, repo, digest, key, value, mediaType)
+err := client.DeleteManifestLabel(ctx, namespace, repo, digest, labelID)
 ```
 
 ### Security Scanning
 
 ```go
 // Get security scan results
-security, err := client.GetManifestSecurity(namespace, repo, digest, includeVulns)
+security, err := client.GetManifestSecurity(ctx, namespace, repo, digest, includeVulns)
 
 // Access vulnerability data
 if security.Status == "scanned" && security.Data != nil {
@@ -161,145 +165,145 @@ if security.Status == "scanned" && security.Data != nil {
 
 ```go
 // CRUD
-org, err := client.CreateOrganization(name, email)
-org, err := client.GetOrganization(name)
-org, err := client.UpdateOrganization(name, email)
-err := client.DeleteOrganization(name)
+org, err := client.CreateOrganization(ctx, name, email)
+org, err := client.GetOrganization(ctx, name)
+org, err := client.UpdateOrganization(ctx, name, email)
+err := client.DeleteOrganization(ctx, name)
 
 // Members
-members, err := client.GetOrganizationMembers(orgname)
-member, err := client.GetOrganizationMember(orgname, membername)
-err := client.AddOrganizationMember(orgname, membername)
-err := client.RemoveOrganizationMember(orgname, membername)
+members, err := client.GetOrganizationMembers(ctx, orgname)
+member, err := client.GetOrganizationMember(ctx, orgname, membername)
+err := client.AddOrganizationMember(ctx, orgname, membername)
+err := client.RemoveOrganizationMember(ctx, orgname, membername)
 
 // Collaborators
-collaborators, err := client.GetOrganizationCollaborators(orgname)
+collaborators, err := client.GetOrganizationCollaborators(ctx, orgname)
 
 // Repositories
-repos, err := client.GetOrganizationRepositories(orgname)
+repos, err := client.GetOrganizationRepositories(ctx, orgname)
 
 // Robots
-robots, err := client.GetRobotAccounts(orgname)
-robot, err := client.CreateRobotAccount(orgname, name, description, nil)
-robot, err := client.GetRobotAccount(orgname, name)
-robot, err := client.RegenerateRobotToken(orgname, name)
-err := client.DeleteRobotAccount(orgname, name)
-perms, err := client.GetRobotPermissions(orgname, name)
-err := client.SetRobotRepositoryPermission(orgname, name, repository, role)
-err := client.RemoveRobotRepositoryPermission(orgname, name, repository)
+robots, err := client.GetRobotAccounts(ctx, orgname)
+robot, err := client.CreateRobotAccount(ctx, orgname, name, description, nil)
+robot, err := client.GetRobotAccount(ctx, orgname, name)
+robot, err := client.RegenerateRobotToken(ctx, orgname, name)
+err := client.DeleteRobotAccount(ctx, orgname, name)
+perms, err := client.GetRobotPermissions(ctx, orgname, name)
+err := client.SetRobotRepositoryPermission(ctx, orgname, name, repository, role)
+err := client.RemoveRobotRepositoryPermission(ctx, orgname, name, repository)
 
 // Robot federation
-federation, err := client.GetRobotFederation(orgname, name)
-err := client.CreateRobotFederation(orgname, name, []lib.RobotFederationConfig{{Issuer: "issuer", Subject: "subject"}})
-err := client.DeleteRobotFederation(orgname, name)
+federation, err := client.GetRobotFederation(ctx, orgname, name)
+err := client.CreateRobotFederation(ctx, orgname, name, []lib.RobotFederationConfig{{Issuer: "issuer", Subject: "subject"}})
+err := client.DeleteRobotFederation(ctx, orgname, name)
 ```
 
 ### Team Operations
 
 ```go
 // CRUD
-teams, err := client.GetTeams(orgname)
-team, err := client.CreateTeam(orgname, teamname, description, role)
-team, err := client.GetTeam(orgname, teamname)
-team, err := client.UpdateTeam(orgname, teamname, description, role)
-err := client.DeleteTeam(orgname, teamname)
+teams, err := client.GetTeams(ctx, orgname)
+team, err := client.CreateTeam(ctx, orgname, teamname, description, role)
+team, err := client.GetTeam(ctx, orgname, teamname)
+team, err := client.UpdateTeam(ctx, orgname, teamname, description, role)
+err := client.DeleteTeam(ctx, orgname, teamname)
 
 // Members
-members, err := client.GetTeamMembers(orgname, teamname)
-err := client.AddTeamMember(orgname, teamname, membername)
-err := client.RemoveTeamMember(orgname, teamname, membername)
+members, err := client.GetTeamMembers(ctx, orgname, teamname)
+err := client.AddTeamMember(ctx, orgname, teamname, membername)
+err := client.RemoveTeamMember(ctx, orgname, teamname, membername)
 
 // Invitations
-err := client.InviteTeamMember(orgname, teamname, email)
-err := client.DeleteTeamInvite(orgname, teamname, email)
+err := client.InviteTeamMember(ctx, orgname, teamname, email)
+err := client.DeleteTeamInvite(ctx, orgname, teamname, email)
 
 // Permissions
-perms, err := client.GetTeamPermissions(orgname, teamname)
-err := client.SetTeamRepositoryPermission(orgname, teamname, repo, role)
-err := client.RemoveTeamRepositoryPermission(orgname, teamname, repo)
+perms, err := client.GetTeamPermissions(ctx, orgname, teamname)
+err := client.SetTeamRepositoryPermission(ctx, orgname, teamname, repo, role)
+err := client.RemoveTeamRepositoryPermission(ctx, orgname, teamname, repo)
 ```
 
 ### Permission Operations
 
 ```go
 // Combined user/robot permissions (used by CLI `permissions list/set/remove`)
-perms, err := client.GetRepositoryPermissions(namespace, repo)
-err := client.SetRepositoryPermission(namespace, repo, username, role)
-err := client.RemoveRepositoryPermission(namespace, repo, username)
+perms, err := client.GetRepositoryPermissions(ctx, namespace, repo)
+err := client.SetRepositoryPermission(ctx, namespace, repo, username, role)
+err := client.RemoveRepositoryPermission(ctx, namespace, repo, username)
 
 // User permissions
-perms, err := client.ListUserPermissions(namespace, repo)
-perm, err := client.GetUserPermission(namespace, repo, username)
-err := client.SetUserPermission(namespace, repo, username, role)
-err := client.DeleteUserPermission(namespace, repo, username)
-perm, err := client.GetUserTransitivePermission(namespace, repo, username)
+perms, err := client.ListUserPermissions(ctx, namespace, repo)
+perm, err := client.GetUserPermission(ctx, namespace, repo, username)
+err := client.SetUserPermission(ctx, namespace, repo, username, role)
+err := client.DeleteUserPermission(ctx, namespace, repo, username)
+perm, err := client.GetUserTransitivePermission(ctx, namespace, repo, username)
 
 // Team permissions
-perms, err := client.ListTeamPermissions(namespace, repo)
-perm, err := client.GetTeamPermission(namespace, repo, teamname)
-err := client.SetTeamPermission(namespace, repo, teamname, role)
-err := client.DeleteTeamPermission(namespace, repo, teamname)
+perms, err := client.ListTeamPermissions(ctx, namespace, repo)
+perm, err := client.GetTeamPermission(ctx, namespace, repo, teamname)
+err := client.SetTeamPermission(ctx, namespace, repo, teamname, role)
+err := client.DeleteTeamPermission(ctx, namespace, repo, teamname)
 ```
 
 ### Build Operations
 
 ```go
 // List builds
-builds, err := client.GetBuilds(namespace, repo, limit)
+builds, err := client.GetBuilds(ctx, namespace, repo, limit)
 
 // Get build
-build, err := client.GetBuild(namespace, repo, buildUUID)
+build, err := client.GetBuild(ctx, namespace, repo, buildUUID)
 
 // Get build logs
-logs, err := client.GetBuildLogs(namespace, repo, buildUUID)
+logs, err := client.GetBuildLogs(ctx, namespace, repo, buildUUID)
 
 // Get build status
-status, err := client.GetBuildStatus(namespace, repo, buildUUID)
+status, err := client.GetBuildStatus(ctx, namespace, repo, buildUUID)
 
 // Request new build
-build, err := client.RequestBuild(namespace, repo, &lib.RequestBuildRequest{...})
+build, err := client.RequestBuild(ctx, namespace, repo, &lib.RequestBuildRequest{...})
 
 // Cancel build
-err := client.CancelBuild(namespace, repo, buildUUID)
+err := client.CancelBuild(ctx, namespace, repo, buildUUID)
 ```
 
 ### Build Trigger Operations
 
 ```go
 // List triggers
-triggers, err := client.GetTriggers(namespace, repo)
+triggers, err := client.GetTriggers(ctx, namespace, repo)
 
 // Get trigger
-trigger, err := client.GetTrigger(namespace, repo, triggerUUID)
+trigger, err := client.GetTrigger(ctx, namespace, repo, triggerUUID)
 
 // Activate trigger
-trigger, err := client.ActivateTrigger(namespace, repo, triggerUUID, &lib.ActivateTriggerRequest{...})
+trigger, err := client.ActivateTrigger(ctx, namespace, repo, triggerUUID, &lib.ActivateTriggerRequest{...})
 
 // Start build from trigger
-build, err := client.StartTriggerBuild(namespace, repo, triggerUUID, &lib.ManualTriggerRequest{...})
+build, err := client.StartTriggerBuild(ctx, namespace, repo, triggerUUID, &lib.ManualTriggerRequest{...})
 
 // Enable/disable trigger
-trigger, err := client.UpdateTrigger(namespace, repo, triggerUUID, true)
-trigger, err := client.UpdateTrigger(namespace, repo, triggerUUID, false)
+trigger, err := client.UpdateTrigger(ctx, namespace, repo, triggerUUID, true)
+trigger, err := client.UpdateTrigger(ctx, namespace, repo, triggerUUID, false)
 
 // List builds from a specific trigger
-builds, err := client.GetTriggerBuilds(namespace, repo, triggerUUID, limit)
+builds, err := client.GetTriggerBuilds(ctx, namespace, repo, triggerUUID, limit)
 
 // Delete trigger
-err := client.DeleteTrigger(namespace, repo, triggerUUID)
+err := client.DeleteTrigger(ctx, namespace, repo, triggerUUID)
 ```
 
 ### Notification Operations
 
 ```go
 // List notifications
-notifications, err := client.GetNotifications(namespace, repo)
+notifications, err := client.GetNotifications(ctx, namespace, repo)
 
 // Get notification
-notification, err := client.GetNotification(namespace, repo, uuid)
+notification, err := client.GetNotification(ctx, namespace, repo, uuid)
 
 // Create notification
-notification, err := client.CreateNotification(namespace, repo, &lib.CreateNotificationRequest{
+notification, err := client.CreateNotification(ctx, namespace, repo, &lib.CreateNotificationRequest{
     Event:  "repo_push",
     Method: "webhook",
     Title:  "My Notification",
@@ -307,242 +311,242 @@ notification, err := client.CreateNotification(namespace, repo, &lib.CreateNotif
 })
 
 // Update notification
-notification, err := client.UpdateNotification(namespace, repo, uuid, request)
+notification, err := client.UpdateNotification(ctx, namespace, repo, uuid, request)
 
 // Test notification
-err := client.TestNotification(namespace, repo, uuid)
+err := client.TestNotification(ctx, namespace, repo, uuid)
 
 // Reset failure count
-err := client.ResetNotification(namespace, repo, uuid)
+err := client.ResetNotification(ctx, namespace, repo, uuid)
 
 // Delete notification
-err := client.DeleteNotification(namespace, repo, uuid)
+err := client.DeleteNotification(ctx, namespace, repo, uuid)
 ```
 
 ### Quota Operations
 
 ```go
 // Get quota
-quota, err := client.GetQuota(orgname)
+quota, err := client.GetQuota(ctx, orgname)
 
 // Create quota
-quota, err := client.CreateQuota(orgname, limitBytes)
+quota, err := client.CreateQuota(ctx, orgname, limitBytes)
 
 // Update quota
-quota, err := client.UpdateQuota(orgname, limitBytes)
+quota, err := client.UpdateQuota(ctx, orgname, limitBytes)
 
 // Delete quota
-err := client.DeleteQuota(orgname)
+err := client.DeleteQuota(ctx, orgname)
 ```
 
 ### Auto-Prune Operations
 
 ```go
 // Get policies
-policies, err := client.GetAutoPrunePolicies(orgname)
+policies, err := client.GetAutoPrunePolicies(ctx, orgname)
 
 // Create policy
-policy, err := client.CreateAutoPrunePolicy(orgname, method, value, tagPattern)
+policy, err := client.CreateAutoPrunePolicy(ctx, orgname, method, value, tagPattern)
 
 // Get specific policy
-policy, err := client.GetAutoPrunePolicy(orgname, policyUUID)
+policy, err := client.GetAutoPrunePolicy(ctx, orgname, policyUUID)
 
 // Update policy
-policy, err := client.UpdateAutoPrunePolicy(orgname, policyUUID, method, value, tagPattern)
+policy, err := client.UpdateAutoPrunePolicy(ctx, orgname, policyUUID, method, value, tagPattern)
 
 // Delete policy
-err := client.DeleteAutoPrunePolicy(orgname, policyUUID)
+err := client.DeleteAutoPrunePolicy(ctx, orgname, policyUUID)
 ```
 
 ### Logs Operations
 
 ```go
 // Repository logs
-logs, err := client.GetLogs(namespace, repo, nextPage, startDate, endDate)
-aggLogs, err := client.GetAggregatedLogs(namespace, repo, startDate, endDate)
+logs, err := client.GetLogs(ctx, namespace, repo, nextPage, startDate, endDate)
+aggLogs, err := client.GetAggregatedLogs(ctx, namespace, repo, startDate, endDate)
 
 // Organization logs
-logs, err := client.GetOrganizationLogs(orgname, nextPage, startDate, endDate)
-aggLogs, err := client.GetOrganizationAggregatedLogs(orgname, startDate, endDate)
+logs, err := client.GetOrganizationLogs(ctx, orgname, nextPage, startDate, endDate)
+aggLogs, err := client.GetOrganizationAggregatedLogs(ctx, orgname, startDate, endDate)
 
 // User logs
-logs, err := client.GetUserLogs(nextPage, startDate, endDate)
-aggLogs, err := client.GetUserAggregatedLogs(startDate, endDate)
+logs, err := client.GetUserLogs(ctx, nextPage, startDate, endDate)
+aggLogs, err := client.GetUserAggregatedLogs(ctx, startDate, endDate)
 
 // Export logs
-err := client.ExportRepositoryLogs(namespace, repo, &lib.ExportLogsRequest{...})
-err := client.ExportOrganizationLogs(orgname, &lib.ExportLogsRequest{...})
-err := client.ExportUserLogs(&lib.ExportLogsRequest{...})
+err := client.ExportRepositoryLogs(ctx, namespace, repo, &lib.ExportLogsRequest{...})
+err := client.ExportOrganizationLogs(ctx, orgname, &lib.ExportLogsRequest{...})
+err := client.ExportUserLogs(ctx, &lib.ExportLogsRequest{...})
 ```
 
 ### Search Operations
 
 ```go
 // Search repositories
-results, err := client.SearchRepositories(query, page)
+results, err := client.SearchRepositories(ctx, query, page)
 
 // Search all (repos, users, teams, etc.)
-results, err := client.SearchAll(query)
+results, err := client.SearchAll(ctx, query)
 ```
 
 ### Billing Operations
 
 ```go
 // Plans
-plans, err := client.GetAvailablePlans()
+plans, err := client.GetAvailablePlans(ctx)
 
 // User billing
-billing, err := client.GetUserBilling()
-subscription, err := client.GetUserSubscription()
+billing, err := client.GetUserBilling(ctx)
+subscription, err := client.GetUserSubscription(ctx)
 
 // User invoices are not available in the Quay API.
 // GetUserInvoices() always returns an error.
 
 // Organization billing
-billing, err := client.GetOrganizationBilling(orgname)
-subscription, err := client.GetOrganizationSubscription(orgname)
-invoices, err := client.GetOrganizationInvoices(orgname)
+billing, err := client.GetOrganizationBilling(ctx, orgname)
+subscription, err := client.GetOrganizationSubscription(ctx, orgname)
+invoices, err := client.GetOrganizationInvoices(ctx, orgname)
 ```
 
 ### Discovery Operations
 
 ```go
 // Get API discovery information
-discovery, err := client.GetDiscovery()
+discovery, err := client.GetDiscovery(ctx)
 
 // Get registry capabilities
-capabilities, err := client.GetRegistryCapabilities()
+capabilities, err := client.GetRegistryCapabilities(ctx)
 
 // Get application info by client ID
-app, err := client.GetAppInfo(clientID)
+app, err := client.GetAppInfo(ctx, clientID)
 
 // Search entities by prefix
-entities, err := client.GetEntities(prefix, includeOrgs, includeTeams)
+entities, err := client.GetEntities(ctx, prefix, includeOrgs, includeTeams)
 ```
 
 ### Messages Operations
 
 ```go
 // Get system messages
-messages, err := client.GetMessages()
+messages, err := client.GetMessages(ctx)
 
 // Create a message
-message, err := client.CreateMessage(content, severity, mediaType)
+message, err := client.CreateMessage(ctx, content, severity, mediaType)
 ```
 
 ### Prototype Operations
 
 ```go
 // List default permission prototypes
-prototypes, err := client.GetPrototypes(orgname)
+prototypes, err := client.GetPrototypes(ctx, orgname)
 
 // Create prototype
-prototype, err := client.CreatePrototype(orgname, &lib.CreatePrototypeRequest{...})
+prototype, err := client.CreatePrototype(ctx, orgname, &lib.CreatePrototypeRequest{...})
 
 // Get specific prototype
-prototype, err := client.GetPrototype(orgname, prototypeUUID)
+prototype, err := client.GetPrototype(ctx, orgname, prototypeUUID)
 
 // Update prototype
-prototype, err := client.UpdatePrototype(orgname, prototypeUUID, &lib.UpdatePrototypeRequest{...})
+prototype, err := client.UpdatePrototype(ctx, orgname, prototypeUUID, &lib.UpdatePrototypeRequest{...})
 
 // Delete prototype
-err := client.DeletePrototype(orgname, prototypeUUID)
+err := client.DeletePrototype(ctx, orgname, prototypeUUID)
 ```
 
 ### RepoToken Operations (Deprecated)
 
 ```go
 // List repository tokens
-tokens, err := client.GetRepoTokens(namespace, repo)
+tokens, err := client.GetRepoTokens(ctx, namespace, repo)
 
 // Create token
-token, err := client.CreateRepoToken(namespace, repo, &lib.CreateRepoTokenRequest{...})
+token, err := client.CreateRepoToken(ctx, namespace, repo, &lib.CreateRepoTokenRequest{...})
 
 // Get specific token
-token, err := client.GetRepoToken(namespace, repo, code)
+token, err := client.GetRepoToken(ctx, namespace, repo, code)
 
 // Update token
-token, err := client.UpdateRepoToken(namespace, repo, code, &lib.UpdateRepoTokenRequest{...})
+token, err := client.UpdateRepoToken(ctx, namespace, repo, code, &lib.UpdateRepoTokenRequest{...})
 
 // Delete token
-err := client.DeleteRepoToken(namespace, repo, code)
+err := client.DeleteRepoToken(ctx, namespace, repo, code)
 ```
 
 ### Application Operations
 
 ```go
 // List applications
-apps, err := client.GetApplications(orgname)
+apps, err := client.GetApplications(ctx, orgname)
 
 // Create application
-app, err := client.CreateApplication(orgname, name, description, applicationURI, redirectURI)
+app, err := client.CreateApplication(ctx, orgname, name, description, applicationURI, redirectURI)
 
 // Get application
-app, err := client.GetApplication(orgname, clientID)
+app, err := client.GetApplication(ctx, orgname, clientID)
 
 // Update application
-app, err := client.UpdateApplication(orgname, clientID, name, description, applicationURI, redirectURI)
+app, err := client.UpdateApplication(ctx, orgname, clientID, name, description, applicationURI, redirectURI)
 
 // Delete application
-err := client.DeleteApplication(orgname, clientID)
+err := client.DeleteApplication(ctx, orgname, clientID)
 
 // Reset client secret
-app, err := client.ResetApplicationClientSecret(orgname, clientID)
+app, err := client.ResetApplicationClientSecret(ctx, orgname, clientID)
 ```
 
 ### Marketplace Operations
 
 ```go
 // Get organization marketplace info
-marketplace, err := client.GetOrganizationMarketplace(orgname)
+marketplace, err := client.GetOrganizationMarketplace(ctx, orgname)
 
 // Create subscription
-err := client.CreateOrganizationMarketplaceSubscription(orgname, &lib.MarketplaceSubscriptionRequest{...})
+err := client.CreateOrganizationMarketplaceSubscription(ctx, orgname, &lib.MarketplaceSubscriptionRequest{...})
 
 // Delete subscription
-err := client.DeleteOrganizationMarketplaceSubscription(orgname, subscriptionID)
+err := client.DeleteOrganizationMarketplaceSubscription(ctx, orgname, subscriptionID)
 
 // Batch remove subscriptions
-err := client.BatchRemoveOrganizationMarketplaceSubscriptions(orgname, subscriptionIDs)
+err := client.BatchRemoveOrganizationMarketplaceSubscriptions(ctx, orgname, subscriptionIDs)
 ```
 
 ### Proxy Cache Operations
 
 ```go
 // Get proxy cache config
-config, err := client.GetProxyCacheConfig(orgname)
+config, err := client.GetProxyCacheConfig(ctx, orgname)
 
 // Create proxy cache config
-config, err := client.CreateProxyCacheConfig(orgname, upstreamRegistry, insecure, expiration)
+config, err := client.CreateProxyCacheConfig(ctx, orgname, upstreamRegistry, insecure, expiration)
 
 // Delete proxy cache config
-err := client.DeleteProxyCacheConfig(orgname)
+err := client.DeleteProxyCacheConfig(ctx, orgname)
 ```
 
 ### Error Operations
 
 ```go
 // Get error type details
-details, err := client.GetErrorType("invalid_token")
+details, err := client.GetErrorType(ctx, "invalid_token")
 ```
 
 ### Repository Tag Listing
 
 ```go
 // List tags for a repository
-tags, err := client.ListTags(namespace, repo, limit, onlyActive)
+tags, err := client.ListTags(ctx, namespace, repo, limit, onlyActive)
 ```
 
 ### Mirror Operations
 
 ```go
-config, err := client.GetMirrorConfig(namespace, repo)
-config, err := client.CreateMirrorConfig(namespace, repo, &lib.CreateMirrorConfigRequest{
+config, err := client.GetMirrorConfig(ctx, namespace, repo)
+config, err := client.CreateMirrorConfig(ctx, namespace, repo, &lib.CreateMirrorConfigRequest{
     ExternalRef:   "docker.io/library/nginx",
     SyncInterval:  86400,
     RobotUsername: "myorg+mirrorbot",
 })
-config, err := client.UpdateMirrorConfig(namespace, repo, &lib.UpdateMirrorConfigRequest{
+config, err := client.UpdateMirrorConfig(ctx, namespace, repo, &lib.UpdateMirrorConfigRequest{
     ExternalRef: "docker.io/library/nginx",
 })
 ```
@@ -554,7 +558,7 @@ API errors that include a Quay JSON body are returned as `*lib.QuayError`:
 ```go
 import "errors"
 
-result, err := client.GetRepository("namespace", "repo")
+result, err := client.GetRepository(ctx, "namespace", "repo")
 if err != nil {
     var qerr *lib.QuayError
     if errors.As(err, &qerr) {

--- a/docs/tutorials/01-getting-started.md
+++ b/docs/tutorials/01-getting-started.md
@@ -79,6 +79,7 @@ Let's get information about the current user:
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "os"
@@ -97,8 +98,10 @@ func main() {
         log.Fatalf("Failed to create client: %v", err)
     }
 
+    ctx := context.Background()
+
     // Get current user information
-    user, err := client.GetUser()
+    user, err := client.GetUser(ctx)
     if err != nil {
         log.Fatalf("Failed to get user: %v", err)
     }
@@ -117,7 +120,7 @@ Now let's list repositories in a namespace:
 
 ```go
 // List repositories in your namespace
-repos, err := client.ListRepositories("your-username", false, false, false, 1, 10)
+repos, err := client.ListRepositories(ctx, "your-username", false, false, false, 1, 10)
 if err != nil {
     log.Fatalf("Failed to list repositories: %v", err)
 }
@@ -138,7 +141,7 @@ Get detailed information about a specific repository:
 
 ```go
 // Get repository with tags
-repo, err := client.GetRepository("namespace", "repository-name")
+repo, err := client.GetRepository(ctx, "namespace", "repository-name")
 if err != nil {
     log.Fatalf("Failed to get repository: %v", err)
 }
@@ -159,13 +162,14 @@ The go-quay library returns `*lib.QuayError` when the API sends a JSON error bod
 
 ```go
 import (
+    "context"
     "errors"
     "fmt"
 
     "github.com/sebrandon1/go-quay/lib"
 )
 
-repo, err := client.GetRepository("namespace", "nonexistent-repo")
+repo, err := client.GetRepository(ctx, "namespace", "nonexistent-repo")
 if err != nil {
     var qerr *lib.QuayError
     if errors.As(err, &qerr) {

--- a/docs/tutorials/02-repository-management.md
+++ b/docs/tutorials/02-repository-management.md
@@ -15,6 +15,7 @@ Create a new container repository:
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "os"
@@ -24,9 +25,10 @@ import (
 
 func main() {
     client, _ := lib.NewClient(os.Getenv("QUAY_TOKEN"))
+    ctx := context.Background()
 
     // Create a private repository
-    repo, err := client.CreateRepository(
+    repo, err := client.CreateRepository(ctx, 
         "my-namespace",          // namespace (org or username)
         "my-new-app",           // repository name
         "private",              // visibility: "private" or "public"
@@ -46,7 +48,7 @@ List all repositories you have access to:
 
 ```go
 // List repositories with filters
-repos, err := client.ListRepositories(
+repos, err := client.ListRepositories(ctx, 
     "my-namespace", // namespace (empty for all)
     false,          // include public repos
     false,          // only starred repos
@@ -69,7 +71,7 @@ for _, r := range repos.Repositories {
 Fetch complete repository information including tags:
 
 ```go
-repo, err := client.GetRepository("my-namespace", "my-app")
+repo, err := client.GetRepository(ctx, "my-namespace", "my-app")
 if err != nil {
     log.Fatalf("Failed to get repository: %v", err)
 }
@@ -103,7 +105,7 @@ Modify repository settings:
 
 ```go
 // Update description and visibility
-updatedRepo, err := client.UpdateRepository(
+updatedRepo, err := client.UpdateRepository(ctx, 
     "my-namespace",
     "my-app",
     "Updated description for my app", // new description
@@ -119,7 +121,7 @@ fmt.Printf("Updated: %s/%s\n", updatedRepo.Namespace, updatedRepo.Name)
 You can also change just the visibility:
 
 ```go
-err := client.ChangeRepositoryVisibility("my-namespace", "my-app", "private")
+err := client.ChangeRepositoryVisibility(ctx, "my-namespace", "my-app", "private")
 if err != nil {
     log.Fatalf("Failed to change visibility: %v", err)
 }
@@ -131,7 +133,7 @@ fmt.Println("Repository is now private")
 ### Get Tag Details
 
 ```go
-tag, err := client.GetTag("my-namespace", "my-app", "v1.0.0")
+tag, err := client.GetTag(ctx, "my-namespace", "my-app", "v1.0.0")
 if err != nil {
     log.Fatalf("Failed to get tag: %v", err)
 }
@@ -144,7 +146,7 @@ fmt.Printf("Digest: %s\n", tag.ManifestDigest)
 
 ```go
 // Set tag to expire in 30 days
-updatedTag, err := client.UpdateTag(
+updatedTag, err := client.UpdateTag(ctx, 
     "my-namespace",
     "my-app",
     "latest",
@@ -160,7 +162,7 @@ fmt.Printf("Tag %s will expire at %s\n", updatedTag.Name, updatedTag.Expiration)
 ### View Tag History
 
 ```go
-history, err := client.GetTagHistory("my-namespace", "my-app", "latest")
+history, err := client.GetTagHistory(ctx, "my-namespace", "my-app", "latest")
 if err != nil {
     log.Fatalf("Failed to get history: %v", err)
 }
@@ -178,7 +180,7 @@ for _, entry := range history.Tags {
 ### Delete a Tag
 
 ```go
-err := client.DeleteTag("my-namespace", "my-app", "old-version")
+err := client.DeleteTag(ctx, "my-namespace", "my-app", "old-version")
 if err != nil {
     log.Fatalf("Failed to delete tag: %v", err)
 }
@@ -190,7 +192,7 @@ fmt.Println("Tag deleted")
 Restore a tag to a previous image:
 
 ```go
-err := client.RestoreTag(
+err := client.RestoreTag(ctx, 
     "my-namespace",
     "my-app",
     "latest",
@@ -205,7 +207,7 @@ fmt.Println("Tag restored")
 ### Change a tag to a digest
 
 ```go
-err := client.ChangeTag("my-namespace", "my-app", "latest", "sha256:abc123...")
+err := client.ChangeTag(ctx, "my-namespace", "my-app", "latest", "sha256:abc123...")
 if err != nil {
     log.Fatalf("Failed to change tag: %v", err)
 }
@@ -216,7 +218,7 @@ if err != nil {
 **Warning:** This operation is irreversible!
 
 ```go
-err := client.DeleteRepository("my-namespace", "my-app")
+err := client.DeleteRepository(ctx, "my-namespace", "my-app")
 if err != nil {
     log.Fatalf("Failed to delete: %v", err)
 }
@@ -229,13 +231,13 @@ Star a repository for easy access:
 
 ```go
 // Star a repository
-err := client.StarRepository("quay", "quay")
+err := client.StarRepository(ctx, "quay", "quay")
 if err != nil {
     log.Fatalf("Failed to star: %v", err)
 }
 
 // Get starred repositories
-starred, err := client.GetStarredRepositories()
+starred, err := client.GetStarredRepositories(ctx)
 if err != nil {
     log.Fatalf("Failed to get starred: %v", err)
 }
@@ -246,7 +248,7 @@ for _, r := range starred.Repositories {
 }
 
 // Unstar a repository
-err = client.UnstarRepository("quay", "quay")
+err = client.UnstarRepository(ctx, "quay", "quay")
 ```
 
 ## Complete Workflow Example
@@ -257,6 +259,7 @@ Here's a complete example managing a repository lifecycle:
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "os"
@@ -266,12 +269,13 @@ import (
 
 func main() {
     client, _ := lib.NewClient(os.Getenv("QUAY_TOKEN"))
+    ctx := context.Background()
     namespace := "my-org"
     repoName := "demo-app"
 
     // 1. Create repository
     fmt.Println("Creating repository...")
-    repo, err := client.CreateRepository(namespace, repoName, "private", "Demo application")
+    repo, err := client.CreateRepository(ctx, namespace, repoName, "private", "Demo application")
     if err != nil {
         log.Fatalf("Create failed: %v", err)
     }
@@ -279,7 +283,7 @@ func main() {
 
     // 2. Update description
     fmt.Println("Updating repository...")
-    _, err = client.UpdateRepository(namespace, repoName, "Production demo application", "")
+    _, err = client.UpdateRepository(ctx, namespace, repoName, "Production demo application", "")
     if err != nil {
         log.Fatalf("Update failed: %v", err)
     }
@@ -287,7 +291,7 @@ func main() {
 
     // 3. Star the repository
     fmt.Println("Starring repository...")
-    err = client.StarRepository(namespace, repoName)
+    err = client.StarRepository(ctx, namespace, repoName)
     if err != nil {
         log.Printf("Star failed (might not be supported): %v\n", err)
     } else {
@@ -296,7 +300,7 @@ func main() {
 
     // 4. Get final state
     fmt.Println("Final repository state:")
-    finalRepo, _ := client.GetRepository(namespace, repoName)
+    finalRepo, _ := client.GetRepository(ctx, namespace, repoName)
     fmt.Printf("  Name: %s\n", finalRepo.Name)
     fmt.Printf("  Description: %s\n", finalRepo.Description)
     fmt.Printf("  Starred: %v\n", finalRepo.IsStarred)

--- a/docs/tutorials/03-security-scanning.md
+++ b/docs/tutorials/03-security-scanning.md
@@ -34,6 +34,7 @@ Quay.io uses Clair to scan container images for vulnerabilities. When you push a
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "os"
@@ -43,9 +44,10 @@ import (
 
 func main() {
     client, _ := lib.NewClient(os.Getenv("QUAY_TOKEN"))
+    ctx := context.Background()
 
     // First, get the manifest digest for a tag
-    repo, err := client.GetRepository("my-namespace", "my-app")
+    repo, err := client.GetRepository(ctx, "my-namespace", "my-app")
     if err != nil {
         log.Fatalf("Failed to get repository: %v", err)
     }
@@ -64,7 +66,7 @@ func main() {
     }
 
     // Get security scan results
-    security, err := client.GetManifestSecurity(
+    security, err := client.GetManifestSecurity(ctx, 
         "my-namespace",
         "my-app",
         manifestDigest,
@@ -82,7 +84,7 @@ func main() {
 
 ```go
 // Get security scan with vulnerability details
-security, err := client.GetManifestSecurity(namespace, repo, digest, true)
+security, err := client.GetManifestSecurity(ctx, namespace, repo, digest, true)
 if err != nil {
     log.Fatalf("Failed to get security scan: %v", err)
 }
@@ -168,7 +170,8 @@ Loop over repos and tags, calling `GetManifestSecurity` for each digest. A full 
 
 ```go
 client, _ := lib.NewClient(os.Getenv("QUAY_TOKEN"))
-security, err := client.GetManifestSecurity(namespace, repo, digest, true)
+ctx := context.Background()
+security, err := client.GetManifestSecurity(ctx, namespace, repo, digest, true)
 if err != nil {
     log.Fatal(err)
 }
@@ -182,7 +185,7 @@ fmt.Printf("%s/%s: %s\n", namespace, repo, security.Status)
 Add security metadata to your images:
 
 ```go
-label, err := client.AddManifestLabel(
+label, err := client.AddManifestLabel(ctx, 
     "my-namespace",
     "my-app",
     manifestDigest,
@@ -196,7 +199,7 @@ if err != nil {
     fmt.Printf("Added label %s\n", label.ID)
 }
 
-labels, err := client.GetManifestLabels("my-namespace", "my-app", manifestDigest)
+labels, err := client.GetManifestLabels(ctx, "my-namespace", "my-app", manifestDigest)
 if err != nil {
     log.Fatalf("Failed to get labels: %v", err)
 }

--- a/docs/tutorials/04-ci-cd-automation.md
+++ b/docs/tutorials/04-ci-cd-automation.md
@@ -22,19 +22,23 @@ Robot accounts are service accounts designed for automation. They provide:
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "os"
+    "time"
 
     "github.com/sebrandon1/go-quay/lib"
 )
 
 func main() {
     client, _ := lib.NewClient(os.Getenv("QUAY_TOKEN"))
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    defer cancel()
     orgName := "my-org"
 
     // Create a robot account
-    robot, err := client.CreateRobotAccount(
+    robot, err := client.CreateRobotAccount(ctx, 
         orgName,
         "ci-deploy",                    // short name (becomes org+ci-deploy)
         "CI/CD deployment automation",  // description
@@ -53,7 +57,7 @@ func main() {
 ### Listing Robot Accounts
 
 ```go
-robots, err := client.GetRobotAccounts("my-org")
+robots, err := client.GetRobotAccounts(ctx, "my-org")
 if err != nil {
     log.Fatalf("Failed to list robots: %v", err)
 }
@@ -69,7 +73,7 @@ for _, robot := range robots.Robots {
 If a token is compromised:
 
 ```go
-newRobot, err := client.RegenerateRobotToken("my-org", "ci-deploy")
+newRobot, err := client.RegenerateRobotToken(ctx, "my-org", "ci-deploy")
 if err != nil {
     log.Fatalf("Failed to regenerate: %v", err)
 }
@@ -84,13 +88,13 @@ You can also create robots at the user level:
 
 ```go
 // Create user robot
-robot, err := client.CreateUserRobotAccount("my-deploy-bot", "Personal deployment bot", nil)
+robot, err := client.CreateUserRobotAccount(ctx, "my-deploy-bot", "Personal deployment bot", nil)
 
 // List user robots
-robots, err := client.GetUserRobotAccounts()
+robots, err := client.GetUserRobotAccounts(ctx)
 
 // Regenerate user robot token
-newRobot, err := client.RegenerateUserRobotToken("my-deploy-bot")
+newRobot, err := client.RegenerateUserRobotToken(ctx, "my-deploy-bot")
 ```
 
 ## Setting Repository Permissions
@@ -99,7 +103,7 @@ Grant robots access to specific repositories:
 
 ```go
 // Grant write access to a repository
-err := client.SetUserPermission(
+err := client.SetUserPermission(ctx, 
     "my-org",                    // namespace
     "my-app",                    // repository
     "my-org+ci-deploy",          // robot username
@@ -112,7 +116,7 @@ if err != nil {
 fmt.Println("Permission granted!")
 
 // Verify the permission
-perm, err := client.GetUserPermission("my-org", "my-app", "my-org+ci-deploy")
+perm, err := client.GetUserPermission(ctx, "my-org", "my-app", "my-org+ci-deploy")
 if err != nil {
     log.Fatalf("Failed to verify: %v", err)
 }
@@ -134,7 +138,7 @@ You can also grant permissions to entire teams:
 
 ```go
 // Set team permission
-err := client.SetTeamPermission(
+err := client.SetTeamPermission(ctx, 
     "my-org",
     "my-app",
     "developers",  // team name
@@ -142,7 +146,7 @@ err := client.SetTeamPermission(
 )
 
 // List team permissions
-perms, err := client.ListTeamPermissions("my-org", "my-app")
+perms, err := client.ListTeamPermissions(ctx, "my-org", "my-app")
 ```
 
 ## Webhook Notifications
@@ -152,7 +156,7 @@ Set up webhooks to notify external services when events occur:
 ### Creating a Webhook
 
 ```go
-notification, err := client.CreateNotification(
+notification, err := client.CreateNotification(ctx, 
     "my-org",
     "my-app",
     &lib.CreateNotificationRequest{
@@ -196,7 +200,7 @@ fmt.Printf("Notification created: %s\n", notification.UUID)
 ### Slack Integration
 
 ```go
-notification, err := client.CreateNotification(
+notification, err := client.CreateNotification(ctx, 
     "my-org",
     "my-app",
     &lib.CreateNotificationRequest{
@@ -214,7 +218,7 @@ notification, err := client.CreateNotification(
 
 ```go
 // Test a notification
-err := client.TestNotification("my-org", "my-app", notificationUUID)
+err := client.TestNotification(ctx, "my-org", "my-app", notificationUUID)
 if err != nil {
     log.Printf("Test failed: %v\n", err)
 } else {
@@ -226,16 +230,16 @@ if err != nil {
 
 ```go
 // List all notifications
-notifications, err := client.GetNotifications("my-org", "my-app")
+notifications, err := client.GetNotifications(ctx, "my-org", "my-app")
 for _, n := range notifications.Notifications {
     fmt.Printf("- %s: %s (%s)\n", n.UUID[:8], n.Event, n.Method)
 }
 
 // Reset failure count
-err = client.ResetNotification("my-org", "my-app", notificationUUID)
+err = client.ResetNotification(ctx, "my-org", "my-app", notificationUUID)
 
 // Delete a notification
-err = client.DeleteNotification("my-org", "my-app", notificationUUID)
+err = client.DeleteNotification(ctx, "my-org", "my-app", notificationUUID)
 ```
 
 ## Build Triggers
@@ -245,7 +249,7 @@ Build triggers automatically build images when code is pushed to a repository.
 ### Listing Triggers
 
 ```go
-triggers, err := client.GetTriggers("my-org", "my-app")
+triggers, err := client.GetTriggers(ctx, "my-org", "my-app")
 if err != nil {
     log.Fatalf("Failed to list triggers: %v", err)
 }
@@ -262,7 +266,7 @@ for _, t := range triggers.Triggers {
 ### Getting Trigger Details
 
 ```go
-trigger, err := client.GetTrigger("my-org", "my-app", triggerUUID)
+trigger, err := client.GetTrigger(ctx, "my-org", "my-app", triggerUUID)
 if err != nil {
     log.Fatalf("Failed to get trigger: %v", err)
 }
@@ -276,7 +280,7 @@ fmt.Printf("Enabled: %v\n", trigger.Enabled)
 
 ```go
 // Start a build from a trigger
-build, err := client.StartTriggerBuild("my-org", "my-app", triggerUUID, nil)
+build, err := client.StartTriggerBuild(ctx, "my-org", "my-app", triggerUUID, nil)
 if err != nil {
     log.Fatalf("Failed to start build: %v", err)
 }
@@ -289,7 +293,7 @@ fmt.Printf("Status: %s\n", build.Phase)
 
 ```go
 // Activate a trigger with configuration
-trigger, err := client.ActivateTrigger(
+trigger, err := client.ActivateTrigger(ctx, 
     "my-org",
     "my-app",
     triggerUUID,
@@ -311,9 +315,9 @@ fmt.Printf("Trigger activated: %s\n", trigger.ID)
 Typical order: create the repo, create a robot, `SetUserPermission` for `org+robot`, then `CreateNotification` for `repo_push` / `vulnerability_found`. The runnable program is [ci-cd-integration](../../examples/ci-cd-integration/main.go).
 
 ```go
-robot, err := client.CreateRobotAccount(org, robotName, "CI/CD builder", nil)
-err = client.SetUserPermission(org, repo, org+"+"+robotName, "write")
-notification, err := client.CreateNotification(org, repo, &lib.CreateNotificationRequest{
+robot, err := client.CreateRobotAccount(ctx, org, robotName, "CI/CD builder", nil)
+err = client.SetUserPermission(ctx, org, repo, org+"+"+robotName, "write")
+notification, err := client.CreateNotification(ctx, org, repo, &lib.CreateNotificationRequest{
     Event:  "repo_push",
     Method: "webhook",
     Title:  "CI Build Trigger",

--- a/docs/tutorials/05-organization-admin.md
+++ b/docs/tutorials/05-organization-admin.md
@@ -13,6 +13,7 @@ This tutorial covers organization management tasks: teams, members, quotas, poli
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "os"
@@ -22,9 +23,10 @@ import (
 
 func main() {
     client, _ := lib.NewClient(os.Getenv("QUAY_TOKEN"))
+    ctx := context.Background()
     orgName := "my-org"
 
-    org, err := client.GetOrganization(orgName)
+    org, err := client.GetOrganization(ctx, orgName)
     if err != nil {
         log.Fatalf("Failed to get org: %v", err)
     }
@@ -43,7 +45,7 @@ Teams group users together for easier permission management.
 ### Creating a Team
 
 ```go
-team, err := client.CreateTeam(
+team, err := client.CreateTeam(ctx, 
     "my-org",
     "developers",           // team name
     "Development team",     // description
@@ -67,7 +69,7 @@ fmt.Printf("Created team: %s\n", team.Name)
 ### Listing Teams
 
 ```go
-teams, err := client.GetTeams("my-org")
+teams, err := client.GetTeams(ctx, "my-org")
 if err != nil {
     log.Fatalf("Failed to list teams: %v", err)
 }
@@ -81,7 +83,7 @@ for _, team := range teams {
 ### Updating a Team
 
 ```go
-updatedTeam, err := client.UpdateTeam(
+updatedTeam, err := client.UpdateTeam(ctx, 
     "my-org",
     "developers",
     "Updated description",
@@ -92,7 +94,7 @@ updatedTeam, err := client.UpdateTeam(
 ### Deleting a Team
 
 ```go
-err := client.DeleteTeam("my-org", "developers")
+err := client.DeleteTeam(ctx, "my-org", "developers")
 if err != nil {
     log.Fatalf("Failed to delete team: %v", err)
 }
@@ -103,7 +105,7 @@ if err != nil {
 ### Adding Members to a Team
 
 ```go
-err := client.AddTeamMember("my-org", "developers", "john.doe")
+err := client.AddTeamMember(ctx, "my-org", "developers", "john.doe")
 if err != nil {
     log.Fatalf("Failed to add member: %v", err)
 }
@@ -113,7 +115,7 @@ fmt.Println("Member added!")
 ### Listing Team Members
 
 ```go
-members, err := client.GetTeamMembers("my-org", "developers")
+members, err := client.GetTeamMembers(ctx, "my-org", "developers")
 if err != nil {
     log.Fatalf("Failed to get members: %v", err)
 }
@@ -126,7 +128,7 @@ for _, m := range members.Members {
 ### Removing Members
 
 ```go
-err := client.RemoveTeamMember("my-org", "developers", "john.doe")
+err := client.RemoveTeamMember(ctx, "my-org", "developers", "john.doe")
 if err != nil {
     log.Fatalf("Failed to remove member: %v", err)
 }
@@ -137,7 +139,7 @@ if err != nil {
 List all organization members:
 
 ```go
-members, err := client.GetOrganizationMembers("my-org")
+members, err := client.GetOrganizationMembers(ctx, "my-org")
 if err != nil {
     log.Fatalf("Failed to list members: %v", err)
 }
@@ -154,7 +156,7 @@ Grant teams access to repositories:
 
 ```go
 // Set team permission for a repository
-err := client.SetTeamRepositoryPermission(
+err := client.SetTeamRepositoryPermission(ctx, 
     "my-org",
     "developers",   // team name
     "my-app",       // repository
@@ -165,7 +167,7 @@ if err != nil {
 }
 
 // List team permissions
-perms, err := client.GetTeamPermissions("my-org", "developers")
+perms, err := client.GetTeamPermissions(ctx, "my-org", "developers")
 if err != nil {
     log.Fatalf("Failed to get permissions: %v", err)
 }
@@ -175,7 +177,7 @@ for _, p := range perms.Permissions {
 }
 
 // Remove team permission
-err = client.RemoveTeamRepositoryPermission("my-org", "developers", "my-app")
+err = client.RemoveTeamRepositoryPermission(ctx, "my-org", "developers", "my-app")
 ```
 
 ## Quota Management
@@ -185,7 +187,7 @@ Control storage usage in your organization:
 ### Getting Quota Information
 
 ```go
-org, err := client.GetOrganization("my-org")
+org, err := client.GetOrganization(ctx, "my-org")
 if err != nil {
     log.Fatalf("Failed to get organization: %v", err)
 }
@@ -202,7 +204,7 @@ if org.QuotaReport != nil {
 }
 
 // Get configured quota limits (admin only)
-quota, err := client.GetQuota("my-org")
+quota, err := client.GetQuota(ctx, "my-org")
 if err != nil {
     log.Fatalf("Failed to get quota: %v", err)
 }
@@ -214,7 +216,7 @@ fmt.Printf("Limit: %d bytes\n", quota.LimitBytes)
 ```go
 // Set 10 GB limit (requires super user)
 limitBytes := int64(10 * 1024 * 1024 * 1024)
-quota, err := client.CreateQuota("my-org", limitBytes)
+quota, err := client.CreateQuota(ctx, "my-org", limitBytes)
 if err != nil {
     log.Fatalf("Failed to create quota: %v", err)
 }
@@ -227,7 +229,7 @@ fmt.Printf("Quota set: %d bytes\n", quota.LimitBytes)
 ```go
 // Increase to 50 GB
 newLimit := int64(50 * 1024 * 1024 * 1024)
-quota, err := client.UpdateQuota("my-org", newLimit)
+quota, err := client.UpdateQuota(ctx, "my-org", newLimit)
 if err != nil {
     log.Fatalf("Failed to update quota: %v", err)
 }
@@ -242,7 +244,7 @@ Automatically clean up old tags to save storage:
 
 ```go
 // Keep only the last 10 tags
-policy, err := client.CreateAutoPrunePolicy(
+policy, err := client.CreateAutoPrunePolicy(ctx, 
     "my-org",
     "number_of_tags",   // method
     10,                 // value: keep 10 tags
@@ -266,7 +268,7 @@ fmt.Printf("Policy created: %s\n", policy.UUID)
 
 ```go
 // Only prune tags matching pattern
-policy, err := client.CreateAutoPrunePolicy(
+policy, err := client.CreateAutoPrunePolicy(ctx, 
     "my-org",
     "creation_date",
     30,                 // keep tags from last 30 days
@@ -277,7 +279,7 @@ policy, err := client.CreateAutoPrunePolicy(
 ### Listing Policies
 
 ```go
-policies, err := client.GetAutoPrunePolicies("my-org")
+policies, err := client.GetAutoPrunePolicies(ctx, "my-org")
 if err != nil {
     log.Fatalf("Failed to get policies: %v", err)
 }
@@ -293,7 +295,7 @@ for _, p := range policies.Policies {
 ### Updating a Policy
 
 ```go
-updatedPolicy, err := client.UpdateAutoPrunePolicy(
+updatedPolicy, err := client.UpdateAutoPrunePolicy(ctx, 
     "my-org",
     policyUUID,
     "number_of_tags",
@@ -305,7 +307,7 @@ updatedPolicy, err := client.UpdateAutoPrunePolicy(
 ### Deleting a Policy
 
 ```go
-err := client.DeleteAutoPrunePolicy("my-org", policyUUID)
+err := client.DeleteAutoPrunePolicy(ctx, "my-org", policyUUID)
 ```
 
 ## Default Permissions (Prototypes)
@@ -315,7 +317,7 @@ Automatically apply permissions to new repositories:
 ### Creating a Prototype
 
 ```go
-prototype, err := client.CreatePrototype("my-org", &lib.CreatePrototypeRequest{
+prototype, err := client.CreatePrototype(ctx, "my-org", &lib.CreatePrototypeRequest{
     Role: "write",
     Delegate: lib.PrototypeDelegateRequest{
         Kind: "team",
@@ -332,7 +334,7 @@ fmt.Printf("Prototype created: %s\n", prototype.ID)
 ### Listing Prototypes
 
 ```go
-prototypes, err := client.GetPrototypes("my-org")
+prototypes, err := client.GetPrototypes(ctx, "my-org")
 if err != nil {
     log.Fatalf("Failed to get prototypes: %v", err)
 }
@@ -346,7 +348,7 @@ for _, p := range prototypes.Prototypes {
 ### Deleting a Prototype
 
 ```go
-err := client.DeletePrototype("my-org", prototypeID)
+err := client.DeletePrototype(ctx, "my-org", prototypeID)
 ```
 
 ## OAuth Applications
@@ -356,7 +358,7 @@ Manage OAuth applications for your organization:
 ### Creating an Application
 
 ```go
-app, err := client.CreateApplication(
+app, err := client.CreateApplication(ctx, 
     "my-org",
     "My CI Tool",                           // name
     "CI/CD integration app",                // description
@@ -375,7 +377,7 @@ fmt.Printf("Client Secret: %s\n", app.ClientSecret)
 ### Listing Applications
 
 ```go
-apps, err := client.GetApplications("my-org")
+apps, err := client.GetApplications(ctx, "my-org")
 if err != nil {
     log.Fatalf("Failed to list apps: %v", err)
 }
@@ -388,7 +390,7 @@ for _, app := range apps.Applications {
 ### Resetting Client Secret
 
 ```go
-app, err := client.ResetApplicationClientSecret("my-org", clientID)
+app, err := client.ResetApplicationClientSecret(ctx, "my-org", clientID)
 if err != nil {
     log.Fatalf("Failed to reset secret: %v", err)
 }
@@ -401,7 +403,7 @@ fmt.Printf("New secret: %s\n", app.ClientSecret)
 Access organization activity logs:
 
 ```go
-logs, err := client.GetOrganizationLogs("my-org", "", "", "")
+logs, err := client.GetOrganizationLogs(ctx, "my-org", "", "", "")
 if err != nil {
     log.Fatalf("Failed to get logs: %v", err)
 }
@@ -414,7 +416,7 @@ for _, entry := range logs.Logs {
 
 // Pagination
 if logs.NextPage != "" {
-    nextLogs, err := client.GetOrganizationLogs("my-org", logs.NextPage, "", "")
+    nextLogs, err := client.GetOrganizationLogs(ctx, "my-org", logs.NextPage, "", "")
     // ... process next page
 }
 ```
@@ -424,7 +426,7 @@ if logs.NextPage != "" {
 Get log statistics:
 
 ```go
-aggLogs, err := client.GetOrganizationAggregatedLogs(
+aggLogs, err := client.GetOrganizationAggregatedLogs(ctx, 
     "my-org",
     "01/01/2024",  // start date
     "01/31/2024",  // end date

--- a/examples/basic-usage/main.go
+++ b/examples/basic-usage/main.go
@@ -13,6 +13,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -32,12 +33,13 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)
 	}
+	ctx := context.Background()
 
 	fmt.Println("=== go-quay Basic Usage Example ===")
 
 	// Step 3: Get current user information
 	fmt.Println("1. Getting current user information...")
-	user, err := client.GetUser()
+	user, err := client.GetUser(ctx)
 	if err != nil {
 		log.Fatalf("Failed to get user: %v", err)
 	}
@@ -47,7 +49,7 @@ func main() {
 
 	// Step 4: List starred repositories
 	fmt.Println("2. Getting starred repositories...")
-	starred, err := client.GetStarredRepositories()
+	starred, err := client.GetStarredRepositories(ctx)
 	if err != nil {
 		log.Printf("   Could not get starred repos: %v\n", err)
 	} else if len(starred.Repositories) == 0 {
@@ -68,7 +70,7 @@ func main() {
 	}
 
 	fmt.Printf("3. Listing repositories in namespace '%s'...\n", namespace)
-	repos, err := client.ListRepositories(namespace, false, false, false, 1, 10)
+	repos, err := client.ListRepositories(ctx, namespace, false, false, false, 1, 10)
 	if err != nil {
 		log.Printf("   Could not list repositories: %v\n", err)
 	} else if len(repos.Repositories) == 0 {
@@ -90,7 +92,7 @@ func main() {
 		firstRepo := repos.Repositories[0]
 		fmt.Printf("4. Getting details for repository '%s/%s'...\n", firstRepo.Namespace, firstRepo.Name)
 
-		repoDetails, err := client.GetRepository(firstRepo.Namespace, firstRepo.Name)
+		repoDetails, err := client.GetRepository(ctx, firstRepo.Namespace, firstRepo.Name)
 		if err != nil {
 			log.Printf("   Could not get repository details: %v\n", err)
 		} else {

--- a/examples/ci-cd-integration/main.go
+++ b/examples/ci-cd-integration/main.go
@@ -13,6 +13,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -45,6 +46,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)
 	}
+	ctx := context.Background()
 
 	fmt.Println("=== CI/CD Integration Setup ===")
 	fmt.Printf("Organization: %s\n", *namespace)
@@ -52,7 +54,7 @@ func main() {
 
 	// Step 1: Check organization access
 	fmt.Println("1. Verifying organization access...")
-	org, err := client.GetOrganization(*namespace)
+	org, err := client.GetOrganization(ctx, *namespace)
 	if err != nil {
 		log.Fatalf("Failed to get organization (do you have access?): %v", err)
 	}
@@ -61,7 +63,7 @@ func main() {
 
 	// Step 2: List existing robot accounts
 	fmt.Println("2. Checking existing robot accounts...")
-	robots, err := client.GetRobotAccounts(*namespace)
+	robots, err := client.GetRobotAccounts(ctx, *namespace)
 	if err != nil {
 		log.Printf("   Could not list robots: %v\n", err)
 	} else {
@@ -77,7 +79,7 @@ func main() {
 	fmt.Printf("3. Setting up robot account '%s'...\n", fullRobotName)
 
 	// Check if robot exists
-	existingRobot, err := client.GetRobotAccount(*namespace, *robotName)
+	existingRobot, err := client.GetRobotAccount(ctx, *namespace, *robotName)
 	if err == nil {
 		fmt.Println("   Robot already exists, using existing account")
 		fmt.Printf("   Name: %s\n", existingRobot.Name)
@@ -85,7 +87,7 @@ func main() {
 	} else {
 		// Create new robot
 		fmt.Println("   Creating new robot account...")
-		newRobot, err := client.CreateRobotAccount(*namespace, *robotName, "CI/CD automation robot", nil)
+		newRobot, err := client.CreateRobotAccount(ctx, *namespace, *robotName, "CI/CD automation robot", nil)
 		if err != nil {
 			log.Fatalf("Failed to create robot: %v", err)
 		}
@@ -99,7 +101,7 @@ func main() {
 	fmt.Printf("4. Setting repository permissions for '%s'...\n", fullRobotName)
 
 	// Grant write permission to the robot
-	err = client.SetUserPermission(*namespace, *repository, fullRobotName, "write")
+	err = client.SetUserPermission(ctx, *namespace, *repository, fullRobotName, "write")
 	if err != nil {
 		log.Printf("   Could not set permission: %v\n", err)
 	} else {
@@ -107,7 +109,7 @@ func main() {
 	}
 
 	// Verify permission was set
-	perm, err := client.GetUserPermission(*namespace, *repository, fullRobotName)
+	perm, err := client.GetUserPermission(ctx, *namespace, *repository, fullRobotName)
 	if err != nil {
 		log.Printf("   Could not verify permission: %v\n", err)
 	} else {
@@ -119,7 +121,7 @@ func main() {
 	if *webhookURL != "" {
 		fmt.Println("5. Setting up webhook notification...")
 
-		notification, err := client.CreateNotification(*namespace, *repository, &lib.CreateNotificationRequest{
+		notification, err := client.CreateNotification(ctx, *namespace, *repository, &lib.CreateNotificationRequest{
 			Event:  "repo_push",
 			Method: "webhook",
 			Title:  "CI/CD Push Notification",
@@ -140,7 +142,7 @@ func main() {
 
 	// Step 6: List build triggers
 	fmt.Println("6. Checking build triggers...")
-	triggers, err := client.GetTriggers(*namespace, *repository)
+	triggers, err := client.GetTriggers(ctx, *namespace, *repository)
 	if err != nil {
 		log.Printf("   Could not list triggers: %v\n", err)
 	} else if len(triggers.Triggers) == 0 {
@@ -160,7 +162,7 @@ func main() {
 
 	// Step 7: List existing notifications
 	fmt.Println("7. Checking existing notifications...")
-	notifications, err := client.GetNotifications(*namespace, *repository)
+	notifications, err := client.GetNotifications(ctx, *namespace, *repository)
 	if err != nil {
 		log.Printf("   Could not list notifications: %v\n", err)
 	} else if len(notifications.Notifications) == 0 {

--- a/examples/organization-management/main.go
+++ b/examples/organization-management/main.go
@@ -13,6 +13,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -43,6 +44,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)
 	}
+	ctx := context.Background()
 
 	fmt.Println("=== Organization Management Dashboard ===")
 	fmt.Printf("Organization: %s\n\n", *orgName)
@@ -51,7 +53,7 @@ func main() {
 	fmt.Println("1. Organization Information")
 	fmt.Println("   " + repeat("-", 40))
 
-	org, err := client.GetOrganization(*orgName)
+	org, err := client.GetOrganization(ctx, *orgName)
 	if err != nil {
 		log.Fatalf("Failed to get organization: %v", err)
 	}
@@ -65,7 +67,7 @@ func main() {
 	fmt.Println("2. Organization Members")
 	fmt.Println("   " + repeat("-", 40))
 
-	members, err := client.GetOrganizationMembers(*orgName)
+	members, err := client.GetOrganizationMembers(ctx, *orgName)
 	if err != nil {
 		log.Printf("   Could not get members: %v\n", err)
 	} else {
@@ -82,7 +84,7 @@ func main() {
 	fmt.Println("3. Teams")
 	fmt.Println("   " + repeat("-", 40))
 
-	teams, err := client.GetTeams(*orgName)
+	teams, err := client.GetTeams(ctx, *orgName)
 	if err != nil {
 		log.Printf("   Could not get teams: %v\n", err)
 	} else {
@@ -93,7 +95,7 @@ func main() {
 
 			if *showDetails {
 				// Get team members
-				teamMembers, err := client.GetTeamMembers(*orgName, team.Name)
+				teamMembers, err := client.GetTeamMembers(ctx, *orgName, team.Name)
 				if err == nil {
 					for _, m := range teamMembers.Members {
 						fmt.Printf("     * %s\n", m.Name)
@@ -108,7 +110,7 @@ func main() {
 	fmt.Println("4. Robot Accounts")
 	fmt.Println("   " + repeat("-", 40))
 
-	robots, err := client.GetRobotAccounts(*orgName)
+	robots, err := client.GetRobotAccounts(ctx, *orgName)
 	if err != nil {
 		log.Printf("   Could not get robots: %v\n", err)
 	} else {
@@ -128,7 +130,7 @@ func main() {
 	fmt.Println("5. Quota Information")
 	fmt.Println("   " + repeat("-", 40))
 
-	quota, err := client.GetQuota(*orgName)
+	quota, err := client.GetQuota(ctx, *orgName)
 	if err != nil {
 		log.Printf("   Could not get quota: %v\n", err)
 	} else if quota.LimitBytes == 0 {
@@ -145,7 +147,7 @@ func main() {
 	fmt.Println("6. Auto-Prune Policies")
 	fmt.Println("   " + repeat("-", 40))
 
-	policies, err := client.GetAutoPrunePolicies(*orgName)
+	policies, err := client.GetAutoPrunePolicies(ctx, *orgName)
 	if err != nil {
 		log.Printf("   Could not get auto-prune policies: %v\n", err)
 	} else if len(policies.Policies) == 0 {
@@ -166,7 +168,7 @@ func main() {
 	fmt.Println("7. OAuth Applications")
 	fmt.Println("   " + repeat("-", 40))
 
-	apps, err := client.GetApplications(*orgName)
+	apps, err := client.GetApplications(ctx, *orgName)
 	if err != nil {
 		log.Printf("   Could not get applications: %v\n", err)
 	} else if len(apps.Applications) == 0 {
@@ -183,7 +185,7 @@ func main() {
 	fmt.Println("8. Default Permission Prototypes")
 	fmt.Println("   " + repeat("-", 40))
 
-	prototypes, err := client.GetPrototypes(*orgName)
+	prototypes, err := client.GetPrototypes(ctx, *orgName)
 	if err != nil {
 		log.Printf("   Could not get prototypes: %v\n", err)
 	} else if len(prototypes.Prototypes) == 0 {

--- a/examples/security-scan/main.go
+++ b/examples/security-scan/main.go
@@ -13,6 +13,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -45,6 +46,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)
 	}
+	ctx := context.Background()
 
 	fmt.Println("=== Security Scan Report ===")
 	fmt.Printf("Repository: %s/%s\n", *namespace, *repository)
@@ -52,7 +54,7 @@ func main() {
 
 	// Step 1: Get repository and tag information
 	fmt.Println("1. Fetching repository information...")
-	repo, err := client.GetRepository(*namespace, *repository)
+	repo, err := client.GetRepository(ctx, *namespace, *repository)
 	if err != nil {
 		log.Fatalf("Failed to get repository: %v", err)
 	}
@@ -73,7 +75,7 @@ func main() {
 
 	// Step 2: Get manifest details
 	fmt.Println("\n2. Fetching manifest details...")
-	manifest, err := client.GetManifest(*namespace, *repository, manifestDigest)
+	manifest, err := client.GetManifest(ctx, *namespace, *repository, manifestDigest)
 	if err != nil {
 		log.Fatalf("Failed to get manifest: %v", err)
 	}
@@ -82,7 +84,7 @@ func main() {
 
 	// Step 3: Get security scan results
 	fmt.Println("\n3. Fetching security scan results...")
-	security, err := client.GetManifestSecurity(*namespace, *repository, manifestDigest, true)
+	security, err := client.GetManifestSecurity(ctx, *namespace, *repository, manifestDigest, true)
 	if err != nil {
 		log.Fatalf("Failed to get security scan: %v", err)
 	}

--- a/lib/README.md
+++ b/lib/README.md
@@ -14,6 +14,7 @@ go get github.com/sebrandon1/go-quay
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "os"
@@ -27,7 +28,8 @@ func main() {
         log.Fatal(err)
     }
 
-    user, err := client.GetUser()
+    ctx := context.Background()
+    user, err := client.GetUser(ctx)
     if err != nil {
         log.Fatal(err)
     }

--- a/lib/application.go
+++ b/lib/application.go
@@ -14,17 +14,18 @@ Applications Management:
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetApplications retrieves applications for an organization
-func (c *Client) GetApplications(orgname string) (*Applications, error) {
+func (c *Client) GetApplications(ctx context.Context, orgname string) (*Applications, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/applications", orgname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/applications", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get applications request: %w", err)
 	}
@@ -38,7 +39,7 @@ func (c *Client) GetApplications(orgname string) (*Applications, error) {
 }
 
 // CreateApplication creates a new application for an organization
-func (c *Client) CreateApplication(orgname, name, description, applicationURI, redirectURI string) (*Application, error) {
+func (c *Client) CreateApplication(ctx context.Context, orgname, name, description, applicationURI, redirectURI string) (*Application, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -46,7 +47,7 @@ func (c *Client) CreateApplication(orgname, name, description, applicationURI, r
 		return nil, fmt.Errorf("name is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/applications", orgname), CreateApplicationRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/organization/%s/applications", orgname), CreateApplicationRequest{
 		Name:           name,
 		Description:    description,
 		ApplicationURI: applicationURI,
@@ -65,7 +66,7 @@ func (c *Client) CreateApplication(orgname, name, description, applicationURI, r
 }
 
 // GetApplication retrieves details for a specific application
-func (c *Client) GetApplication(orgname, clientID string) (*Application, error) {
+func (c *Client) GetApplication(ctx context.Context, orgname, clientID string) (*Application, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -73,7 +74,7 @@ func (c *Client) GetApplication(orgname, clientID string) (*Application, error) 
 		return nil, fmt.Errorf("clientID is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/applications/%s", orgname, clientID), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/applications/%s", orgname, clientID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get application request: %w", err)
 	}
@@ -87,7 +88,7 @@ func (c *Client) GetApplication(orgname, clientID string) (*Application, error) 
 }
 
 // UpdateApplication updates an application
-func (c *Client) UpdateApplication(orgname, clientID, name, description, applicationURI, redirectURI string) (*Application, error) {
+func (c *Client) UpdateApplication(ctx context.Context, orgname, clientID, name, description, applicationURI, redirectURI string) (*Application, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -95,7 +96,7 @@ func (c *Client) UpdateApplication(orgname, clientID, name, description, applica
 		return nil, fmt.Errorf("clientID is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/applications/%s", orgname, clientID), CreateApplicationRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/organization/%s/applications/%s", orgname, clientID), CreateApplicationRequest{
 		Name:           name,
 		Description:    description,
 		ApplicationURI: applicationURI,
@@ -114,7 +115,7 @@ func (c *Client) UpdateApplication(orgname, clientID, name, description, applica
 }
 
 // DeleteApplication deletes an application
-func (c *Client) DeleteApplication(orgname, clientID string) error {
+func (c *Client) DeleteApplication(ctx context.Context, orgname, clientID string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -122,7 +123,7 @@ func (c *Client) DeleteApplication(orgname, clientID string) error {
 		return fmt.Errorf("clientID is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/applications/%s", orgname, clientID), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/organization/%s/applications/%s", orgname, clientID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete application request: %w", err)
 	}
@@ -135,7 +136,7 @@ func (c *Client) DeleteApplication(orgname, clientID string) error {
 }
 
 // ResetApplicationClientSecret resets the client secret for an application
-func (c *Client) ResetApplicationClientSecret(orgname, clientID string) (*Application, error) {
+func (c *Client) ResetApplicationClientSecret(ctx context.Context, orgname, clientID string) (*Application, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -143,7 +144,7 @@ func (c *Client) ResetApplicationClientSecret(orgname, clientID string) (*Applic
 		return nil, fmt.Errorf("clientID is required")
 	}
 
-	req, err := newRequest(http.MethodPost, c.buildURL("/organization/%s/applications/%s/resetclientsecret", orgname, clientID), nil)
+	req, err := newRequest(ctx, http.MethodPost, c.buildURL("/organization/%s/applications/%s/resetclientsecret", orgname, clientID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create reset application client secret request: %w", err)
 	}

--- a/lib/application_test.go
+++ b/lib/application_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -35,7 +36,7 @@ func TestGetApplications(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	apps, err := client.GetApplications(testOrgName)
+	apps, err := client.GetApplications(context.Background(), testOrgName)
 	if err != nil {
 		t.Fatalf("GetApplications returned error: %v", err)
 	}
@@ -86,7 +87,7 @@ func TestCreateApplication(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := client.CreateApplication(testOrgName, testAppName, "New application", testAppURI, testRedirectURI)
+	app, err := client.CreateApplication(context.Background(), testOrgName, testAppName, "New application", testAppURI, testRedirectURI)
 	if err != nil {
 		t.Fatalf("CreateApplication returned error: %v", err)
 	}
@@ -125,7 +126,7 @@ func TestGetApplication(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := client.GetApplication(testOrgName, testClientID)
+	app, err := client.GetApplication(context.Background(), testOrgName, testClientID)
 	if err != nil {
 		t.Fatalf("GetApplication returned error: %v", err)
 	}
@@ -163,7 +164,7 @@ func TestUpdateApplication(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := client.UpdateApplication(testOrgName, testClientID, "Updated App", updatedDescription, testAppURI, testRedirectURI)
+	app, err := client.UpdateApplication(context.Background(), testOrgName, testClientID, "Updated App", updatedDescription, testAppURI, testRedirectURI)
 	if err != nil {
 		t.Fatalf("UpdateApplication returned error: %v", err)
 	}
@@ -191,7 +192,7 @@ func TestDeleteApplication(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteApplication(testOrgName, testClientID)
+	err = client.DeleteApplication(context.Background(), testOrgName, testClientID)
 	if err != nil {
 		t.Fatalf("DeleteApplication returned error: %v", err)
 	}
@@ -223,7 +224,7 @@ func TestResetApplicationClientSecret(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := client.ResetApplicationClientSecret(testOrgName, testClientID)
+	app, err := client.ResetApplicationClientSecret(context.Background(), testOrgName, testClientID)
 	if err != nil {
 		t.Fatalf("ResetApplicationClientSecret returned error: %v", err)
 	}
@@ -236,32 +237,32 @@ func TestResetApplicationClientSecret(t *testing.T) {
 func TestApplicationHTTPErrors(t *testing.T) {
 	client := newOrgErrorClient(t)
 
-	_, err := client.GetApplications(testOrgName)
+	_, err := client.GetApplications(context.Background(), testOrgName)
 	if err == nil {
 		t.Error("Expected error from GetApplications, got nil")
 	}
 
-	_, err = client.CreateApplication(testOrgName, testAppName, "desc", testAppURI, testRedirectURI)
+	_, err = client.CreateApplication(context.Background(), testOrgName, testAppName, "desc", testAppURI, testRedirectURI)
 	if err == nil {
 		t.Error("Expected error from CreateApplication, got nil")
 	}
 
-	_, err = client.GetApplication(testOrgName, testClientID)
+	_, err = client.GetApplication(context.Background(), testOrgName, testClientID)
 	if err == nil {
 		t.Error("Expected error from GetApplication, got nil")
 	}
 
-	_, err = client.UpdateApplication(testOrgName, testClientID, testAppName, "desc", testAppURI, testRedirectURI)
+	_, err = client.UpdateApplication(context.Background(), testOrgName, testClientID, testAppName, "desc", testAppURI, testRedirectURI)
 	if err == nil {
 		t.Error("Expected error from UpdateApplication, got nil")
 	}
 
-	err = client.DeleteApplication(testOrgName, testClientID)
+	err = client.DeleteApplication(context.Background(), testOrgName, testClientID)
 	if err == nil {
 		t.Error("Expected error from DeleteApplication, got nil")
 	}
 
-	_, err = client.ResetApplicationClientSecret(testOrgName, testClientID)
+	_, err = client.ResetApplicationClientSecret(context.Background(), testOrgName, testClientID)
 	if err == nil {
 		t.Error("Expected error from ResetApplicationClientSecret, got nil")
 	}

--- a/lib/auto_prune.go
+++ b/lib/auto_prune.go
@@ -13,17 +13,18 @@ Auto-Prune Policy Management:
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetAutoPrunePolicies retrieves auto-prune policies for an organization
-func (c *Client) GetAutoPrunePolicies(orgname string) (*AutoPrunePolicies, error) {
+func (c *Client) GetAutoPrunePolicies(ctx context.Context, orgname string) (*AutoPrunePolicies, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/autoprunepolicy", orgname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/autoprunepolicy", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get auto-prune policies request: %w", err)
 	}
@@ -37,7 +38,7 @@ func (c *Client) GetAutoPrunePolicies(orgname string) (*AutoPrunePolicies, error
 }
 
 // CreateAutoPrunePolicy creates an auto-prune policy for an organization
-func (c *Client) CreateAutoPrunePolicy(orgname, method string, value int, tagPattern string) (*AutoPrunePolicy, error) {
+func (c *Client) CreateAutoPrunePolicy(ctx context.Context, orgname, method string, value int, tagPattern string) (*AutoPrunePolicy, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -45,7 +46,7 @@ func (c *Client) CreateAutoPrunePolicy(orgname, method string, value int, tagPat
 		return nil, fmt.Errorf("method is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/autoprunepolicy", orgname), CreateAutoPruneRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/organization/%s/autoprunepolicy", orgname), CreateAutoPruneRequest{
 		Method:     method,
 		Value:      value,
 		TagPattern: tagPattern,
@@ -63,7 +64,7 @@ func (c *Client) CreateAutoPrunePolicy(orgname, method string, value int, tagPat
 }
 
 // GetAutoPrunePolicy retrieves a specific auto-prune policy
-func (c *Client) GetAutoPrunePolicy(orgname, policyUUID string) (*AutoPrunePolicy, error) {
+func (c *Client) GetAutoPrunePolicy(ctx context.Context, orgname, policyUUID string) (*AutoPrunePolicy, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -71,7 +72,7 @@ func (c *Client) GetAutoPrunePolicy(orgname, policyUUID string) (*AutoPrunePolic
 		return nil, fmt.Errorf("policyUUID is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get auto-prune policy request: %w", err)
 	}
@@ -85,7 +86,7 @@ func (c *Client) GetAutoPrunePolicy(orgname, policyUUID string) (*AutoPrunePolic
 }
 
 // UpdateAutoPrunePolicy updates an auto-prune policy
-func (c *Client) UpdateAutoPrunePolicy(orgname, policyUUID, method string, value int, tagPattern string) (*AutoPrunePolicy, error) {
+func (c *Client) UpdateAutoPrunePolicy(ctx context.Context, orgname, policyUUID, method string, value int, tagPattern string) (*AutoPrunePolicy, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -96,7 +97,7 @@ func (c *Client) UpdateAutoPrunePolicy(orgname, policyUUID, method string, value
 		return nil, fmt.Errorf("method is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), CreateAutoPruneRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), CreateAutoPruneRequest{
 		Method:     method,
 		Value:      value,
 		TagPattern: tagPattern,
@@ -114,7 +115,7 @@ func (c *Client) UpdateAutoPrunePolicy(orgname, policyUUID, method string, value
 }
 
 // DeleteAutoPrunePolicy deletes an auto-prune policy
-func (c *Client) DeleteAutoPrunePolicy(orgname, policyUUID string) error {
+func (c *Client) DeleteAutoPrunePolicy(ctx context.Context, orgname, policyUUID string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -122,7 +123,7 @@ func (c *Client) DeleteAutoPrunePolicy(orgname, policyUUID string) error {
 		return fmt.Errorf("policyUUID is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/organization/%s/autoprunepolicy/%s", orgname, policyUUID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete auto-prune policy request: %w", err)
 	}

--- a/lib/auto_prune_test.go
+++ b/lib/auto_prune_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -35,7 +36,7 @@ func TestGetAutoPrunePolicies(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	policies, err := client.GetAutoPrunePolicies(testOrgName)
+	policies, err := client.GetAutoPrunePolicies(context.Background(), testOrgName)
 	if err != nil {
 		t.Fatalf("GetAutoPrunePolicies returned error: %v", err)
 	}
@@ -85,7 +86,7 @@ func TestCreateAutoPrunePolicy(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	policy, err := client.CreateAutoPrunePolicy(testOrgName, testAutoPruneMethodNumberOfTags, 20, testTagPatternRelease)
+	policy, err := client.CreateAutoPrunePolicy(context.Background(), testOrgName, testAutoPruneMethodNumberOfTags, 20, testTagPatternRelease)
 	if err != nil {
 		t.Fatalf("CreateAutoPrunePolicy returned error: %v", err)
 	}
@@ -122,7 +123,7 @@ func TestGetAutoPrunePolicy(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	policy, err := client.GetAutoPrunePolicy(testOrgName, testPolicyUUID)
+	policy, err := client.GetAutoPrunePolicy(context.Background(), testOrgName, testPolicyUUID)
 	if err != nil {
 		t.Fatalf("GetAutoPrunePolicy returned error: %v", err)
 	}
@@ -162,7 +163,7 @@ func TestUpdateAutoPrunePolicy(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	policy, err := client.UpdateAutoPrunePolicy(testOrgName, testPolicyUUID, testAutoPruneMethodNumberOfTags, 30, testTagPatternRelease)
+	policy, err := client.UpdateAutoPrunePolicy(context.Background(), testOrgName, testPolicyUUID, testAutoPruneMethodNumberOfTags, 30, testTagPatternRelease)
 	if err != nil {
 		t.Fatalf("UpdateAutoPrunePolicy returned error: %v", err)
 	}
@@ -193,7 +194,7 @@ func TestDeleteAutoPrunePolicy(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteAutoPrunePolicy(testOrgName, testPolicyUUID)
+	err = client.DeleteAutoPrunePolicy(context.Background(), testOrgName, testPolicyUUID)
 	if err != nil {
 		t.Fatalf("DeleteAutoPrunePolicy returned error: %v", err)
 	}
@@ -202,27 +203,27 @@ func TestDeleteAutoPrunePolicy(t *testing.T) {
 func TestAutoPruneHTTPErrors(t *testing.T) {
 	client := newOrgErrorClient(t)
 
-	_, err := client.GetAutoPrunePolicies(testOrgName)
+	_, err := client.GetAutoPrunePolicies(context.Background(), testOrgName)
 	if err == nil {
 		t.Error("Expected error from GetAutoPrunePolicies, got nil")
 	}
 
-	_, err = client.CreateAutoPrunePolicy(testOrgName, testAutoPruneMethodNumberOfTags, 10, "")
+	_, err = client.CreateAutoPrunePolicy(context.Background(), testOrgName, testAutoPruneMethodNumberOfTags, 10, "")
 	if err == nil {
 		t.Error("Expected error from CreateAutoPrunePolicy, got nil")
 	}
 
-	_, err = client.GetAutoPrunePolicy(testOrgName, testPolicyUUID)
+	_, err = client.GetAutoPrunePolicy(context.Background(), testOrgName, testPolicyUUID)
 	if err == nil {
 		t.Error("Expected error from GetAutoPrunePolicy, got nil")
 	}
 
-	_, err = client.UpdateAutoPrunePolicy(testOrgName, testPolicyUUID, testAutoPruneMethodNumberOfTags, 20, "")
+	_, err = client.UpdateAutoPrunePolicy(context.Background(), testOrgName, testPolicyUUID, testAutoPruneMethodNumberOfTags, 20, "")
 	if err == nil {
 		t.Error("Expected error from UpdateAutoPrunePolicy, got nil")
 	}
 
-	err = client.DeleteAutoPrunePolicy(testOrgName, testPolicyUUID)
+	err = client.DeleteAutoPrunePolicy(context.Background(), testOrgName, testPolicyUUID)
 	if err == nil {
 		t.Error("Expected error from DeleteAutoPrunePolicy, got nil")
 	}

--- a/lib/billing.go
+++ b/lib/billing.go
@@ -20,18 +20,19 @@ Note: User invoice endpoint is not available in Quay API.
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetOrganizationBilling returns billing information for an organization
-func (c *Client) GetOrganizationBilling(orgname string) (*BillingInfo, error) {
+func (c *Client) GetOrganizationBilling(ctx context.Context, orgname string) (*BillingInfo, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
 	// Get new request
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/plan", orgname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/plan", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization billing request: %w", err)
 	}
@@ -45,9 +46,9 @@ func (c *Client) GetOrganizationBilling(orgname string) (*BillingInfo, error) {
 }
 
 // GetUserBilling returns billing information for the current user
-func (c *Client) GetUserBilling() (*BillingInfo, error) {
+func (c *Client) GetUserBilling(ctx context.Context) (*BillingInfo, error) {
 	// Get new request
-	req, err := newRequest(http.MethodGet, c.buildURL("/user/plan"), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/user/plan"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user billing request: %w", err)
 	}
@@ -61,13 +62,13 @@ func (c *Client) GetUserBilling() (*BillingInfo, error) {
 }
 
 // GetOrganizationSubscription returns subscription details for an organization
-func (c *Client) GetOrganizationSubscription(orgname string) (*Subscription, error) {
+func (c *Client) GetOrganizationSubscription(ctx context.Context, orgname string) (*Subscription, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
 	// Get new request
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/plan", orgname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/plan", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization subscription request: %w", err)
 	}
@@ -81,9 +82,9 @@ func (c *Client) GetOrganizationSubscription(orgname string) (*Subscription, err
 }
 
 // GetUserSubscription returns subscription details for the current user
-func (c *Client) GetUserSubscription() (*Subscription, error) {
+func (c *Client) GetUserSubscription(ctx context.Context) (*Subscription, error) {
 	// Get new request
-	req, err := newRequest(http.MethodGet, c.buildURL("/user/plan"), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/user/plan"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user subscription request: %w", err)
 	}
@@ -97,13 +98,13 @@ func (c *Client) GetUserSubscription() (*Subscription, error) {
 }
 
 // GetOrganizationInvoices returns invoices for an organization
-func (c *Client) GetOrganizationInvoices(orgname string) ([]Invoice, error) {
+func (c *Client) GetOrganizationInvoices(ctx context.Context, orgname string) ([]Invoice, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
 	// Get new request
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/invoices", orgname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/invoices", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization invoices request: %w", err)
 	}
@@ -119,14 +120,14 @@ func (c *Client) GetOrganizationInvoices(orgname string) ([]Invoice, error) {
 }
 
 // GetUserInvoices - NOT AVAILABLE in Quay API (returns 404)
-func (c *Client) GetUserInvoices() ([]Invoice, error) {
+func (c *Client) GetUserInvoices(_ context.Context) ([]Invoice, error) {
 	return nil, fmt.Errorf("user invoices endpoint not available in Quay API")
 }
 
 // GetAvailablePlans returns available subscription plans
-func (c *Client) GetAvailablePlans() ([]Subscription, error) {
+func (c *Client) GetAvailablePlans(ctx context.Context) ([]Subscription, error) {
 	// Get new request
-	req, err := newRequest(http.MethodGet, c.buildURL("/plans"), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/plans"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get available plans request: %w", err)
 	}

--- a/lib/billing_test.go
+++ b/lib/billing_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -40,7 +41,7 @@ func TestGetOrganizationBilling(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	billing, err := client.GetOrganizationBilling(testNamespace)
+	billing, err := client.GetOrganizationBilling(context.Background(), testNamespace)
 	if err != nil {
 		t.Fatalf("GetOrganizationBilling returned error: %v", err)
 	}
@@ -93,7 +94,7 @@ func TestGetUserBilling(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	billing, err := client.GetUserBilling()
+	billing, err := client.GetUserBilling(context.Background())
 	if err != nil {
 		t.Fatalf("GetUserBilling returned error: %v", err)
 	}
@@ -141,7 +142,7 @@ func TestGetOrganizationSubscription(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	subscription, err := client.GetOrganizationSubscription(testNamespace)
+	subscription, err := client.GetOrganizationSubscription(context.Background(), testNamespace)
 	if err != nil {
 		t.Fatalf("GetOrganizationSubscription returned error: %v", err)
 	}
@@ -189,7 +190,7 @@ func TestGetUserSubscription(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	subscription, err := client.GetUserSubscription()
+	subscription, err := client.GetUserSubscription(context.Background())
 	if err != nil {
 		t.Fatalf("GetUserSubscription returned error: %v", err)
 	}
@@ -246,7 +247,7 @@ func TestGetOrganizationInvoices(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	invoices, err := client.GetOrganizationInvoices(testNamespace)
+	invoices, err := client.GetOrganizationInvoices(context.Background(), testNamespace)
 	if err != nil {
 		t.Fatalf("GetOrganizationInvoices returned error: %v", err)
 	}
@@ -274,7 +275,7 @@ func TestGetUserInvoices(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	invoices, err := client.GetUserInvoices()
+	invoices, err := client.GetUserInvoices(context.Background())
 	if err == nil {
 		t.Error("Expected error for unsupported endpoint, got nil")
 	}
@@ -328,7 +329,7 @@ func TestGetAvailablePlans(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	plans, err := client.GetAvailablePlans()
+	plans, err := client.GetAvailablePlans(context.Background())
 	if err != nil {
 		t.Fatalf("GetAvailablePlans returned error: %v", err)
 	}
@@ -366,7 +367,7 @@ func TestGetOrganizationBillingError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	billing, err := client.GetOrganizationBilling(testNamespace)
+	billing, err := client.GetOrganizationBilling(context.Background(), testNamespace)
 	if err == nil {
 		t.Error("Expected error for 500 response, got nil")
 	}
@@ -388,7 +389,7 @@ func TestGetUserBillingError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	billing, err := client.GetUserBilling()
+	billing, err := client.GetUserBilling(context.Background())
 	if err == nil {
 		t.Error("Expected error for 401 response, got nil")
 	}
@@ -410,7 +411,7 @@ func TestGetAvailablePlansError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	plans, err := client.GetAvailablePlans()
+	plans, err := client.GetAvailablePlans(context.Background())
 	if err == nil {
 		t.Error("Expected error for 404 response, got nil")
 	}
@@ -431,17 +432,17 @@ func TestBillingHTTPErrors(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetOrganizationSubscription(testNamespace)
+	_, err = client.GetOrganizationSubscription(context.Background(), testNamespace)
 	if err == nil {
 		t.Error("Expected error from GetOrganizationSubscription, got nil")
 	}
 
-	_, err = client.GetUserSubscription()
+	_, err = client.GetUserSubscription(context.Background())
 	if err == nil {
 		t.Error("Expected error from GetUserSubscription, got nil")
 	}
 
-	_, err = client.GetOrganizationInvoices(testNamespace)
+	_, err = client.GetOrganizationInvoices(context.Background(), testNamespace)
 	if err == nil {
 		t.Error("Expected error from GetOrganizationInvoices, got nil")
 	}

--- a/lib/build.go
+++ b/lib/build.go
@@ -16,12 +16,13 @@ or uploaded archives.
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetBuilds retrieves a list of builds for a repository
-func (c *Client) GetBuilds(namespace, repository string, limit int) (*Builds, error) {
+func (c *Client) GetBuilds(ctx context.Context, namespace, repository string, limit int) (*Builds, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -34,7 +35,7 @@ func (c *Client) GetBuilds(namespace, repository string, limit int) (*Builds, er
 		url = fmt.Sprintf("%s?limit=%d", url, limit)
 	}
 
-	req, err := newRequest(http.MethodGet, url, nil)
+	req, err := newRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get builds request: %w", err)
 	}
@@ -48,7 +49,7 @@ func (c *Client) GetBuilds(namespace, repository string, limit int) (*Builds, er
 }
 
 // GetBuild retrieves a specific build by UUID
-func (c *Client) GetBuild(namespace, repository, buildUUID string) (*Build, error) {
+func (c *Client) GetBuild(ctx context.Context, namespace, repository, buildUUID string) (*Build, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -59,7 +60,7 @@ func (c *Client) GetBuild(namespace, repository, buildUUID string) (*Build, erro
 		return nil, fmt.Errorf("buildUUID is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/build/%s", namespace, repository, buildUUID), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/build/%s", namespace, repository, buildUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get build request: %w", err)
 	}
@@ -73,7 +74,7 @@ func (c *Client) GetBuild(namespace, repository, buildUUID string) (*Build, erro
 }
 
 // GetBuildLogs retrieves the logs for a specific build
-func (c *Client) GetBuildLogs(namespace, repository, buildUUID string) (*BuildLogs, error) {
+func (c *Client) GetBuildLogs(ctx context.Context, namespace, repository, buildUUID string) (*BuildLogs, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -84,7 +85,7 @@ func (c *Client) GetBuildLogs(namespace, repository, buildUUID string) (*BuildLo
 		return nil, fmt.Errorf("buildUUID is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/build/%s/logs", namespace, repository, buildUUID), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/build/%s/logs", namespace, repository, buildUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get build logs request: %w", err)
 	}
@@ -98,7 +99,7 @@ func (c *Client) GetBuildLogs(namespace, repository, buildUUID string) (*BuildLo
 }
 
 // RequestBuild triggers a new build for a repository
-func (c *Client) RequestBuild(namespace, repository string, buildRequest *RequestBuildRequest) (*Build, error) {
+func (c *Client) RequestBuild(ctx context.Context, namespace, repository string, buildRequest *RequestBuildRequest) (*Build, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -106,7 +107,7 @@ func (c *Client) RequestBuild(namespace, repository string, buildRequest *Reques
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/build/", namespace, repository), buildRequest)
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/repository/%s/%s/build/", namespace, repository), buildRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request build request: %w", err)
 	}
@@ -120,7 +121,7 @@ func (c *Client) RequestBuild(namespace, repository string, buildRequest *Reques
 }
 
 // CancelBuild cancels an ongoing build
-func (c *Client) CancelBuild(namespace, repository, buildUUID string) error {
+func (c *Client) CancelBuild(ctx context.Context, namespace, repository, buildUUID string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -131,7 +132,7 @@ func (c *Client) CancelBuild(namespace, repository, buildUUID string) error {
 		return fmt.Errorf("buildUUID is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/build/%s", namespace, repository, buildUUID), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/repository/%s/%s/build/%s", namespace, repository, buildUUID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create cancel build request: %w", err)
 	}
@@ -144,7 +145,7 @@ func (c *Client) CancelBuild(namespace, repository, buildUUID string) error {
 }
 
 // GetBuildStatus gets the status of a build
-func (c *Client) GetBuildStatus(namespace, repository, buildUUID string) (*BuildStatus, error) {
+func (c *Client) GetBuildStatus(ctx context.Context, namespace, repository, buildUUID string) (*BuildStatus, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -155,7 +156,7 @@ func (c *Client) GetBuildStatus(namespace, repository, buildUUID string) (*Build
 		return nil, fmt.Errorf("buildUUID is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/build/%s/status", namespace, repository, buildUUID), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/build/%s/status", namespace, repository, buildUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get build status request: %w", err)
 	}

--- a/lib/build_test.go
+++ b/lib/build_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -39,7 +40,7 @@ func TestGetBuilds(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	builds, err := client.GetBuilds(testNamespace, testRepository, 0)
+	builds, err := client.GetBuilds(context.Background(), testNamespace, testRepository, 0)
 	if err != nil {
 		t.Fatalf("GetBuilds returned error: %v", err)
 	}
@@ -79,7 +80,7 @@ func TestGetBuild(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	build, err := client.GetBuild(testNamespace, testRepository, testBuildUUID)
+	build, err := client.GetBuild(context.Background(), testNamespace, testRepository, testBuildUUID)
 	if err != nil {
 		t.Fatalf("GetBuild returned error: %v", err)
 	}
@@ -121,7 +122,7 @@ func TestGetBuildLogs(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	logs, err := client.GetBuildLogs(testNamespace, testRepository, testBuildUUID)
+	logs, err := client.GetBuildLogs(context.Background(), testNamespace, testRepository, testBuildUUID)
 	if err != nil {
 		t.Fatalf("GetBuildLogs returned error: %v", err)
 	}
@@ -166,7 +167,7 @@ func TestRequestBuild(t *testing.T) {
 		Tags:       []string{testTagNameLatest},
 	}
 
-	build, err := client.RequestBuild(testNamespace, testRepository, buildReq)
+	build, err := client.RequestBuild(context.Background(), testNamespace, testRepository, buildReq)
 	if err != nil {
 		t.Fatalf("RequestBuild returned error: %v", err)
 	}
@@ -194,7 +195,7 @@ func TestCancelBuild(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.CancelBuild(testNamespace, testRepository, testBuildUUID)
+	err = client.CancelBuild(context.Background(), testNamespace, testRepository, testBuildUUID)
 	if err != nil {
 		t.Fatalf("CancelBuild returned error: %v", err)
 	}
@@ -211,7 +212,7 @@ func TestGetBuildsError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetBuilds(testNamespace, testRepository, 0)
+	_, err = client.GetBuilds(context.Background(), testNamespace, testRepository, 0)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -245,7 +246,7 @@ func TestGetBuildStatus(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	status, err := client.GetBuildStatus(testNamespace, testRepository, testBuildUUID)
+	status, err := client.GetBuildStatus(context.Background(), testNamespace, testRepository, testBuildUUID)
 	if err != nil {
 		t.Fatalf("GetBuildStatus returned error: %v", err)
 	}
@@ -272,7 +273,7 @@ func TestGetBuildError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetBuild(testNamespace, testRepository, "nonexistent-uuid")
+	_, err = client.GetBuild(context.Background(), testNamespace, testRepository, "nonexistent-uuid")
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -289,22 +290,22 @@ func TestBuildHTTPErrors(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetBuildLogs(testNamespace, testRepository, testBuildUUID)
+	_, err = client.GetBuildLogs(context.Background(), testNamespace, testRepository, testBuildUUID)
 	if err == nil {
 		t.Error("Expected error from GetBuildLogs, got nil")
 	}
 
-	_, err = client.GetBuildStatus(testNamespace, testRepository, testBuildUUID)
+	_, err = client.GetBuildStatus(context.Background(), testNamespace, testRepository, testBuildUUID)
 	if err == nil {
 		t.Error("Expected error from GetBuildStatus, got nil")
 	}
 
-	_, err = client.RequestBuild(testNamespace, testRepository, &RequestBuildRequest{ArchiveURL: "https://example.com/archive.tar.gz"})
+	_, err = client.RequestBuild(context.Background(), testNamespace, testRepository, &RequestBuildRequest{ArchiveURL: "https://example.com/archive.tar.gz"})
 	if err == nil {
 		t.Error("Expected error from RequestBuild, got nil")
 	}
 
-	err = client.CancelBuild(testNamespace, testRepository, testBuildUUID)
+	err = client.CancelBuild(context.Background(), testNamespace, testRepository, testBuildUUID)
 	if err == nil {
 		t.Error("Expected error from CancelBuild, got nil")
 	}

--- a/lib/client.go
+++ b/lib/client.go
@@ -12,8 +12,8 @@ HTTP Helper Methods:
   - get(req, v) / post(req, v) / put(req, v) / delete(req) - Thin wrappers with preset accepted statuses
 
 Request Helpers:
-  - newRequest(method, url string, body io.Reader) (*http.Request, error)
-  - newRequestWithBody(method, url string, body any) (*http.Request, error)
+  - newRequest(ctx, method, url string, body io.Reader) (*http.Request, error)
+  - newRequestWithBody(ctx, method, url string, body any) (*http.Request, error)
   - decodeJSON(r io.Reader, v any) error
 
 All HTTP methods include:
@@ -26,6 +26,7 @@ package lib
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -119,7 +120,9 @@ func (c *Client) do(req *http.Request, v any, acceptedStatuses ...int) error {
 			return err
 		}
 
-		c.backoff(attempt, retryAfter)
+		if err := c.backoff(req.Context(), attempt, retryAfter); err != nil {
+			return err
+		}
 	}
 
 	return lastErr
@@ -144,6 +147,9 @@ func (e *retryableError) Unwrap() error { return e.err }
 func (c *Client) doOnce(req *http.Request, v any, acceptedStatuses []int) (error, error) {
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
 		return nil, &retryableError{err: err}
 	}
 	defer resp.Body.Close()
@@ -198,11 +204,7 @@ func (c *Client) shouldRetry(attempt, maxAttempts int) bool {
 	return c.Retry != nil && attempt < maxAttempts-1
 }
 
-func (c *Client) backoff(attempt int, retryAfterSecs int) {
-	if c.Retry == nil {
-		return
-	}
-
+func (c *Client) backoff(ctx context.Context, attempt int, retryAfterSecs int) error {
 	var wait time.Duration
 	if retryAfterSecs > 0 {
 		wait = time.Duration(retryAfterSecs) * time.Second
@@ -214,7 +216,14 @@ func (c *Client) backoff(attempt int, retryAfterSecs int) {
 		wait = c.Retry.MaxBackoff
 	}
 
-	time.Sleep(wait)
+	t := time.NewTimer(wait)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
 }
 
 func isRetryableStatus(status int) bool {
@@ -260,13 +269,12 @@ func decodeJSON(r io.Reader, v any) error {
 	return json.NewDecoder(r).Decode(v)
 }
 
-//nolint:unparam
-func newRequest(method, url string, body io.Reader) (*http.Request, error) {
-	return http.NewRequest(method, url, body)
+func newRequest(ctx context.Context, method, url string, body io.Reader) (*http.Request, error) {
+	return http.NewRequestWithContext(ctx, method, url, body)
 }
 
 // newRequestWithBody creates a new HTTP request with JSON body
-func newRequestWithBody(method, url string, body any) (*http.Request, error) {
+func newRequestWithBody(ctx context.Context, method, url string, body any) (*http.Request, error) {
 	var bodyReader io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -275,5 +283,5 @@ func newRequestWithBody(method, url string, body any) (*http.Request, error) {
 		}
 		bodyReader = bytes.NewReader(data)
 	}
-	return http.NewRequest(method, url, bodyReader)
+	return newRequest(ctx, method, url, bodyReader)
 }

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -113,7 +114,7 @@ func TestUserAgentHeader(t *testing.T) {
 	}
 	client.Version = "1.2.3"
 
-	req, err := newRequest(httpMethodGet, server.URL+"/test", nil)
+	req, err := newRequest(context.Background(), httpMethodGet, server.URL+"/test", nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -160,7 +161,7 @@ func TestGetRequest(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	req, err := newRequest(httpMethodGet, server.URL+"/api/v1/test", nil)
+	req, err := newRequest(context.Background(), httpMethodGet, server.URL+"/api/v1/test", nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -193,7 +194,7 @@ func TestQuayErrorParsing(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	req, err := newRequest(httpMethodGet, server.URL+"/api/v1/test", nil)
+	req, err := newRequest(context.Background(), httpMethodGet, server.URL+"/api/v1/test", nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -239,7 +240,7 @@ func TestQuayErrorFallbackToRawError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	req, err := newRequest(httpMethodGet, server.URL+"/api/v1/test", nil)
+	req, err := newRequest(context.Background(), httpMethodGet, server.URL+"/api/v1/test", nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -268,7 +269,7 @@ func TestGetRequestError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	req, err := newRequest(httpMethodGet, server.URL+"/api/v1/test", nil)
+	req, err := newRequest(context.Background(), httpMethodGet, server.URL+"/api/v1/test", nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -329,7 +330,7 @@ func TestPostRequest(t *testing.T) {
 	}
 
 	reqBody := postBody{Name: "test-create"}
-	req, err := newRequestWithBody(httpMethodPost, server.URL+"/api/v1/test", reqBody)
+	req, err := newRequestWithBody(context.Background(), httpMethodPost, server.URL+"/api/v1/test", reqBody)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -364,7 +365,7 @@ func TestPostRequestNoResponse(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	req, err := newRequestWithBody(httpMethodPost, server.URL+"/api/v1/test", nil)
+	req, err := newRequestWithBody(context.Background(), httpMethodPost, server.URL+"/api/v1/test", nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -405,7 +406,7 @@ func TestPutRequest(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	req, err := newRequestWithBody(httpMethodPut, server.URL+"/api/v1/test", map[string]string{testFieldName: testUpdatedItem})
+	req, err := newRequestWithBody(context.Background(), httpMethodPut, server.URL+"/api/v1/test", map[string]string{testFieldName: testUpdatedItem})
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -440,7 +441,7 @@ func TestPutRequestNoContent(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	req, err := newRequestWithBody(httpMethodPut, server.URL+"/api/v1/test", map[string]string{testFieldName: testPlaceholder})
+	req, err := newRequestWithBody(context.Background(), httpMethodPut, server.URL+"/api/v1/test", map[string]string{testFieldName: testPlaceholder})
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -476,7 +477,7 @@ func TestDeleteRequest(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	req, err := newRequest(httpMethodDelete, server.URL+"/api/v1/test/item-123", nil)
+	req, err := newRequest(context.Background(), httpMethodDelete, server.URL+"/api/v1/test/item-123", nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -499,7 +500,7 @@ func TestDeleteRequestError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	req, err := newRequest(httpMethodDelete, server.URL+"/api/v1/test/item-123", nil)
+	req, err := newRequest(context.Background(), httpMethodDelete, server.URL+"/api/v1/test/item-123", nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -536,7 +537,7 @@ func TestRetryOn429(t *testing.T) {
 		MaxBackoff:     10 * time.Millisecond,
 	}
 
-	req, err := newRequest(httpMethodGet, server.URL+"/api/v1/test", nil)
+	req, err := newRequest(context.Background(), httpMethodGet, server.URL+"/api/v1/test", nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -581,7 +582,7 @@ func TestRetryOn500(t *testing.T) {
 		MaxBackoff:     10 * time.Millisecond,
 	}
 
-	req, err := newRequest(httpMethodGet, server.URL+"/api/v1/test", nil)
+	req, err := newRequest(context.Background(), httpMethodGet, server.URL+"/api/v1/test", nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -616,7 +617,7 @@ func TestRetryExhausted(t *testing.T) {
 		MaxBackoff:     10 * time.Millisecond,
 	}
 
-	req, err := newRequest(httpMethodGet, server.URL+"/api/v1/test", nil)
+	req, err := newRequest(context.Background(), httpMethodGet, server.URL+"/api/v1/test", nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -650,7 +651,7 @@ func TestNoRetryOn4xx(t *testing.T) {
 		InitialBackoff: 1 * time.Millisecond,
 	}
 
-	req, err := newRequest(httpMethodGet, server.URL+"/api/v1/test", nil)
+	req, err := newRequest(context.Background(), httpMethodGet, server.URL+"/api/v1/test", nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -680,7 +681,7 @@ func TestNoRetryWithoutConfig(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	req, err := newRequest(httpMethodGet, server.URL+"/api/v1/test", nil)
+	req, err := newRequest(context.Background(), httpMethodGet, server.URL+"/api/v1/test", nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -693,5 +694,173 @@ func TestNoRetryWithoutConfig(t *testing.T) {
 
 	if attempts.Load() != 1 {
 		t.Errorf("Expected 1 attempt (no retry config), got %d", attempts.Load())
+	}
+}
+
+func TestCanceledContextBeforeDo(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL(testTokenValue, server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	req, err := newRequest(ctx, httpMethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	var result map[string]string
+	err = client.get(req, &result)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Expected context.Canceled, got %v", err)
+	}
+	if attempts.Load() != 0 {
+		t.Errorf("Expected 0 HTTP attempts for canceled context, got %d", attempts.Load())
+	}
+}
+
+func TestCanceledContextAbortsInFlightRequest(t *testing.T) {
+	started := make(chan struct{})
+	block := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(started)
+		<-block
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+	defer close(block)
+
+	client, err := NewClientWithURL(testTokenValue, server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req, err := newRequest(ctx, httpMethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		var result map[string]string
+		done <- client.get(req, &result)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not receive request")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Expected context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("get did not return after cancel")
+	}
+}
+
+func TestCanceledContextDuringBackoff(t *testing.T) {
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case <-started:
+		default:
+			close(started)
+		}
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"error":"rate_limited"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL(testTokenValue, server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	client.Retry = &RetryConfig{
+		MaxRetries:     3,
+		InitialBackoff: 30 * time.Second,
+		MaxBackoff:     30 * time.Second,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req, err := newRequest(ctx, httpMethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		var result map[string]string
+		done <- client.get(req, &result)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not receive request")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Expected context.Canceled during backoff, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("get did not return after cancel during backoff")
+	}
+}
+
+func TestDeadlineExceededDuringBackoff(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"error":"rate_limited"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithURL(testTokenValue, server.URL+"/api/v1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	client.Retry = &RetryConfig{
+		MaxRetries:     3,
+		InitialBackoff: 30 * time.Second,
+		MaxBackoff:     30 * time.Second,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	req, err := newRequest(ctx, httpMethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	var result map[string]string
+	err = client.get(req, &result)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Expected context.DeadlineExceeded during backoff, got %v", err)
 	}
 }

--- a/lib/discovery.go
+++ b/lib/discovery.go
@@ -12,13 +12,14 @@ Registry Capabilities:
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetDiscovery retrieves API discovery information
-func (c *Client) GetDiscovery() (*Discovery, error) {
-	req, err := newRequest(http.MethodGet, c.buildURL("/discovery"), nil)
+func (c *Client) GetDiscovery(ctx context.Context) (*Discovery, error) {
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/discovery"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discovery request: %w", err)
 	}
@@ -32,8 +33,8 @@ func (c *Client) GetDiscovery() (*Discovery, error) {
 }
 
 // GetRegistryCapabilities retrieves the registry capabilities including sparse manifest support and mirror architectures
-func (c *Client) GetRegistryCapabilities() (*RegistryCapabilities, error) {
-	req, err := newRequest(http.MethodGet, c.buildURL("/registry/capabilities"), nil)
+func (c *Client) GetRegistryCapabilities(ctx context.Context) (*RegistryCapabilities, error) {
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/registry/capabilities"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create registry capabilities request: %w", err)
 	}
@@ -47,12 +48,12 @@ func (c *Client) GetRegistryCapabilities() (*RegistryCapabilities, error) {
 }
 
 // GetAppInfo retrieves public information about an OAuth application by client ID
-func (c *Client) GetAppInfo(clientID string) (*Application, error) {
+func (c *Client) GetAppInfo(ctx context.Context, clientID string) (*Application, error) {
 	if clientID == "" {
 		return nil, fmt.Errorf("clientID is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/app/%s", clientID), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/app/%s", clientID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get app info request: %w", err)
 	}
@@ -66,12 +67,12 @@ func (c *Client) GetAppInfo(clientID string) (*Application, error) {
 }
 
 // GetEntities searches for entities (users, robots, teams) matching a prefix
-func (c *Client) GetEntities(prefix string, includeOrgs, includeTeams bool) (*Entities, error) {
+func (c *Client) GetEntities(ctx context.Context, prefix string, includeOrgs, includeTeams bool) (*Entities, error) {
 	if prefix == "" {
 		return nil, fmt.Errorf("prefix is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/entities/%s", prefix), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/entities/%s", prefix), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get entities request: %w", err)
 	}

--- a/lib/discovery_test.go
+++ b/lib/discovery_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -38,7 +39,7 @@ func TestGetDiscovery(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	discovery, err := client.GetDiscovery()
+	discovery, err := client.GetDiscovery(context.Background())
 	if err != nil {
 		t.Fatalf("GetDiscovery returned error: %v", err)
 	}
@@ -80,7 +81,7 @@ func TestGetRegistryCapabilities(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	capabilities, err := client.GetRegistryCapabilities()
+	capabilities, err := client.GetRegistryCapabilities(context.Background())
 	if err != nil {
 		t.Fatalf("GetRegistryCapabilities returned error: %v", err)
 	}
@@ -121,7 +122,7 @@ func TestGetAppInfo(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := client.GetAppInfo(testClientID)
+	app, err := client.GetAppInfo(context.Background(), testClientID)
 	if err != nil {
 		t.Fatalf("GetAppInfo returned error: %v", err)
 	}
@@ -167,7 +168,7 @@ func TestGetEntities(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	entities, err := client.GetEntities("test", true, true)
+	entities, err := client.GetEntities(context.Background(), "test", true, true)
 	if err != nil {
 		t.Fatalf("GetEntities returned error: %v", err)
 	}
@@ -191,7 +192,7 @@ func TestGetDiscoveryError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetDiscovery()
+	_, err = client.GetDiscovery(context.Background())
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -208,17 +209,17 @@ func TestDiscoveryHTTPErrors(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetRegistryCapabilities()
+	_, err = client.GetRegistryCapabilities(context.Background())
 	if err == nil {
 		t.Error("Expected error from GetRegistryCapabilities, got nil")
 	}
 
-	_, err = client.GetAppInfo(testClientID)
+	_, err = client.GetAppInfo(context.Background(), testClientID)
 	if err == nil {
 		t.Error("Expected error from GetAppInfo, got nil")
 	}
 
-	_, err = client.GetEntities("test", true, true)
+	_, err = client.GetEntities(context.Background(), "test", true, true)
 	if err == nil {
 		t.Error("Expected error from GetEntities, got nil")
 	}

--- a/lib/error.go
+++ b/lib/error.go
@@ -12,17 +12,18 @@ that can be returned by the Quay.io API.
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetErrorType retrieves details about a specific error type
-func (c *Client) GetErrorType(errorType string) (*ErrorType, error) {
+func (c *Client) GetErrorType(ctx context.Context, errorType string) (*ErrorType, error) {
 	if errorType == "" {
 		return nil, fmt.Errorf("errorType is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/error/%s", errorType), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/error/%s", errorType), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create error type request: %w", err)
 	}

--- a/lib/error_test.go
+++ b/lib/error_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -38,7 +39,7 @@ func TestGetErrorType(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	errType, err := client.GetErrorType(testErrorType)
+	errType, err := client.GetErrorType(context.Background(), testErrorType)
 	if err != nil {
 		t.Fatalf("GetErrorType returned error: %v", err)
 	}
@@ -62,7 +63,7 @@ func TestGetErrorTypeError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetErrorType("nonexistent_error")
+	_, err = client.GetErrorType(context.Background(), "nonexistent_error")
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}

--- a/lib/logs.go
+++ b/lib/logs.go
@@ -15,6 +15,7 @@ All log endpoints support pagination via next_page parameter.
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -42,7 +43,7 @@ func addLogQueryParams(req *http.Request, nextPage, startDate, endDate string) {
 }
 
 // GetAggregatedLogs returns the aggregated logs for a repository
-func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate string) (*AggregatedLogs, error) {
+func (c *Client) GetAggregatedLogs(ctx context.Context, namespace, repository, startDate, endDate string) (*AggregatedLogs, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -51,7 +52,7 @@ func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate str
 	}
 
 	// Get new request
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/aggregatelogs", namespace, repository), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/aggregatelogs", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repository aggregate logs request: %w", err)
 	}
@@ -71,7 +72,7 @@ func (c *Client) GetAggregatedLogs(namespace, repository, startDate, endDate str
 }
 
 // GetLogs returns the logs for a repository
-func (c *Client) GetLogs(namespace, repository, nextPage, startDate, endDate string) (*Logs, error) {
+func (c *Client) GetLogs(ctx context.Context, namespace, repository, nextPage, startDate, endDate string) (*Logs, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -79,7 +80,7 @@ func (c *Client) GetLogs(namespace, repository, nextPage, startDate, endDate str
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/logs", namespace, repository), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/logs", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repository logs request: %w", err)
 	}
@@ -95,12 +96,12 @@ func (c *Client) GetLogs(namespace, repository, nextPage, startDate, endDate str
 }
 
 // GetOrganizationLogs returns the logs for an organization
-func (c *Client) GetOrganizationLogs(orgname, nextPage, startDate, endDate string) (*Logs, error) {
+func (c *Client) GetOrganizationLogs(ctx context.Context, orgname, nextPage, startDate, endDate string) (*Logs, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/logs", orgname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/logs", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization logs request: %w", err)
 	}
@@ -116,12 +117,12 @@ func (c *Client) GetOrganizationLogs(orgname, nextPage, startDate, endDate strin
 }
 
 // GetOrganizationAggregatedLogs returns the aggregated logs for an organization
-func (c *Client) GetOrganizationAggregatedLogs(orgname, startDate, endDate string) (*AggregatedLogs, error) {
+func (c *Client) GetOrganizationAggregatedLogs(ctx context.Context, orgname, startDate, endDate string) (*AggregatedLogs, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/aggregatelogs", orgname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/aggregatelogs", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization aggregate logs request: %w", err)
 	}
@@ -140,12 +141,12 @@ func (c *Client) GetOrganizationAggregatedLogs(orgname, startDate, endDate strin
 }
 
 // ExportOrganizationLogs exports the logs for an organization
-func (c *Client) ExportOrganizationLogs(orgname string, request *ExportLogsRequest) error {
+func (c *Client) ExportOrganizationLogs(ctx context.Context, orgname string, request *ExportLogsRequest) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/exportlogs", orgname), request)
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/organization/%s/exportlogs", orgname), request)
 	if err != nil {
 		return fmt.Errorf("failed to create export organization logs request: %w", err)
 	}
@@ -158,8 +159,8 @@ func (c *Client) ExportOrganizationLogs(orgname string, request *ExportLogsReque
 }
 
 // GetUserLogs returns the logs for the current user
-func (c *Client) GetUserLogs(nextPage, startDate, endDate string) (*Logs, error) {
-	req, err := newRequest(http.MethodGet, c.buildURL("/user/logs"), nil)
+func (c *Client) GetUserLogs(ctx context.Context, nextPage, startDate, endDate string) (*Logs, error) {
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/user/logs"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user logs request: %w", err)
 	}
@@ -175,8 +176,8 @@ func (c *Client) GetUserLogs(nextPage, startDate, endDate string) (*Logs, error)
 }
 
 // GetUserAggregatedLogs returns the aggregated logs for the current user
-func (c *Client) GetUserAggregatedLogs(startDate, endDate string) (*AggregatedLogs, error) {
-	req, err := newRequest(http.MethodGet, c.buildURL("/user/aggregatelogs"), nil)
+func (c *Client) GetUserAggregatedLogs(ctx context.Context, startDate, endDate string) (*AggregatedLogs, error) {
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/user/aggregatelogs"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user aggregate logs request: %w", err)
 	}
@@ -195,8 +196,8 @@ func (c *Client) GetUserAggregatedLogs(startDate, endDate string) (*AggregatedLo
 }
 
 // ExportUserLogs exports the logs for the current user
-func (c *Client) ExportUserLogs(request *ExportLogsRequest) error {
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/user/exportlogs"), request)
+func (c *Client) ExportUserLogs(ctx context.Context, request *ExportLogsRequest) error {
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/user/exportlogs"), request)
 	if err != nil {
 		return fmt.Errorf("failed to create export user logs request: %w", err)
 	}
@@ -209,7 +210,7 @@ func (c *Client) ExportUserLogs(request *ExportLogsRequest) error {
 }
 
 // ExportRepositoryLogs exports the logs for a repository
-func (c *Client) ExportRepositoryLogs(namespace, repository string, request *ExportLogsRequest) error {
+func (c *Client) ExportRepositoryLogs(ctx context.Context, namespace, repository string, request *ExportLogsRequest) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -217,7 +218,7 @@ func (c *Client) ExportRepositoryLogs(namespace, repository string, request *Exp
 		return fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/exportlogs", namespace, repository), request)
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/repository/%s/%s/exportlogs", namespace, repository), request)
 	if err != nil {
 		return fmt.Errorf("failed to create export repository logs request: %w", err)
 	}

--- a/lib/logs_test.go
+++ b/lib/logs_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -50,7 +51,7 @@ func TestGetAggregatedLogs(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	logs, err := client.GetAggregatedLogs(testNamespace, testRepository, testStartDate, testEndDate)
+	logs, err := client.GetAggregatedLogs(context.Background(), testNamespace, testRepository, testStartDate, testEndDate)
 	if err != nil {
 		t.Fatalf("GetAggregatedLogs returned error: %v", err)
 	}
@@ -98,7 +99,7 @@ func TestGetLogs(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	logs, err := client.GetLogs(testNamespace, testRepository, "", "", "")
+	logs, err := client.GetLogs(context.Background(), testNamespace, testRepository, "", "", "")
 	if err != nil {
 		t.Fatalf("GetLogs returned error: %v", err)
 	}
@@ -134,7 +135,7 @@ func TestGetLogsWithDateRange(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetLogs(testNamespace, testRepository, "", testStartDate, testEndDate)
+	_, err = client.GetLogs(context.Background(), testNamespace, testRepository, "", testStartDate, testEndDate)
 	if err != nil {
 		t.Fatalf("GetLogs with date range returned error: %v", err)
 	}
@@ -157,7 +158,7 @@ func TestGetLogsWithNextPage(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetLogs(testNamespace, testRepository, testNextPage, "", "")
+	_, err = client.GetLogs(context.Background(), testNamespace, testRepository, testNextPage, "", "")
 	if err != nil {
 		t.Fatalf("GetLogs with next page returned error: %v", err)
 	}
@@ -187,7 +188,7 @@ func TestGetOrganizationLogsWithDateRange(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetOrganizationLogs(testNamespace, "", testStartDate, testEndDateMay)
+	_, err = client.GetOrganizationLogs(context.Background(), testNamespace, "", testStartDate, testEndDateMay)
 	if err != nil {
 		t.Fatalf("GetOrganizationLogs with date range returned error: %v", err)
 	}
@@ -217,7 +218,7 @@ func TestGetUserLogsWithDateRange(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetUserLogs("", testStartDate, testEndDateMay)
+	_, err = client.GetUserLogs(context.Background(), "", testStartDate, testEndDateMay)
 	if err != nil {
 		t.Fatalf("GetUserLogs with date range returned error: %v", err)
 	}
@@ -255,7 +256,7 @@ func TestGetOrganizationAggregatedLogs(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	logs, err := client.GetOrganizationAggregatedLogs(testNamespace, testStartDate, testEndDateMay)
+	logs, err := client.GetOrganizationAggregatedLogs(context.Background(), testNamespace, testStartDate, testEndDateMay)
 	if err != nil {
 		t.Fatalf("GetOrganizationAggregatedLogs returned error: %v", err)
 	}
@@ -292,7 +293,7 @@ func TestExportOrganizationLogs(t *testing.T) {
 		CallbackURL: "https://example.com/callback",
 	}
 
-	err = client.ExportOrganizationLogs(testNamespace, exportReq)
+	err = client.ExportOrganizationLogs(context.Background(), testNamespace, exportReq)
 	if err != nil {
 		t.Fatalf("ExportOrganizationLogs returned error: %v", err)
 	}
@@ -330,7 +331,7 @@ func TestGetUserAggregatedLogs(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	logs, err := client.GetUserAggregatedLogs(testStartDate, testEndDateMay)
+	logs, err := client.GetUserAggregatedLogs(context.Background(), testStartDate, testEndDateMay)
 	if err != nil {
 		t.Fatalf("GetUserAggregatedLogs returned error: %v", err)
 	}
@@ -367,7 +368,7 @@ func TestExportUserLogs(t *testing.T) {
 		Email:     testEmailAddress,
 	}
 
-	err = client.ExportUserLogs(exportReq)
+	err = client.ExportUserLogs(context.Background(), exportReq)
 	if err != nil {
 		t.Fatalf("ExportUserLogs returned error: %v", err)
 	}
@@ -397,7 +398,7 @@ func TestExportRepositoryLogs(t *testing.T) {
 		CallbackURL: "https://example.com/callback",
 	}
 
-	err = client.ExportRepositoryLogs(testNamespace, testRepository, exportReq)
+	err = client.ExportRepositoryLogs(context.Background(), testNamespace, testRepository, exportReq)
 	if err != nil {
 		t.Fatalf("ExportRepositoryLogs returned error: %v", err)
 	}
@@ -414,7 +415,7 @@ func TestGetAggregatedLogsError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetAggregatedLogs(testNamespace, testRepository, "", "")
+	_, err = client.GetAggregatedLogs(context.Background(), testNamespace, testRepository, "", "")
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -431,7 +432,7 @@ func TestGetLogsError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetLogs(testNamespace, testRepository, "", "", "")
+	_, err = client.GetLogs(context.Background(), testNamespace, testRepository, "", "", "")
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -448,37 +449,37 @@ func TestLogsHTTPErrors(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetOrganizationLogs(testNamespace, "", "", "")
+	_, err = client.GetOrganizationLogs(context.Background(), testNamespace, "", "", "")
 	if err == nil {
 		t.Error("Expected error from GetOrganizationLogs, got nil")
 	}
 
-	_, err = client.GetOrganizationAggregatedLogs(testNamespace, testStartDate, testEndDateMay)
+	_, err = client.GetOrganizationAggregatedLogs(context.Background(), testNamespace, testStartDate, testEndDateMay)
 	if err == nil {
 		t.Error("Expected error from GetOrganizationAggregatedLogs, got nil")
 	}
 
-	err = client.ExportOrganizationLogs(testNamespace, &ExportLogsRequest{StartTime: testStartDate, EndTime: testEndDateMay})
+	err = client.ExportOrganizationLogs(context.Background(), testNamespace, &ExportLogsRequest{StartTime: testStartDate, EndTime: testEndDateMay})
 	if err == nil {
 		t.Error("Expected error from ExportOrganizationLogs, got nil")
 	}
 
-	_, err = client.GetUserLogs("", testStartDate, testEndDateMay)
+	_, err = client.GetUserLogs(context.Background(), "", testStartDate, testEndDateMay)
 	if err == nil {
 		t.Error("Expected error from GetUserLogs, got nil")
 	}
 
-	_, err = client.GetUserAggregatedLogs(testStartDate, testEndDateMay)
+	_, err = client.GetUserAggregatedLogs(context.Background(), testStartDate, testEndDateMay)
 	if err == nil {
 		t.Error("Expected error from GetUserAggregatedLogs, got nil")
 	}
 
-	err = client.ExportUserLogs(&ExportLogsRequest{StartTime: testStartDate, EndTime: testEndDateMay})
+	err = client.ExportUserLogs(context.Background(), &ExportLogsRequest{StartTime: testStartDate, EndTime: testEndDateMay})
 	if err == nil {
 		t.Error("Expected error from ExportUserLogs, got nil")
 	}
 
-	err = client.ExportRepositoryLogs(testNamespace, testRepository, &ExportLogsRequest{StartTime: testStartDate, EndTime: testEndDateMay})
+	err = client.ExportRepositoryLogs(context.Background(), testNamespace, testRepository, &ExportLogsRequest{StartTime: testStartDate, EndTime: testEndDateMay})
 	if err == nil {
 		t.Error("Expected error from ExportRepositoryLogs, got nil")
 	}

--- a/lib/manifest.go
+++ b/lib/manifest.go
@@ -19,12 +19,13 @@ configuration, and labels for inspection and management.
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetManifest retrieves detailed information about a specific manifest
-func (c *Client) GetManifest(namespace, repository, manifestRef string) (*Manifest, error) {
+func (c *Client) GetManifest(ctx context.Context, namespace, repository, manifestRef string) (*Manifest, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -35,7 +36,7 @@ func (c *Client) GetManifest(namespace, repository, manifestRef string) (*Manife
 		return nil, fmt.Errorf("manifestRef is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/manifest/%s", namespace, repository, manifestRef), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/manifest/%s", namespace, repository, manifestRef), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest request: %w", err)
 	}
@@ -49,7 +50,7 @@ func (c *Client) GetManifest(namespace, repository, manifestRef string) (*Manife
 }
 
 // DeleteManifest deletes a specific manifest from a repository
-func (c *Client) DeleteManifest(namespace, repository, manifestRef string) error {
+func (c *Client) DeleteManifest(ctx context.Context, namespace, repository, manifestRef string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -60,7 +61,7 @@ func (c *Client) DeleteManifest(namespace, repository, manifestRef string) error
 		return fmt.Errorf("manifestRef is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/manifest/%s", namespace, repository, manifestRef), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/repository/%s/%s/manifest/%s", namespace, repository, manifestRef), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete manifest request: %w", err)
 	}
@@ -73,7 +74,7 @@ func (c *Client) DeleteManifest(namespace, repository, manifestRef string) error
 }
 
 // GetManifestLabels retrieves all labels for a specific manifest
-func (c *Client) GetManifestLabels(namespace, repository, manifestRef string) (*ManifestLabels, error) {
+func (c *Client) GetManifestLabels(ctx context.Context, namespace, repository, manifestRef string) (*ManifestLabels, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -84,7 +85,7 @@ func (c *Client) GetManifestLabels(namespace, repository, manifestRef string) (*
 		return nil, fmt.Errorf("manifestRef is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/manifest/%s/labels", namespace, repository, manifestRef), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/manifest/%s/labels", namespace, repository, manifestRef), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest labels request: %w", err)
 	}
@@ -98,7 +99,7 @@ func (c *Client) GetManifestLabels(namespace, repository, manifestRef string) (*
 }
 
 // AddManifestLabel adds a label to a specific manifest
-func (c *Client) AddManifestLabel(namespace, repository, manifestRef, key, value, mediaType string) (*ManifestLabel, error) {
+func (c *Client) AddManifestLabel(ctx context.Context, namespace, repository, manifestRef, key, value, mediaType string) (*ManifestLabel, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -124,7 +125,7 @@ func (c *Client) AddManifestLabel(namespace, repository, manifestRef, key, value
 		addReq.MediaType = mediaType
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/manifest/%s/labels", namespace, repository, manifestRef), addReq)
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/repository/%s/%s/manifest/%s/labels", namespace, repository, manifestRef), addReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create add manifest label request: %w", err)
 	}
@@ -138,7 +139,7 @@ func (c *Client) AddManifestLabel(namespace, repository, manifestRef, key, value
 }
 
 // GetManifestLabel retrieves a specific label from a manifest
-func (c *Client) GetManifestLabel(namespace, repository, manifestRef, labelID string) (*ManifestLabel, error) {
+func (c *Client) GetManifestLabel(ctx context.Context, namespace, repository, manifestRef, labelID string) (*ManifestLabel, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -152,7 +153,7 @@ func (c *Client) GetManifestLabel(namespace, repository, manifestRef, labelID st
 		return nil, fmt.Errorf("labelID is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/manifest/%s/labels/%s", namespace, repository, manifestRef, labelID), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/manifest/%s/labels/%s", namespace, repository, manifestRef, labelID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest label request: %w", err)
 	}
@@ -166,7 +167,7 @@ func (c *Client) GetManifestLabel(namespace, repository, manifestRef, labelID st
 }
 
 // DeleteManifestLabel deletes a specific label from a manifest
-func (c *Client) DeleteManifestLabel(namespace, repository, manifestRef, labelID string) error {
+func (c *Client) DeleteManifestLabel(ctx context.Context, namespace, repository, manifestRef, labelID string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -180,7 +181,7 @@ func (c *Client) DeleteManifestLabel(namespace, repository, manifestRef, labelID
 		return fmt.Errorf("labelID is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/manifest/%s/labels/%s", namespace, repository, manifestRef, labelID), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/repository/%s/%s/manifest/%s/labels/%s", namespace, repository, manifestRef, labelID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete manifest label request: %w", err)
 	}

--- a/lib/manifest_test.go
+++ b/lib/manifest_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -61,7 +62,7 @@ func TestGetManifest(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	manifest, err := client.GetManifest(testNamespace, testRepository, testManifestRef)
+	manifest, err := client.GetManifest(context.Background(), testNamespace, testRepository, testManifestRef)
 	if err != nil {
 		t.Fatalf("GetManifest failed: %v", err)
 	}
@@ -98,7 +99,7 @@ func TestDeleteManifest(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteManifest(testNamespace, testRepository, testManifestRef)
+	err = client.DeleteManifest(context.Background(), testNamespace, testRepository, testManifestRef)
 	if err != nil {
 		t.Fatalf("DeleteManifest failed: %v", err)
 	}
@@ -145,7 +146,7 @@ func TestGetManifestLabels(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	labels, err := client.GetManifestLabels(testNamespace, testRepository, testManifestRef)
+	labels, err := client.GetManifestLabels(context.Background(), testNamespace, testRepository, testManifestRef)
 	if err != nil {
 		t.Fatalf("GetManifestLabels failed: %v", err)
 	}
@@ -204,7 +205,7 @@ func TestAddManifestLabel(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	label, err := client.AddManifestLabel(testNamespace, testRepository, testManifestRef, testLabelKeyEnvironment, testLabelValProduction, testMediaTypePlain)
+	label, err := client.AddManifestLabel(context.Background(), testNamespace, testRepository, testManifestRef, testLabelKeyEnvironment, testLabelValProduction, testMediaTypePlain)
 	if err != nil {
 		t.Fatalf("AddManifestLabel failed: %v", err)
 	}
@@ -251,7 +252,7 @@ func TestGetManifestLabel(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	label, err := client.GetManifestLabel(testNamespace, testRepository, testManifestRef, testLabelID)
+	label, err := client.GetManifestLabel(context.Background(), testNamespace, testRepository, testManifestRef, testLabelID)
 	if err != nil {
 		t.Fatalf("GetManifestLabel failed: %v", err)
 	}
@@ -283,7 +284,7 @@ func TestDeleteManifestLabel(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteManifestLabel(testNamespace, testRepository, testManifestRef, testLabelID)
+	err = client.DeleteManifestLabel(context.Background(), testNamespace, testRepository, testManifestRef, testLabelID)
 	if err != nil {
 		t.Fatalf("DeleteManifestLabel failed: %v", err)
 	}
@@ -303,37 +304,37 @@ func TestManifestErrorHandling(t *testing.T) {
 	}
 
 	// Test GetManifest error
-	_, err = client.GetManifest(testNamespace, testRepository, "nonexistent")
+	_, err = client.GetManifest(context.Background(), testNamespace, testRepository, "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent manifest, got nil")
 	}
 
 	// Test DeleteManifest error
-	err = client.DeleteManifest(testNamespace, testRepository, "nonexistent")
+	err = client.DeleteManifest(context.Background(), testNamespace, testRepository, "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent manifest, got nil")
 	}
 
 	// Test GetManifestLabels error
-	_, err = client.GetManifestLabels(testNamespace, testRepository, "nonexistent")
+	_, err = client.GetManifestLabels(context.Background(), testNamespace, testRepository, "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent manifest, got nil")
 	}
 
 	// Test AddManifestLabel error
-	_, err = client.AddManifestLabel(testNamespace, testRepository, "nonexistent", "key", "value", "")
+	_, err = client.AddManifestLabel(context.Background(), testNamespace, testRepository, "nonexistent", "key", "value", "")
 	if err == nil {
 		t.Error("Expected error for non-existent manifest, got nil")
 	}
 
 	// Test GetManifestLabel error
-	_, err = client.GetManifestLabel(testNamespace, testRepository, "nonexistent", "labelid")
+	_, err = client.GetManifestLabel(context.Background(), testNamespace, testRepository, "nonexistent", "labelid")
 	if err == nil {
 		t.Error("Expected error for non-existent manifest label, got nil")
 	}
 
 	// Test DeleteManifestLabel error
-	err = client.DeleteManifestLabel(testNamespace, testRepository, "nonexistent", "labelid")
+	err = client.DeleteManifestLabel(context.Background(), testNamespace, testRepository, "nonexistent", "labelid")
 	if err == nil {
 		t.Error("Expected error for non-existent manifest label, got nil")
 	}

--- a/lib/messages.go
+++ b/lib/messages.go
@@ -12,13 +12,14 @@ such as maintenance notifications or important announcements.
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetMessages retrieves system messages for the user
-func (c *Client) GetMessages() (*Messages, error) {
-	req, err := newRequest(http.MethodGet, c.buildURL("/messages"), nil)
+func (c *Client) GetMessages(ctx context.Context) (*Messages, error) {
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/messages"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create messages request: %w", err)
 	}
@@ -32,7 +33,7 @@ func (c *Client) GetMessages() (*Messages, error) {
 }
 
 // CreateMessage creates a new global message (admin only)
-func (c *Client) CreateMessage(content, severity, mediaType string) (*Message, error) {
+func (c *Client) CreateMessage(ctx context.Context, content, severity, mediaType string) (*Message, error) {
 	if content == "" {
 		return nil, fmt.Errorf("content is required")
 	}
@@ -58,7 +59,7 @@ func (c *Client) CreateMessage(content, severity, mediaType string) (*Message, e
 		},
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/messages"), body)
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/messages"), body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create message request: %w", err)
 	}

--- a/lib/messages_test.go
+++ b/lib/messages_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -44,7 +45,7 @@ func TestGetMessages(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	messages, err := client.GetMessages()
+	messages, err := client.GetMessages(context.Background())
 	if err != nil {
 		t.Fatalf("GetMessages returned error: %v", err)
 	}
@@ -74,7 +75,7 @@ func TestGetMessagesEmpty(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	messages, err := client.GetMessages()
+	messages, err := client.GetMessages(context.Background())
 	if err != nil {
 		t.Fatalf("GetMessages returned error: %v", err)
 	}
@@ -112,7 +113,7 @@ func TestCreateMessage(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	message, err := client.CreateMessage("System maintenance scheduled", "warning", testMediaTypePlain)
+	message, err := client.CreateMessage(context.Background(), "System maintenance scheduled", "warning", testMediaTypePlain)
 	if err != nil {
 		t.Fatalf("CreateMessage returned error: %v", err)
 	}
@@ -136,7 +137,7 @@ func TestGetMessagesError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetMessages()
+	_, err = client.GetMessages(context.Background())
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -153,7 +154,7 @@ func TestMessagesHTTPErrors(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.CreateMessage("test content", "info", testMediaTypePlain)
+	_, err = client.CreateMessage(context.Background(), "test content", "info", testMediaTypePlain)
 	if err == nil {
 		t.Error("Expected error from CreateMessage, got nil")
 	}

--- a/lib/mirror.go
+++ b/lib/mirror.go
@@ -11,12 +11,13 @@ Repository Mirror Configuration:
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetMirrorConfig retrieves mirror configuration for a repository
-func (c *Client) GetMirrorConfig(namespace, repository string) (*MirrorConfig, error) {
+func (c *Client) GetMirrorConfig(ctx context.Context, namespace, repository string) (*MirrorConfig, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -24,7 +25,7 @@ func (c *Client) GetMirrorConfig(namespace, repository string) (*MirrorConfig, e
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/mirror", namespace, repository), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/mirror", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get mirror config request: %w", err)
 	}
@@ -38,7 +39,7 @@ func (c *Client) GetMirrorConfig(namespace, repository string) (*MirrorConfig, e
 }
 
 // CreateMirrorConfig creates mirror configuration for a repository
-func (c *Client) CreateMirrorConfig(namespace, repository string, config *CreateMirrorConfigRequest) (*MirrorConfig, error) {
+func (c *Client) CreateMirrorConfig(ctx context.Context, namespace, repository string, config *CreateMirrorConfigRequest) (*MirrorConfig, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -46,7 +47,7 @@ func (c *Client) CreateMirrorConfig(namespace, repository string, config *Create
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/mirror", namespace, repository), config)
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/repository/%s/%s/mirror", namespace, repository), config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create mirror config request: %w", err)
 	}
@@ -60,7 +61,7 @@ func (c *Client) CreateMirrorConfig(namespace, repository string, config *Create
 }
 
 // UpdateMirrorConfig updates mirror configuration for a repository
-func (c *Client) UpdateMirrorConfig(namespace, repository string, config *UpdateMirrorConfigRequest) (*MirrorConfig, error) {
+func (c *Client) UpdateMirrorConfig(ctx context.Context, namespace, repository string, config *UpdateMirrorConfigRequest) (*MirrorConfig, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -68,7 +69,7 @@ func (c *Client) UpdateMirrorConfig(namespace, repository string, config *Update
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s/mirror", namespace, repository), config)
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/repository/%s/%s/mirror", namespace, repository), config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update mirror config request: %w", err)
 	}

--- a/lib/mirror_test.go
+++ b/lib/mirror_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -37,7 +38,7 @@ func TestGetMirrorConfig(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	config, err := client.GetMirrorConfig(testNamespace, testRepository)
+	config, err := client.GetMirrorConfig(context.Background(), testNamespace, testRepository)
 	if err != nil {
 		t.Fatalf("GetMirrorConfig returned error: %v", err)
 	}
@@ -77,7 +78,7 @@ func TestCreateMirrorConfig(t *testing.T) {
 		RobotUsername: "org+robot",
 	}
 
-	config, err := client.CreateMirrorConfig(testNamespace, testRepository, createReq)
+	config, err := client.CreateMirrorConfig(context.Background(), testNamespace, testRepository, createReq)
 	if err != nil {
 		t.Fatalf("CreateMirrorConfig returned error: %v", err)
 	}
@@ -115,7 +116,7 @@ func TestUpdateMirrorConfig(t *testing.T) {
 		IsEnabled: &enabled,
 	}
 
-	config, err := client.UpdateMirrorConfig(testNamespace, testRepository, updateReq)
+	config, err := client.UpdateMirrorConfig(context.Background(), testNamespace, testRepository, updateReq)
 	if err != nil {
 		t.Fatalf("UpdateMirrorConfig returned error: %v", err)
 	}
@@ -137,17 +138,17 @@ func TestMirrorConfigHTTPErrors(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetMirrorConfig(testNamespace, testRepository)
+	_, err = client.GetMirrorConfig(context.Background(), testNamespace, testRepository)
 	if err == nil {
 		t.Error("Expected error from GetMirrorConfig, got nil")
 	}
 
-	_, err = client.CreateMirrorConfig(testNamespace, testRepository, &CreateMirrorConfigRequest{})
+	_, err = client.CreateMirrorConfig(context.Background(), testNamespace, testRepository, &CreateMirrorConfigRequest{})
 	if err == nil {
 		t.Error("Expected error from CreateMirrorConfig, got nil")
 	}
 
-	_, err = client.UpdateMirrorConfig(testNamespace, testRepository, &UpdateMirrorConfigRequest{})
+	_, err = client.UpdateMirrorConfig(context.Background(), testNamespace, testRepository, &UpdateMirrorConfigRequest{})
 	if err == nil {
 		t.Error("Expected error from UpdateMirrorConfig, got nil")
 	}
@@ -156,12 +157,12 @@ func TestMirrorConfigHTTPErrors(t *testing.T) {
 func TestMirrorConfigValidation(t *testing.T) {
 	client, _ := NewClient(testTokenValue)
 
-	_, err := client.GetMirrorConfig("", testRepository)
+	_, err := client.GetMirrorConfig(context.Background(), "", testRepository)
 	if err == nil {
 		t.Error("Expected error for empty namespace")
 	}
 
-	_, err = client.GetMirrorConfig(testNamespace, "")
+	_, err = client.GetMirrorConfig(context.Background(), testNamespace, "")
 	if err == nil {
 		t.Error("Expected error for empty repository")
 	}

--- a/lib/notification.go
+++ b/lib/notification.go
@@ -33,12 +33,13 @@ Supported methods:
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetNotifications retrieves all notifications for a repository
-func (c *Client) GetNotifications(namespace, repository string) (*RepositoryNotifications, error) {
+func (c *Client) GetNotifications(ctx context.Context, namespace, repository string) (*RepositoryNotifications, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -46,7 +47,7 @@ func (c *Client) GetNotifications(namespace, repository string) (*RepositoryNoti
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/notification/", namespace, repository), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/notification/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get notifications request: %w", err)
 	}
@@ -60,7 +61,7 @@ func (c *Client) GetNotifications(namespace, repository string) (*RepositoryNoti
 }
 
 // GetNotification retrieves a specific notification by UUID
-func (c *Client) GetNotification(namespace, repository, uuid string) (*RepositoryNotification, error) {
+func (c *Client) GetNotification(ctx context.Context, namespace, repository, uuid string) (*RepositoryNotification, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -71,7 +72,7 @@ func (c *Client) GetNotification(namespace, repository, uuid string) (*Repositor
 		return nil, fmt.Errorf("uuid is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/notification/%s", namespace, repository, uuid), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/notification/%s", namespace, repository, uuid), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get notification request: %w", err)
 	}
@@ -85,7 +86,7 @@ func (c *Client) GetNotification(namespace, repository, uuid string) (*Repositor
 }
 
 // CreateNotification creates a new notification for a repository
-func (c *Client) CreateNotification(namespace, repository string, notificationReq *CreateNotificationRequest) (*RepositoryNotification, error) {
+func (c *Client) CreateNotification(ctx context.Context, namespace, repository string, notificationReq *CreateNotificationRequest) (*RepositoryNotification, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -93,7 +94,7 @@ func (c *Client) CreateNotification(namespace, repository string, notificationRe
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/notification/", namespace, repository), notificationReq)
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/repository/%s/%s/notification/", namespace, repository), notificationReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create notification request: %w", err)
 	}
@@ -107,7 +108,7 @@ func (c *Client) CreateNotification(namespace, repository string, notificationRe
 }
 
 // DeleteNotification deletes a notification from a repository
-func (c *Client) DeleteNotification(namespace, repository, uuid string) error {
+func (c *Client) DeleteNotification(ctx context.Context, namespace, repository, uuid string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -118,7 +119,7 @@ func (c *Client) DeleteNotification(namespace, repository, uuid string) error {
 		return fmt.Errorf("uuid is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/notification/%s", namespace, repository, uuid), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/repository/%s/%s/notification/%s", namespace, repository, uuid), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete notification request: %w", err)
 	}
@@ -131,7 +132,7 @@ func (c *Client) DeleteNotification(namespace, repository, uuid string) error {
 }
 
 // TestNotification tests a notification by sending a test event
-func (c *Client) TestNotification(namespace, repository, uuid string) error {
+func (c *Client) TestNotification(ctx context.Context, namespace, repository, uuid string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -142,7 +143,7 @@ func (c *Client) TestNotification(namespace, repository, uuid string) error {
 		return fmt.Errorf("uuid is required")
 	}
 
-	req, err := newRequest(http.MethodPost, c.buildURL("/repository/%s/%s/notification/%s/test", namespace, repository, uuid), nil)
+	req, err := newRequest(ctx, http.MethodPost, c.buildURL("/repository/%s/%s/notification/%s/test", namespace, repository, uuid), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create test notification request: %w", err)
 	}
@@ -155,7 +156,7 @@ func (c *Client) TestNotification(namespace, repository, uuid string) error {
 }
 
 // ResetNotification resets failure count for a notification
-func (c *Client) ResetNotification(namespace, repository, uuid string) error {
+func (c *Client) ResetNotification(ctx context.Context, namespace, repository, uuid string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -166,7 +167,7 @@ func (c *Client) ResetNotification(namespace, repository, uuid string) error {
 		return fmt.Errorf("uuid is required")
 	}
 
-	req, err := newRequest(http.MethodPost, c.buildURL("/repository/%s/%s/notification/%s/reset", namespace, repository, uuid), nil)
+	req, err := newRequest(ctx, http.MethodPost, c.buildURL("/repository/%s/%s/notification/%s/reset", namespace, repository, uuid), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create reset notification request: %w", err)
 	}
@@ -179,7 +180,7 @@ func (c *Client) ResetNotification(namespace, repository, uuid string) error {
 }
 
 // UpdateNotification updates an existing notification
-func (c *Client) UpdateNotification(namespace, repository, uuid string, notificationReq *CreateNotificationRequest) (*RepositoryNotification, error) {
+func (c *Client) UpdateNotification(ctx context.Context, namespace, repository, uuid string, notificationReq *CreateNotificationRequest) (*RepositoryNotification, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -190,7 +191,7 @@ func (c *Client) UpdateNotification(namespace, repository, uuid string, notifica
 		return nil, fmt.Errorf("uuid is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/notification/%s", namespace, repository, uuid), notificationReq)
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/repository/%s/%s/notification/%s", namespace, repository, uuid), notificationReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update notification request: %w", err)
 	}

--- a/lib/notification_test.go
+++ b/lib/notification_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -44,7 +45,7 @@ func TestGetNotifications(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	notifications, err := client.GetNotifications(testNamespace, testRepository)
+	notifications, err := client.GetNotifications(context.Background(), testNamespace, testRepository)
 	if err != nil {
 		t.Fatalf("GetNotifications returned error: %v", err)
 	}
@@ -85,7 +86,7 @@ func TestGetNotification(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	notification, err := client.GetNotification(testNamespace, testRepository, testNotificationUUID)
+	notification, err := client.GetNotification(context.Background(), testNamespace, testRepository, testNotificationUUID)
 	if err != nil {
 		t.Fatalf("GetNotification returned error: %v", err)
 	}
@@ -133,7 +134,7 @@ func TestCreateNotification(t *testing.T) {
 		Title:  "New Webhook",
 	}
 
-	notification, err := client.CreateNotification(testNamespace, testRepository, notificationReq)
+	notification, err := client.CreateNotification(context.Background(), testNamespace, testRepository, notificationReq)
 	if err != nil {
 		t.Fatalf("CreateNotification returned error: %v", err)
 	}
@@ -161,7 +162,7 @@ func TestDeleteNotification(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteNotification(testNamespace, testRepository, testNotificationUUID)
+	err = client.DeleteNotification(context.Background(), testNamespace, testRepository, testNotificationUUID)
 	if err != nil {
 		t.Fatalf("DeleteNotification returned error: %v", err)
 	}
@@ -185,7 +186,7 @@ func TestTestNotification(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.TestNotification(testNamespace, testRepository, testNotificationUUID)
+	err = client.TestNotification(context.Background(), testNamespace, testRepository, testNotificationUUID)
 	if err != nil {
 		t.Fatalf("TestNotification returned error: %v", err)
 	}
@@ -209,7 +210,7 @@ func TestResetNotification(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.ResetNotification(testNamespace, testRepository, testNotificationUUID)
+	err = client.ResetNotification(context.Background(), testNamespace, testRepository, testNotificationUUID)
 	if err != nil {
 		t.Fatalf("ResetNotification returned error: %v", err)
 	}
@@ -250,7 +251,7 @@ func TestUpdateNotification(t *testing.T) {
 		Title:  testNotificationTitleUpdated,
 	}
 
-	notification, err := client.UpdateNotification(testNamespace, testRepository, testNotificationUUID, notificationReq)
+	notification, err := client.UpdateNotification(context.Background(), testNamespace, testRepository, testNotificationUUID, notificationReq)
 	if err != nil {
 		t.Fatalf("UpdateNotification returned error: %v", err)
 	}
@@ -274,7 +275,7 @@ func TestGetNotificationsError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetNotifications(testNamespace, testRepository)
+	_, err = client.GetNotifications(context.Background(), testNamespace, testRepository)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -291,7 +292,7 @@ func TestGetNotificationError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetNotification(testNamespace, testRepository, "nonexistent-uuid")
+	_, err = client.GetNotification(context.Background(), testNamespace, testRepository, "nonexistent-uuid")
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -308,7 +309,7 @@ func TestNotificationHTTPErrors(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.CreateNotification(testNamespace, testRepository, &CreateNotificationRequest{
+	_, err = client.CreateNotification(context.Background(), testNamespace, testRepository, &CreateNotificationRequest{
 		Event:  testNotificationEvent,
 		Method: testNotificationMethod,
 		Title:  "Test",
@@ -317,22 +318,22 @@ func TestNotificationHTTPErrors(t *testing.T) {
 		t.Error("Expected error from CreateNotification, got nil")
 	}
 
-	err = client.DeleteNotification(testNamespace, testRepository, testNotificationUUID)
+	err = client.DeleteNotification(context.Background(), testNamespace, testRepository, testNotificationUUID)
 	if err == nil {
 		t.Error("Expected error from DeleteNotification, got nil")
 	}
 
-	err = client.TestNotification(testNamespace, testRepository, testNotificationUUID)
+	err = client.TestNotification(context.Background(), testNamespace, testRepository, testNotificationUUID)
 	if err == nil {
 		t.Error("Expected error from TestNotification, got nil")
 	}
 
-	err = client.ResetNotification(testNamespace, testRepository, testNotificationUUID)
+	err = client.ResetNotification(context.Background(), testNamespace, testRepository, testNotificationUUID)
 	if err == nil {
 		t.Error("Expected error from ResetNotification, got nil")
 	}
 
-	_, err = client.UpdateNotification(testNamespace, testRepository, testNotificationUUID, &CreateNotificationRequest{
+	_, err = client.UpdateNotification(context.Background(), testNamespace, testRepository, testNotificationUUID, &CreateNotificationRequest{
 		Event:  testNotificationEvent,
 		Method: testNotificationMethod,
 		Title:  "Updated",

--- a/lib/org_marketplace.go
+++ b/lib/org_marketplace.go
@@ -12,17 +12,18 @@ Marketplace Management:
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetOrganizationMarketplace gets marketplace information for an organization
-func (c *Client) GetOrganizationMarketplace(orgname string) (*MarketplaceInfo, error) {
+func (c *Client) GetOrganizationMarketplace(ctx context.Context, orgname string) (*MarketplaceInfo, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/marketplace", orgname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/marketplace", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization marketplace request: %w", err)
 	}
@@ -36,12 +37,12 @@ func (c *Client) GetOrganizationMarketplace(orgname string) (*MarketplaceInfo, e
 }
 
 // CreateOrganizationMarketplaceSubscription creates a marketplace subscription
-func (c *Client) CreateOrganizationMarketplaceSubscription(orgname string, subscription *MarketplaceSubscriptionRequest) error {
+func (c *Client) CreateOrganizationMarketplaceSubscription(ctx context.Context, orgname string, subscription *MarketplaceSubscriptionRequest) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/marketplace", orgname), subscription)
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/organization/%s/marketplace", orgname), subscription)
 	if err != nil {
 		return fmt.Errorf("failed to create marketplace subscription request: %w", err)
 	}
@@ -54,7 +55,7 @@ func (c *Client) CreateOrganizationMarketplaceSubscription(orgname string, subsc
 }
 
 // BatchRemoveOrganizationMarketplaceSubscriptions removes multiple marketplace subscriptions
-func (c *Client) BatchRemoveOrganizationMarketplaceSubscriptions(orgname string, subscriptionIDs []string) error {
+func (c *Client) BatchRemoveOrganizationMarketplaceSubscriptions(ctx context.Context, orgname string, subscriptionIDs []string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -64,7 +65,7 @@ func (c *Client) BatchRemoveOrganizationMarketplaceSubscriptions(orgname string,
 	}{
 		SubscriptionIDs: subscriptionIDs,
 	}
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/marketplace/batchremove", orgname), body)
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/organization/%s/marketplace/batchremove", orgname), body)
 	if err != nil {
 		return fmt.Errorf("failed to create batch remove marketplace subscriptions request: %w", err)
 	}
@@ -77,7 +78,7 @@ func (c *Client) BatchRemoveOrganizationMarketplaceSubscriptions(orgname string,
 }
 
 // DeleteOrganizationMarketplaceSubscription removes a specific marketplace subscription
-func (c *Client) DeleteOrganizationMarketplaceSubscription(orgname, subscriptionID string) error {
+func (c *Client) DeleteOrganizationMarketplaceSubscription(ctx context.Context, orgname, subscriptionID string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -85,7 +86,7 @@ func (c *Client) DeleteOrganizationMarketplaceSubscription(orgname, subscription
 		return fmt.Errorf("subscriptionID is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/marketplace/%s", orgname, subscriptionID), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/organization/%s/marketplace/%s", orgname, subscriptionID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete marketplace subscription request: %w", err)
 	}

--- a/lib/org_marketplace_test.go
+++ b/lib/org_marketplace_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -36,7 +37,7 @@ func TestGetOrganizationMarketplace(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	marketplace, err := client.GetOrganizationMarketplace(testOrgName)
+	marketplace, err := client.GetOrganizationMarketplace(context.Background(), testOrgName)
 	if err != nil {
 		t.Fatalf("GetOrganizationMarketplace returned error: %v", err)
 	}
@@ -75,7 +76,7 @@ func TestCreateOrganizationMarketplaceSubscription(t *testing.T) {
 		Quantity: 1,
 	}
 
-	err = client.CreateOrganizationMarketplaceSubscription(testOrgName, subReq)
+	err = client.CreateOrganizationMarketplaceSubscription(context.Background(), testOrgName, subReq)
 	if err != nil {
 		t.Fatalf("CreateOrganizationMarketplaceSubscription returned error: %v", err)
 	}
@@ -99,7 +100,7 @@ func TestBatchRemoveOrganizationMarketplaceSubscriptions(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.BatchRemoveOrganizationMarketplaceSubscriptions(testOrgName, []string{testSubscriptionID, "sub-456"})
+	err = client.BatchRemoveOrganizationMarketplaceSubscriptions(context.Background(), testOrgName, []string{testSubscriptionID, "sub-456"})
 	if err != nil {
 		t.Fatalf("BatchRemoveOrganizationMarketplaceSubscriptions returned error: %v", err)
 	}
@@ -123,7 +124,7 @@ func TestDeleteOrganizationMarketplaceSubscription(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteOrganizationMarketplaceSubscription(testOrgName, testSubscriptionID)
+	err = client.DeleteOrganizationMarketplaceSubscription(context.Background(), testOrgName, testSubscriptionID)
 	if err != nil {
 		t.Fatalf("DeleteOrganizationMarketplaceSubscription returned error: %v", err)
 	}
@@ -132,22 +133,22 @@ func TestDeleteOrganizationMarketplaceSubscription(t *testing.T) {
 func TestMarketplaceHTTPErrors(t *testing.T) {
 	client := newOrgErrorClient(t)
 
-	_, err := client.GetOrganizationMarketplace(testOrgName)
+	_, err := client.GetOrganizationMarketplace(context.Background(), testOrgName)
 	if err == nil {
 		t.Error("Expected error from GetOrganizationMarketplace, got nil")
 	}
 
-	err = client.CreateOrganizationMarketplaceSubscription(testOrgName, &MarketplaceSubscriptionRequest{SKU: testPlaceholder})
+	err = client.CreateOrganizationMarketplaceSubscription(context.Background(), testOrgName, &MarketplaceSubscriptionRequest{SKU: testPlaceholder})
 	if err == nil {
 		t.Error("Expected error from CreateOrganizationMarketplaceSubscription, got nil")
 	}
 
-	err = client.BatchRemoveOrganizationMarketplaceSubscriptions(testOrgName, []string{testSubscriptionID})
+	err = client.BatchRemoveOrganizationMarketplaceSubscriptions(context.Background(), testOrgName, []string{testSubscriptionID})
 	if err == nil {
 		t.Error("Expected error from BatchRemoveOrganizationMarketplaceSubscriptions, got nil")
 	}
 
-	err = client.DeleteOrganizationMarketplaceSubscription(testOrgName, testSubscriptionID)
+	err = client.DeleteOrganizationMarketplaceSubscription(context.Background(), testOrgName, testSubscriptionID)
 	if err == nil {
 		t.Error("Expected error from DeleteOrganizationMarketplaceSubscription, got nil")
 	}

--- a/lib/org_robot.go
+++ b/lib/org_robot.go
@@ -23,6 +23,7 @@ Robot Federation:
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -30,12 +31,12 @@ import (
 // Robot Account Management
 
 // GetRobotAccounts retrieves all robot accounts for an organization
-func (c *Client) GetRobotAccounts(orgname string) (*RobotAccounts, error) {
+func (c *Client) GetRobotAccounts(ctx context.Context, orgname string) (*RobotAccounts, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/robots", orgname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/robots", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get robot accounts request: %w", err)
 	}
@@ -49,7 +50,7 @@ func (c *Client) GetRobotAccounts(orgname string) (*RobotAccounts, error) {
 }
 
 // CreateRobotAccount creates a new robot account in an organization
-func (c *Client) CreateRobotAccount(orgname, robotShortname, description string, unstructured map[string]interface{}) (*RobotAccount, error) {
+func (c *Client) CreateRobotAccount(ctx context.Context, orgname, robotShortname, description string, unstructured map[string]interface{}) (*RobotAccount, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -57,7 +58,7 @@ func (c *Client) CreateRobotAccount(orgname, robotShortname, description string,
 		return nil, fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), CreateRobotRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), CreateRobotRequest{
 		Description:  description,
 		Unstructured: unstructured,
 	})
@@ -74,7 +75,7 @@ func (c *Client) CreateRobotAccount(orgname, robotShortname, description string,
 }
 
 // GetRobotAccount retrieves details for a specific robot account
-func (c *Client) GetRobotAccount(orgname, robotShortname string) (*RobotAccount, error) {
+func (c *Client) GetRobotAccount(ctx context.Context, orgname, robotShortname string) (*RobotAccount, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -82,7 +83,7 @@ func (c *Client) GetRobotAccount(orgname, robotShortname string) (*RobotAccount,
 		return nil, fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get robot account request: %w", err)
 	}
@@ -96,7 +97,7 @@ func (c *Client) GetRobotAccount(orgname, robotShortname string) (*RobotAccount,
 }
 
 // DeleteRobotAccount deletes a robot account from an organization
-func (c *Client) DeleteRobotAccount(orgname, robotShortname string) error {
+func (c *Client) DeleteRobotAccount(ctx context.Context, orgname, robotShortname string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -104,7 +105,7 @@ func (c *Client) DeleteRobotAccount(orgname, robotShortname string) error {
 		return fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/organization/%s/robots/%s", orgname, robotShortname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete robot account request: %w", err)
 	}
@@ -117,7 +118,7 @@ func (c *Client) DeleteRobotAccount(orgname, robotShortname string) error {
 }
 
 // RegenerateRobotToken regenerates the token for a robot account
-func (c *Client) RegenerateRobotToken(orgname, robotShortname string) (*RobotAccount, error) {
+func (c *Client) RegenerateRobotToken(ctx context.Context, orgname, robotShortname string) (*RobotAccount, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -125,7 +126,7 @@ func (c *Client) RegenerateRobotToken(orgname, robotShortname string) (*RobotAcc
 		return nil, fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest(http.MethodPost, c.buildURL("/organization/%s/robots/%s/regenerate", orgname, robotShortname), nil)
+	req, err := newRequest(ctx, http.MethodPost, c.buildURL("/organization/%s/robots/%s/regenerate", orgname, robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create regenerate robot token request: %w", err)
 	}
@@ -141,7 +142,7 @@ func (c *Client) RegenerateRobotToken(orgname, robotShortname string) (*RobotAcc
 // Robot Permissions Management
 
 // GetRobotPermissions retrieves repository permissions for a robot account
-func (c *Client) GetRobotPermissions(orgname, robotShortname string) (*RobotPermissions, error) {
+func (c *Client) GetRobotPermissions(ctx context.Context, orgname, robotShortname string) (*RobotPermissions, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -149,7 +150,7 @@ func (c *Client) GetRobotPermissions(orgname, robotShortname string) (*RobotPerm
 		return nil, fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/robots/%s/permissions", orgname, robotShortname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/robots/%s/permissions", orgname, robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get robot permissions request: %w", err)
 	}
@@ -163,7 +164,7 @@ func (c *Client) GetRobotPermissions(orgname, robotShortname string) (*RobotPerm
 }
 
 // SetRobotRepositoryPermission sets repository permission for a robot account
-func (c *Client) SetRobotRepositoryPermission(orgname, robotShortname, repository, role string) error {
+func (c *Client) SetRobotRepositoryPermission(ctx context.Context, orgname, robotShortname, repository, role string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -177,7 +178,7 @@ func (c *Client) SetRobotRepositoryPermission(orgname, robotShortname, repositor
 		return fmt.Errorf("role is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/robots/%s/permissions/%s", orgname, robotShortname, repository), SetRepositoryPermissionRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/organization/%s/robots/%s/permissions/%s", orgname, robotShortname, repository), SetRepositoryPermissionRequest{
 		Role: role,
 	})
 	if err != nil {
@@ -192,7 +193,7 @@ func (c *Client) SetRobotRepositoryPermission(orgname, robotShortname, repositor
 }
 
 // RemoveRobotRepositoryPermission removes repository permission for a robot account
-func (c *Client) RemoveRobotRepositoryPermission(orgname, robotShortname, repository string) error {
+func (c *Client) RemoveRobotRepositoryPermission(ctx context.Context, orgname, robotShortname, repository string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -203,7 +204,7 @@ func (c *Client) RemoveRobotRepositoryPermission(orgname, robotShortname, reposi
 		return fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/robots/%s/permissions/%s", orgname, robotShortname, repository), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/organization/%s/robots/%s/permissions/%s", orgname, robotShortname, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create remove robot repository permission request: %w", err)
 	}
@@ -218,7 +219,7 @@ func (c *Client) RemoveRobotRepositoryPermission(orgname, robotShortname, reposi
 // Robot Federation
 
 // GetRobotFederation retrieves the federation configuration for an organization's robot account
-func (c *Client) GetRobotFederation(orgname, robotShortname string) (*RobotFederation, error) {
+func (c *Client) GetRobotFederation(ctx context.Context, orgname, robotShortname string) (*RobotFederation, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -226,7 +227,7 @@ func (c *Client) GetRobotFederation(orgname, robotShortname string) (*RobotFeder
 		return nil, fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/robots/%s/federation", orgname, robotShortname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/robots/%s/federation", orgname, robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get robot federation request: %w", err)
 	}
@@ -240,7 +241,7 @@ func (c *Client) GetRobotFederation(orgname, robotShortname string) (*RobotFeder
 }
 
 // CreateRobotFederation creates or updates the federation configuration for an organization's robot account
-func (c *Client) CreateRobotFederation(orgname, robotShortname string, configs []RobotFederationConfig) error {
+func (c *Client) CreateRobotFederation(ctx context.Context, orgname, robotShortname string, configs []RobotFederationConfig) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -248,7 +249,7 @@ func (c *Client) CreateRobotFederation(orgname, robotShortname string, configs [
 		return fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/robots/%s/federation", orgname, robotShortname), configs)
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/organization/%s/robots/%s/federation", orgname, robotShortname), configs)
 	if err != nil {
 		return fmt.Errorf("failed to create robot federation request: %w", err)
 	}
@@ -261,7 +262,7 @@ func (c *Client) CreateRobotFederation(orgname, robotShortname string, configs [
 }
 
 // DeleteRobotFederation deletes the federation configuration for an organization's robot account
-func (c *Client) DeleteRobotFederation(orgname, robotShortname string) error {
+func (c *Client) DeleteRobotFederation(ctx context.Context, orgname, robotShortname string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -269,7 +270,7 @@ func (c *Client) DeleteRobotFederation(orgname, robotShortname string) error {
 		return fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/robots/%s/federation", orgname, robotShortname), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/organization/%s/robots/%s/federation", orgname, robotShortname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete robot federation request: %w", err)
 	}

--- a/lib/org_robot_test.go
+++ b/lib/org_robot_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -36,7 +37,7 @@ func TestGetRobotAccounts(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	robots, err := client.GetRobotAccounts(testOrgName)
+	robots, err := client.GetRobotAccounts(context.Background(), testOrgName)
 	if err != nil {
 		t.Fatalf("GetRobotAccounts returned error: %v", err)
 	}
@@ -86,7 +87,7 @@ func TestCreateRobotAccount(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	robot, err := client.CreateRobotAccount(testOrgName, testRobotShortname, testRobotDescValue, nil)
+	robot, err := client.CreateRobotAccount(context.Background(), testOrgName, testRobotShortname, testRobotDescValue, nil)
 	if err != nil {
 		t.Fatalf("CreateRobotAccount returned error: %v", err)
 	}
@@ -123,7 +124,7 @@ func TestGetRobotAccount(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	robot, err := client.GetRobotAccount(testOrgName, testRobotShortname)
+	robot, err := client.GetRobotAccount(context.Background(), testOrgName, testRobotShortname)
 	if err != nil {
 		t.Fatalf("GetRobotAccount returned error: %v", err)
 	}
@@ -151,7 +152,7 @@ func TestDeleteRobotAccount(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteRobotAccount(testOrgName, testRobotShortname)
+	err = client.DeleteRobotAccount(context.Background(), testOrgName, testRobotShortname)
 	if err != nil {
 		t.Fatalf("DeleteRobotAccount returned error: %v", err)
 	}
@@ -182,7 +183,7 @@ func TestRegenerateRobotToken(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	robot, err := client.RegenerateRobotToken(testOrgName, testRobotShortname)
+	robot, err := client.RegenerateRobotToken(context.Background(), testOrgName, testRobotShortname)
 	if err != nil {
 		t.Fatalf("RegenerateRobotToken returned error: %v", err)
 	}
@@ -221,7 +222,7 @@ func TestGetRobotPermissions(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	perms, err := client.GetRobotPermissions(testOrgName, testRobotShortname)
+	perms, err := client.GetRobotPermissions(context.Background(), testOrgName, testRobotShortname)
 	if err != nil {
 		t.Fatalf("GetRobotPermissions returned error: %v", err)
 	}
@@ -259,7 +260,7 @@ func TestSetRobotRepositoryPermission(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.SetRobotRepositoryPermission(testOrgName, testRobotShortname, testRepoName, testRoleWrite)
+	err = client.SetRobotRepositoryPermission(context.Background(), testOrgName, testRobotShortname, testRepoName, testRoleWrite)
 	if err != nil {
 		t.Fatalf("SetRobotRepositoryPermission returned error: %v", err)
 	}
@@ -283,7 +284,7 @@ func TestRemoveRobotRepositoryPermission(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.RemoveRobotRepositoryPermission(testOrgName, testRobotShortname, testRepoName)
+	err = client.RemoveRobotRepositoryPermission(context.Background(), testOrgName, testRobotShortname, testRepoName)
 	if err != nil {
 		t.Fatalf("RemoveRobotRepositoryPermission returned error: %v", err)
 	}
@@ -317,7 +318,7 @@ func TestGetRobotFederation(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	federation, err := client.GetRobotFederation(testOrgName, testRobotShortname)
+	federation, err := client.GetRobotFederation(context.Background(), testOrgName, testRobotShortname)
 	if err != nil {
 		t.Fatalf("GetRobotFederation returned error: %v", err)
 	}
@@ -352,7 +353,7 @@ func TestCreateRobotFederation(t *testing.T) {
 		{Issuer: testFederationIssuer, Subject: testFederationSubject},
 	}
 
-	err = client.CreateRobotFederation(testOrgName, testRobotShortname, configs)
+	err = client.CreateRobotFederation(context.Background(), testOrgName, testRobotShortname, configs)
 	if err != nil {
 		t.Fatalf("CreateRobotFederation returned error: %v", err)
 	}
@@ -376,7 +377,7 @@ func TestDeleteRobotFederation(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteRobotFederation(testOrgName, testRobotShortname)
+	err = client.DeleteRobotFederation(context.Background(), testOrgName, testRobotShortname)
 	if err != nil {
 		t.Fatalf("DeleteRobotFederation returned error: %v", err)
 	}
@@ -385,57 +386,57 @@ func TestDeleteRobotFederation(t *testing.T) {
 func TestOrganizationRobotHTTPErrors(t *testing.T) {
 	client := newOrgErrorClient(t)
 
-	_, err := client.GetRobotAccounts(testOrgName)
+	_, err := client.GetRobotAccounts(context.Background(), testOrgName)
 	if err == nil {
 		t.Error("Expected error from GetRobotAccounts, got nil")
 	}
 
-	_, err = client.CreateRobotAccount(testOrgName, "testbot", testRobotDescValue, nil)
+	_, err = client.CreateRobotAccount(context.Background(), testOrgName, "testbot", testRobotDescValue, nil)
 	if err == nil {
 		t.Error("Expected error from CreateRobotAccount, got nil")
 	}
 
-	_, err = client.GetRobotAccount(testOrgName, "testbot")
+	_, err = client.GetRobotAccount(context.Background(), testOrgName, "testbot")
 	if err == nil {
 		t.Error("Expected error from GetRobotAccount, got nil")
 	}
 
-	err = client.DeleteRobotAccount(testOrgName, "testbot")
+	err = client.DeleteRobotAccount(context.Background(), testOrgName, "testbot")
 	if err == nil {
 		t.Error("Expected error from DeleteRobotAccount, got nil")
 	}
 
-	_, err = client.RegenerateRobotToken(testOrgName, "testbot")
+	_, err = client.RegenerateRobotToken(context.Background(), testOrgName, "testbot")
 	if err == nil {
 		t.Error("Expected error from RegenerateRobotToken, got nil")
 	}
 
-	_, err = client.GetRobotPermissions(testOrgName, "testbot")
+	_, err = client.GetRobotPermissions(context.Background(), testOrgName, "testbot")
 	if err == nil {
 		t.Error("Expected error from GetRobotPermissions, got nil")
 	}
 
-	err = client.SetRobotRepositoryPermission(testOrgName, "testbot", testRepository, testRoleRead)
+	err = client.SetRobotRepositoryPermission(context.Background(), testOrgName, "testbot", testRepository, testRoleRead)
 	if err == nil {
 		t.Error("Expected error from SetRobotRepositoryPermission, got nil")
 	}
 
-	err = client.RemoveRobotRepositoryPermission(testOrgName, "testbot", testRepository)
+	err = client.RemoveRobotRepositoryPermission(context.Background(), testOrgName, "testbot", testRepository)
 	if err == nil {
 		t.Error("Expected error from RemoveRobotRepositoryPermission, got nil")
 	}
 
-	_, err = client.GetRobotFederation(testOrgName, "testbot")
+	_, err = client.GetRobotFederation(context.Background(), testOrgName, "testbot")
 	if err == nil {
 		t.Error("Expected error from GetRobotFederation, got nil")
 	}
 
-	err = client.CreateRobotFederation(testOrgName, "testbot", []RobotFederationConfig{{Issuer: "https://example.com", Subject: testPlaceholder}})
+	err = client.CreateRobotFederation(context.Background(), testOrgName, "testbot", []RobotFederationConfig{{Issuer: "https://example.com", Subject: testPlaceholder}})
 	if err == nil {
 		t.Error("Expected error from CreateRobotFederation, got nil")
 	}
 
-	err = client.DeleteRobotFederation(testOrgName, "testbot")
+	err = client.DeleteRobotFederation(context.Background(), testOrgName, "testbot")
 	if err == nil {
 		t.Error("Expected error from DeleteRobotFederation, got nil")
 	}

--- a/lib/org_team.go
+++ b/lib/org_team.go
@@ -27,6 +27,7 @@ Team Invitations:
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -34,12 +35,12 @@ import (
 // Team Management
 
 // GetTeams retrieves all teams for an organization
-func (c *Client) GetTeams(orgname string) ([]Team, error) {
+func (c *Client) GetTeams(ctx context.Context, orgname string) ([]Team, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/teams", orgname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/teams", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get teams request: %w", err)
 	}
@@ -55,7 +56,7 @@ func (c *Client) GetTeams(orgname string) ([]Team, error) {
 }
 
 // CreateTeam creates a new team in an organization
-func (c *Client) CreateTeam(orgname, teamname, description, role string) (*Team, error) {
+func (c *Client) CreateTeam(ctx context.Context, orgname, teamname, description, role string) (*Team, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -66,7 +67,7 @@ func (c *Client) CreateTeam(orgname, teamname, description, role string) (*Team,
 		return nil, fmt.Errorf("role is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/team/%s", orgname, teamname), CreateTeamRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/organization/%s/team/%s", orgname, teamname), CreateTeamRequest{
 		Name:        teamname,
 		Description: description,
 		Role:        role,
@@ -84,7 +85,7 @@ func (c *Client) CreateTeam(orgname, teamname, description, role string) (*Team,
 }
 
 // GetTeam retrieves details for a specific team
-func (c *Client) GetTeam(orgname, teamname string) (*Team, error) {
+func (c *Client) GetTeam(ctx context.Context, orgname, teamname string) (*Team, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -92,7 +93,7 @@ func (c *Client) GetTeam(orgname, teamname string) (*Team, error) {
 		return nil, fmt.Errorf("teamname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/team/%s", orgname, teamname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/team/%s", orgname, teamname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get team request: %w", err)
 	}
@@ -106,7 +107,7 @@ func (c *Client) GetTeam(orgname, teamname string) (*Team, error) {
 }
 
 // DeleteTeam deletes a team from an organization
-func (c *Client) DeleteTeam(orgname, teamname string) error {
+func (c *Client) DeleteTeam(ctx context.Context, orgname, teamname string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -114,7 +115,7 @@ func (c *Client) DeleteTeam(orgname, teamname string) error {
 		return fmt.Errorf("teamname is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/team/%s", orgname, teamname), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/organization/%s/team/%s", orgname, teamname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete team request: %w", err)
 	}
@@ -127,7 +128,7 @@ func (c *Client) DeleteTeam(orgname, teamname string) error {
 }
 
 // UpdateTeam updates team settings
-func (c *Client) UpdateTeam(orgname, teamname, description, role string) (*Team, error) {
+func (c *Client) UpdateTeam(ctx context.Context, orgname, teamname, description, role string) (*Team, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -138,7 +139,7 @@ func (c *Client) UpdateTeam(orgname, teamname, description, role string) (*Team,
 		return nil, fmt.Errorf("role is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/team/%s", orgname, teamname), UpdateTeamRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/organization/%s/team/%s", orgname, teamname), UpdateTeamRequest{
 		Description: description,
 		Role:        role,
 	})
@@ -157,7 +158,7 @@ func (c *Client) UpdateTeam(orgname, teamname, description, role string) (*Team,
 // Team Members Management
 
 // GetTeamMembers retrieves members of a team
-func (c *Client) GetTeamMembers(orgname, teamname string) (*TeamMembers, error) {
+func (c *Client) GetTeamMembers(ctx context.Context, orgname, teamname string) (*TeamMembers, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -165,7 +166,7 @@ func (c *Client) GetTeamMembers(orgname, teamname string) (*TeamMembers, error) 
 		return nil, fmt.Errorf("teamname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/team/%s/members", orgname, teamname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/team/%s/members", orgname, teamname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get team members request: %w", err)
 	}
@@ -179,7 +180,7 @@ func (c *Client) GetTeamMembers(orgname, teamname string) (*TeamMembers, error) 
 }
 
 // AddTeamMember adds a member to a team
-func (c *Client) AddTeamMember(orgname, teamname, membername string) error {
+func (c *Client) AddTeamMember(ctx context.Context, orgname, teamname, membername string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -190,7 +191,7 @@ func (c *Client) AddTeamMember(orgname, teamname, membername string) error {
 		return fmt.Errorf("membername is required")
 	}
 
-	req, err := newRequest(http.MethodPut, c.buildURL("/organization/%s/team/%s/members/%s", orgname, teamname, membername), nil)
+	req, err := newRequest(ctx, http.MethodPut, c.buildURL("/organization/%s/team/%s/members/%s", orgname, teamname, membername), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create add team member request: %w", err)
 	}
@@ -203,7 +204,7 @@ func (c *Client) AddTeamMember(orgname, teamname, membername string) error {
 }
 
 // RemoveTeamMember removes a member from a team
-func (c *Client) RemoveTeamMember(orgname, teamname, membername string) error {
+func (c *Client) RemoveTeamMember(ctx context.Context, orgname, teamname, membername string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -214,7 +215,7 @@ func (c *Client) RemoveTeamMember(orgname, teamname, membername string) error {
 		return fmt.Errorf("membername is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/team/%s/members/%s", orgname, teamname, membername), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/organization/%s/team/%s/members/%s", orgname, teamname, membername), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create remove team member request: %w", err)
 	}
@@ -229,7 +230,7 @@ func (c *Client) RemoveTeamMember(orgname, teamname, membername string) error {
 // Team Permissions Management
 
 // GetTeamPermissions retrieves repository permissions for a team
-func (c *Client) GetTeamPermissions(orgname, teamname string) (*TeamPermissions, error) {
+func (c *Client) GetTeamPermissions(ctx context.Context, orgname, teamname string) (*TeamPermissions, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -237,7 +238,7 @@ func (c *Client) GetTeamPermissions(orgname, teamname string) (*TeamPermissions,
 		return nil, fmt.Errorf("teamname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/team/%s/permissions", orgname, teamname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/team/%s/permissions", orgname, teamname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get team permissions request: %w", err)
 	}
@@ -251,7 +252,7 @@ func (c *Client) GetTeamPermissions(orgname, teamname string) (*TeamPermissions,
 }
 
 // SetTeamRepositoryPermission sets repository permission for a team
-func (c *Client) SetTeamRepositoryPermission(orgname, teamname, repository, role string) error {
+func (c *Client) SetTeamRepositoryPermission(ctx context.Context, orgname, teamname, repository, role string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -265,7 +266,7 @@ func (c *Client) SetTeamRepositoryPermission(orgname, teamname, repository, role
 		return fmt.Errorf("role is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/team/%s/permissions/%s", orgname, teamname, repository), SetRepositoryPermissionRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/organization/%s/team/%s/permissions/%s", orgname, teamname, repository), SetRepositoryPermissionRequest{
 		Role: role,
 	})
 	if err != nil {
@@ -280,7 +281,7 @@ func (c *Client) SetTeamRepositoryPermission(orgname, teamname, repository, role
 }
 
 // RemoveTeamRepositoryPermission removes repository permission for a team
-func (c *Client) RemoveTeamRepositoryPermission(orgname, teamname, repository string) error {
+func (c *Client) RemoveTeamRepositoryPermission(ctx context.Context, orgname, teamname, repository string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -291,7 +292,7 @@ func (c *Client) RemoveTeamRepositoryPermission(orgname, teamname, repository st
 		return fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/team/%s/permissions/%s", orgname, teamname, repository), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/organization/%s/team/%s/permissions/%s", orgname, teamname, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create remove team repository permission request: %w", err)
 	}
@@ -306,7 +307,7 @@ func (c *Client) RemoveTeamRepositoryPermission(orgname, teamname, repository st
 // Team Invitations
 
 // InviteTeamMember invites a member to a team via email
-func (c *Client) InviteTeamMember(orgname, teamname, email string) error {
+func (c *Client) InviteTeamMember(ctx context.Context, orgname, teamname, email string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -317,7 +318,7 @@ func (c *Client) InviteTeamMember(orgname, teamname, email string) error {
 		return fmt.Errorf("email is required")
 	}
 
-	req, err := newRequest(http.MethodPut, c.buildURL("/organization/%s/team/%s/invite/%s", orgname, teamname, email), nil)
+	req, err := newRequest(ctx, http.MethodPut, c.buildURL("/organization/%s/team/%s/invite/%s", orgname, teamname, email), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create invite team member request: %w", err)
 	}
@@ -330,7 +331,7 @@ func (c *Client) InviteTeamMember(orgname, teamname, email string) error {
 }
 
 // DeleteTeamInvite deletes a pending team invitation
-func (c *Client) DeleteTeamInvite(orgname, teamname, email string) error {
+func (c *Client) DeleteTeamInvite(ctx context.Context, orgname, teamname, email string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -341,7 +342,7 @@ func (c *Client) DeleteTeamInvite(orgname, teamname, email string) error {
 		return fmt.Errorf("email is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/team/%s/invite/%s", orgname, teamname, email), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/organization/%s/team/%s/invite/%s", orgname, teamname, email), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete team invite request: %w", err)
 	}

--- a/lib/org_team_test.go
+++ b/lib/org_team_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -38,7 +39,7 @@ func TestGetTeams(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	teams, err := client.GetTeams(testOrgName)
+	teams, err := client.GetTeams(context.Background(), testOrgName)
 	if err != nil {
 		t.Fatalf("GetTeams returned error: %v", err)
 	}
@@ -82,7 +83,7 @@ func TestGetTeam(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	team, err := client.GetTeam(testOrgName, testTeamName)
+	team, err := client.GetTeam(context.Background(), testOrgName, testTeamName)
 	if err != nil {
 		t.Fatalf("GetTeam returned error: %v", err)
 	}
@@ -124,7 +125,7 @@ func TestCreateTeam(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	team, err := client.CreateTeam(testOrgName, testTeamName, testTeamDescNew, roleMember)
+	team, err := client.CreateTeam(context.Background(), testOrgName, testTeamName, testTeamDescNew, roleMember)
 	if err != nil {
 		t.Fatalf("CreateTeam returned error: %v", err)
 	}
@@ -173,7 +174,7 @@ func TestUpdateTeam(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	team, err := client.UpdateTeam(testOrgName, testTeamName, updatedDescription, roleAdmin)
+	team, err := client.UpdateTeam(context.Background(), testOrgName, testTeamName, updatedDescription, roleAdmin)
 	if err != nil {
 		t.Fatalf("UpdateTeam returned error: %v", err)
 	}
@@ -207,7 +208,7 @@ func TestDeleteTeam(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteTeam(testOrgName, testTeamName)
+	err = client.DeleteTeam(context.Background(), testOrgName, testTeamName)
 	if err != nil {
 		t.Fatalf("DeleteTeam returned error: %v", err)
 	}
@@ -242,7 +243,7 @@ func TestGetTeamMembers(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	members, err := client.GetTeamMembers(testOrgName, testTeamName)
+	members, err := client.GetTeamMembers(context.Background(), testOrgName, testTeamName)
 	if err != nil {
 		t.Fatalf("GetTeamMembers returned error: %v", err)
 	}
@@ -279,7 +280,7 @@ func TestAddTeamMember(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.AddTeamMember(testOrgName, testTeamName, testUserName)
+	err = client.AddTeamMember(context.Background(), testOrgName, testTeamName, testUserName)
 	if err != nil {
 		t.Fatalf("AddTeamMember returned error: %v", err)
 	}
@@ -303,7 +304,7 @@ func TestRemoveTeamMember(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.RemoveTeamMember(testOrgName, testTeamName, testUserName)
+	err = client.RemoveTeamMember(context.Background(), testOrgName, testTeamName, testUserName)
 	if err != nil {
 		t.Fatalf("RemoveTeamMember returned error: %v", err)
 	}
@@ -338,7 +339,7 @@ func TestGetTeamPermissions(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	perms, err := client.GetTeamPermissions(testOrgName, testTeamName)
+	perms, err := client.GetTeamPermissions(context.Background(), testOrgName, testTeamName)
 	if err != nil {
 		t.Fatalf("GetTeamPermissions returned error: %v", err)
 	}
@@ -379,7 +380,7 @@ func TestSetTeamRepositoryPermission(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.SetTeamRepositoryPermission(testOrgName, testTeamName, testRepoName, testRoleWrite)
+	err = client.SetTeamRepositoryPermission(context.Background(), testOrgName, testTeamName, testRepoName, testRoleWrite)
 	if err != nil {
 		t.Fatalf("SetTeamRepositoryPermission returned error: %v", err)
 	}
@@ -403,7 +404,7 @@ func TestRemoveTeamRepositoryPermission(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.RemoveTeamRepositoryPermission(testOrgName, testTeamName, testRepoName)
+	err = client.RemoveTeamRepositoryPermission(context.Background(), testOrgName, testTeamName, testRepoName)
 	if err != nil {
 		t.Fatalf("RemoveTeamRepositoryPermission returned error: %v", err)
 	}
@@ -429,7 +430,7 @@ func TestInviteTeamMember(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.InviteTeamMember(testOrgName, testTeamName, testEmailAddress)
+	err = client.InviteTeamMember(context.Background(), testOrgName, testTeamName, testEmailAddress)
 	if err != nil {
 		t.Fatalf("InviteTeamMember returned error: %v", err)
 	}
@@ -453,7 +454,7 @@ func TestDeleteTeamInvite(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteTeamInvite(testOrgName, testTeamName, testEmailAddress)
+	err = client.DeleteTeamInvite(context.Background(), testOrgName, testTeamName, testEmailAddress)
 	if err != nil {
 		t.Fatalf("DeleteTeamInvite returned error: %v", err)
 	}
@@ -472,7 +473,7 @@ func TestGetTeamsError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetTeams(testOrgName)
+	_, err = client.GetTeams(context.Background(), testOrgName)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -489,7 +490,7 @@ func TestGetTeamError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetTeam(testOrgName, "nonexistent-team")
+	_, err = client.GetTeam(context.Background(), testOrgName, "nonexistent-team")
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -498,67 +499,67 @@ func TestGetTeamError(t *testing.T) {
 func TestOrganizationTeamHTTPErrors(t *testing.T) {
 	client := newOrgErrorClient(t)
 
-	_, err := client.GetTeams(testOrgName)
+	_, err := client.GetTeams(context.Background(), testOrgName)
 	if err == nil {
 		t.Error("Expected error from GetTeams, got nil")
 	}
 
-	_, err = client.CreateTeam(testOrgName, testTeamName, testTeamDescDev, roleMember)
+	_, err = client.CreateTeam(context.Background(), testOrgName, testTeamName, testTeamDescDev, roleMember)
 	if err == nil {
 		t.Error("Expected error from CreateTeam, got nil")
 	}
 
-	_, err = client.GetTeam(testOrgName, testTeamName)
+	_, err = client.GetTeam(context.Background(), testOrgName, testTeamName)
 	if err == nil {
 		t.Error("Expected error from GetTeam, got nil")
 	}
 
-	err = client.DeleteTeam(testOrgName, testTeamName)
+	err = client.DeleteTeam(context.Background(), testOrgName, testTeamName)
 	if err == nil {
 		t.Error("Expected error from DeleteTeam, got nil")
 	}
 
-	_, err = client.UpdateTeam(testOrgName, testTeamName, testTeamDescDev, roleMember)
+	_, err = client.UpdateTeam(context.Background(), testOrgName, testTeamName, testTeamDescDev, roleMember)
 	if err == nil {
 		t.Error("Expected error from UpdateTeam, got nil")
 	}
 
-	_, err = client.GetTeamMembers(testOrgName, testTeamName)
+	_, err = client.GetTeamMembers(context.Background(), testOrgName, testTeamName)
 	if err == nil {
 		t.Error("Expected error from GetTeamMembers, got nil")
 	}
 
-	err = client.AddTeamMember(testOrgName, testTeamName, testMemberName)
+	err = client.AddTeamMember(context.Background(), testOrgName, testTeamName, testMemberName)
 	if err == nil {
 		t.Error("Expected error from AddTeamMember, got nil")
 	}
 
-	err = client.RemoveTeamMember(testOrgName, testTeamName, testMemberName)
+	err = client.RemoveTeamMember(context.Background(), testOrgName, testTeamName, testMemberName)
 	if err == nil {
 		t.Error("Expected error from RemoveTeamMember, got nil")
 	}
 
-	_, err = client.GetTeamPermissions(testOrgName, testTeamName)
+	_, err = client.GetTeamPermissions(context.Background(), testOrgName, testTeamName)
 	if err == nil {
 		t.Error("Expected error from GetTeamPermissions, got nil")
 	}
 
-	err = client.SetTeamRepositoryPermission(testOrgName, testTeamName, testRepository, testRoleRead)
+	err = client.SetTeamRepositoryPermission(context.Background(), testOrgName, testTeamName, testRepository, testRoleRead)
 	if err == nil {
 		t.Error("Expected error from SetTeamRepositoryPermission, got nil")
 	}
 
-	err = client.RemoveTeamRepositoryPermission(testOrgName, testTeamName, testRepository)
+	err = client.RemoveTeamRepositoryPermission(context.Background(), testOrgName, testTeamName, testRepository)
 	if err == nil {
 		t.Error("Expected error from RemoveTeamRepositoryPermission, got nil")
 	}
 
-	err = client.InviteTeamMember(testOrgName, testTeamName, testEmailAddress)
+	err = client.InviteTeamMember(context.Background(), testOrgName, testTeamName, testEmailAddress)
 	if err == nil {
 		t.Error("Expected error from InviteTeamMember, got nil")
 	}
 
-	err = client.DeleteTeamInvite(testOrgName, testTeamName, testEmailAddress)
+	err = client.DeleteTeamInvite(context.Background(), testOrgName, testTeamName, testEmailAddress)
 	if err == nil {
 		t.Error("Expected error from DeleteTeamInvite, got nil")
 	}

--- a/lib/organization.go
+++ b/lib/organization.go
@@ -24,6 +24,7 @@ Organization Collaborators:
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -31,7 +32,7 @@ import (
 // Organization Management
 
 // CreateOrganization creates a new organization
-func (c *Client) CreateOrganization(name, email string) (*Organization, error) {
+func (c *Client) CreateOrganization(ctx context.Context, name, email string) (*Organization, error) {
 	if name == "" {
 		return nil, fmt.Errorf("name is required")
 	}
@@ -39,7 +40,7 @@ func (c *Client) CreateOrganization(name, email string) (*Organization, error) {
 		return nil, fmt.Errorf("email is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/"), CreateOrganizationRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/organization/"), CreateOrganizationRequest{
 		Name:  name,
 		Email: email,
 	})
@@ -56,12 +57,12 @@ func (c *Client) CreateOrganization(name, email string) (*Organization, error) {
 }
 
 // GetOrganization retrieves organization details
-func (c *Client) GetOrganization(orgname string) (*Organization, error) {
+func (c *Client) GetOrganization(ctx context.Context, orgname string) (*Organization, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s", orgname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization request: %w", err)
 	}
@@ -75,12 +76,12 @@ func (c *Client) GetOrganization(orgname string) (*Organization, error) {
 }
 
 // DeleteOrganization deletes an organization
-func (c *Client) DeleteOrganization(orgname string) error {
+func (c *Client) DeleteOrganization(ctx context.Context, orgname string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s", orgname), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/organization/%s", orgname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete organization request: %w", err)
 	}
@@ -93,7 +94,7 @@ func (c *Client) DeleteOrganization(orgname string) error {
 }
 
 // UpdateOrganization updates organization settings
-func (c *Client) UpdateOrganization(orgname, email string) (*Organization, error) {
+func (c *Client) UpdateOrganization(ctx context.Context, orgname, email string) (*Organization, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -101,7 +102,7 @@ func (c *Client) UpdateOrganization(orgname, email string) (*Organization, error
 		return nil, fmt.Errorf("email is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s", orgname), UpdateOrganizationRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/organization/%s", orgname), UpdateOrganizationRequest{
 		Email: email,
 	})
 	if err != nil {
@@ -119,12 +120,12 @@ func (c *Client) UpdateOrganization(orgname, email string) (*Organization, error
 // Organization Members Management
 
 // GetOrganizationMembers retrieves organization members
-func (c *Client) GetOrganizationMembers(orgname string) (*OrganizationMembers, error) {
+func (c *Client) GetOrganizationMembers(ctx context.Context, orgname string) (*OrganizationMembers, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/members", orgname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/members", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization members request: %w", err)
 	}
@@ -138,7 +139,7 @@ func (c *Client) GetOrganizationMembers(orgname string) (*OrganizationMembers, e
 }
 
 // GetOrganizationMember gets information about a specific organization member
-func (c *Client) GetOrganizationMember(orgname, membername string) (*OrganizationMember, error) {
+func (c *Client) GetOrganizationMember(ctx context.Context, orgname, membername string) (*OrganizationMember, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -146,7 +147,7 @@ func (c *Client) GetOrganizationMember(orgname, membername string) (*Organizatio
 		return nil, fmt.Errorf("membername is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization member request: %w", err)
 	}
@@ -160,7 +161,7 @@ func (c *Client) GetOrganizationMember(orgname, membername string) (*Organizatio
 }
 
 // AddOrganizationMember adds a member to an organization
-func (c *Client) AddOrganizationMember(orgname, membername string) error {
+func (c *Client) AddOrganizationMember(ctx context.Context, orgname, membername string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -168,7 +169,7 @@ func (c *Client) AddOrganizationMember(orgname, membername string) error {
 		return fmt.Errorf("membername is required")
 	}
 
-	req, err := newRequest(http.MethodPut, c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
+	req, err := newRequest(ctx, http.MethodPut, c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create add organization member request: %w", err)
 	}
@@ -181,7 +182,7 @@ func (c *Client) AddOrganizationMember(orgname, membername string) error {
 }
 
 // RemoveOrganizationMember removes a member from an organization
-func (c *Client) RemoveOrganizationMember(orgname, membername string) error {
+func (c *Client) RemoveOrganizationMember(ctx context.Context, orgname, membername string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -189,7 +190,7 @@ func (c *Client) RemoveOrganizationMember(orgname, membername string) error {
 		return fmt.Errorf("membername is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/organization/%s/members/%s", orgname, membername), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create remove organization member request: %w", err)
 	}
@@ -204,12 +205,12 @@ func (c *Client) RemoveOrganizationMember(orgname, membername string) error {
 // Organization Repositories
 
 // GetOrganizationRepositories retrieves repositories for an organization
-func (c *Client) GetOrganizationRepositories(orgname string) (*OrganizationRepositories, error) {
+func (c *Client) GetOrganizationRepositories(ctx context.Context, orgname string) (*OrganizationRepositories, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/repositories", orgname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/repositories", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization repositories request: %w", err)
 	}
@@ -225,12 +226,12 @@ func (c *Client) GetOrganizationRepositories(orgname string) (*OrganizationRepos
 // Organization Collaborators
 
 // GetOrganizationCollaborators gets the list of collaborators for an organization
-func (c *Client) GetOrganizationCollaborators(orgname string) (*Collaborators, error) {
+func (c *Client) GetOrganizationCollaborators(ctx context.Context, orgname string) (*Collaborators, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/collaborators", orgname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/collaborators", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get organization collaborators request: %w", err)
 	}

--- a/lib/organization_test.go
+++ b/lib/organization_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -36,7 +37,7 @@ func TestGetOrganization(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	org, err := client.GetOrganization(testOrgName)
+	org, err := client.GetOrganization(context.Background(), testOrgName)
 	if err != nil {
 		t.Fatalf("GetOrganization returned error: %v", err)
 	}
@@ -63,7 +64,7 @@ func TestGetOrganizationError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetOrganization(testOrgName)
+	_, err = client.GetOrganization(context.Background(), testOrgName)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -103,7 +104,7 @@ func TestCreateOrganization(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	org, err := client.CreateOrganization(testOrgName, testEmailAddress)
+	org, err := client.CreateOrganization(context.Background(), testOrgName, testEmailAddress)
 	if err != nil {
 		t.Fatalf("CreateOrganization returned error: %v", err)
 	}
@@ -146,7 +147,7 @@ func TestUpdateOrganization(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	org, err := client.UpdateOrganization(testOrgName, updatedEmail)
+	org, err := client.UpdateOrganization(context.Background(), testOrgName, updatedEmail)
 	if err != nil {
 		t.Fatalf("UpdateOrganization returned error: %v", err)
 	}
@@ -174,7 +175,7 @@ func TestDeleteOrganization(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteOrganization(testOrgName)
+	err = client.DeleteOrganization(context.Background(), testOrgName)
 	if err != nil {
 		t.Fatalf("DeleteOrganization returned error: %v", err)
 	}
@@ -209,7 +210,7 @@ func TestGetOrganizationMembers(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	members, err := client.GetOrganizationMembers(testOrgName)
+	members, err := client.GetOrganizationMembers(context.Background(), testOrgName)
 	if err != nil {
 		t.Fatalf("GetOrganizationMembers returned error: %v", err)
 	}
@@ -233,7 +234,7 @@ func TestGetOrganizationMembersError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetOrganizationMembers(testOrgName)
+	_, err = client.GetOrganizationMembers(context.Background(), testOrgName)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -257,7 +258,7 @@ func TestAddOrganizationMember(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.AddOrganizationMember(testOrgName, testMemberName)
+	err = client.AddOrganizationMember(context.Background(), testOrgName, testMemberName)
 	if err != nil {
 		t.Fatalf("AddOrganizationMember returned error: %v", err)
 	}
@@ -281,7 +282,7 @@ func TestRemoveOrganizationMember(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.RemoveOrganizationMember(testOrgName, testMemberName)
+	err = client.RemoveOrganizationMember(context.Background(), testOrgName, testMemberName)
 	if err != nil {
 		t.Fatalf("RemoveOrganizationMember returned error: %v", err)
 	}
@@ -315,7 +316,7 @@ func TestGetOrganizationMember(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	member, err := client.GetOrganizationMember(testOrgName, testMemberName)
+	member, err := client.GetOrganizationMember(context.Background(), testOrgName, testMemberName)
 	if err != nil {
 		t.Fatalf("GetOrganizationMember returned error: %v", err)
 	}
@@ -357,7 +358,7 @@ func TestGetOrganizationRepositories(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	repos, err := client.GetOrganizationRepositories(testOrgName)
+	repos, err := client.GetOrganizationRepositories(context.Background(), testOrgName)
 	if err != nil {
 		t.Fatalf("GetOrganizationRepositories returned error: %v", err)
 	}
@@ -399,7 +400,7 @@ func TestGetOrganizationCollaborators(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	collabs, err := client.GetOrganizationCollaborators(testOrgName)
+	collabs, err := client.GetOrganizationCollaborators(context.Background(), testOrgName)
 	if err != nil {
 		t.Fatalf("GetOrganizationCollaborators returned error: %v", err)
 	}
@@ -417,42 +418,42 @@ func TestGetOrganizationCollaborators(t *testing.T) {
 func TestOrganizationCRUDHTTPErrors(t *testing.T) {
 	client := newOrgErrorClient(t)
 
-	_, err := client.CreateOrganization("testorg", testEmailAddress)
+	_, err := client.CreateOrganization(context.Background(), "testorg", testEmailAddress)
 	if err == nil {
 		t.Error("Expected error from CreateOrganization, got nil")
 	}
 
-	_, err = client.UpdateOrganization(testOrgName, testEmailAddress)
+	_, err = client.UpdateOrganization(context.Background(), testOrgName, testEmailAddress)
 	if err == nil {
 		t.Error("Expected error from UpdateOrganization, got nil")
 	}
 
-	err = client.DeleteOrganization(testOrgName)
+	err = client.DeleteOrganization(context.Background(), testOrgName)
 	if err == nil {
 		t.Error("Expected error from DeleteOrganization, got nil")
 	}
 
-	err = client.AddOrganizationMember(testOrgName, testMemberName)
+	err = client.AddOrganizationMember(context.Background(), testOrgName, testMemberName)
 	if err == nil {
 		t.Error("Expected error from AddOrganizationMember, got nil")
 	}
 
-	err = client.RemoveOrganizationMember(testOrgName, testMemberName)
+	err = client.RemoveOrganizationMember(context.Background(), testOrgName, testMemberName)
 	if err == nil {
 		t.Error("Expected error from RemoveOrganizationMember, got nil")
 	}
 
-	_, err = client.GetOrganizationMember(testOrgName, testMemberName)
+	_, err = client.GetOrganizationMember(context.Background(), testOrgName, testMemberName)
 	if err == nil {
 		t.Error("Expected error from GetOrganizationMember, got nil")
 	}
 
-	_, err = client.GetOrganizationRepositories(testOrgName)
+	_, err = client.GetOrganizationRepositories(context.Background(), testOrgName)
 	if err == nil {
 		t.Error("Expected error from GetOrganizationRepositories, got nil")
 	}
 
-	_, err = client.GetOrganizationCollaborators(testOrgName)
+	_, err = client.GetOrganizationCollaborators(context.Background(), testOrgName)
 	if err == nil {
 		t.Error("Expected error from GetOrganizationCollaborators, got nil")
 	}

--- a/lib/permissions.go
+++ b/lib/permissions.go
@@ -14,12 +14,13 @@ Supported roles: read, write, admin
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetRepositoryPermissions retrieves permissions for a repository
-func (c *Client) GetRepositoryPermissions(namespace, repository string) (*RepositoryPermissions, error) {
+func (c *Client) GetRepositoryPermissions(ctx context.Context, namespace, repository string) (*RepositoryPermissions, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -27,7 +28,7 @@ func (c *Client) GetRepositoryPermissions(namespace, repository string) (*Reposi
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/permissions", namespace, repository), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/permissions", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repository permissions request: %w", err)
 	}
@@ -42,7 +43,7 @@ func (c *Client) GetRepositoryPermissions(namespace, repository string) (*Reposi
 
 // SetRepositoryPermission sets permission for a user/robot on a repository
 // role should be one of: "read", "write", "admin"
-func (c *Client) SetRepositoryPermission(namespace, repository, username, role string) error {
+func (c *Client) SetRepositoryPermission(ctx context.Context, namespace, repository, username, role string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -56,7 +57,7 @@ func (c *Client) SetRepositoryPermission(namespace, repository, username, role s
 		return fmt.Errorf("role is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s/permissions/%s", namespace, repository, username), SetRepositoryPermissionRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/repository/%s/%s/permissions/%s", namespace, repository, username), SetRepositoryPermissionRequest{
 		Role: role,
 	})
 	if err != nil {
@@ -71,7 +72,7 @@ func (c *Client) SetRepositoryPermission(namespace, repository, username, role s
 }
 
 // RemoveRepositoryPermission removes permission for a user/robot from a repository
-func (c *Client) RemoveRepositoryPermission(namespace, repository, username string) error {
+func (c *Client) RemoveRepositoryPermission(ctx context.Context, namespace, repository, username string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -82,7 +83,7 @@ func (c *Client) RemoveRepositoryPermission(namespace, repository, username stri
 		return fmt.Errorf("username is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/permissions/%s", namespace, repository, username), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/repository/%s/%s/permissions/%s", namespace, repository, username), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create remove repository permission request: %w", err)
 	}
@@ -97,7 +98,7 @@ func (c *Client) RemoveRepositoryPermission(namespace, repository, username stri
 // User Permission Endpoints (per Quay API spec)
 
 // ListUserPermissions lists all user permissions for a repository
-func (c *Client) ListUserPermissions(namespace, repository string) (*RepositoryPermissions, error) {
+func (c *Client) ListUserPermissions(ctx context.Context, namespace, repository string) (*RepositoryPermissions, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -105,7 +106,7 @@ func (c *Client) ListUserPermissions(namespace, repository string) (*RepositoryP
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/permissions/user/", namespace, repository), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/permissions/user/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list user permissions request: %w", err)
 	}
@@ -119,7 +120,7 @@ func (c *Client) ListUserPermissions(namespace, repository string) (*RepositoryP
 }
 
 // GetUserPermission gets permission for a specific user on a repository
-func (c *Client) GetUserPermission(namespace, repository, username string) (*RepositoryPermission, error) {
+func (c *Client) GetUserPermission(ctx context.Context, namespace, repository, username string) (*RepositoryPermission, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -130,7 +131,7 @@ func (c *Client) GetUserPermission(namespace, repository, username string) (*Rep
 		return nil, fmt.Errorf("username is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/permissions/user/%s", namespace, repository, username), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/permissions/user/%s", namespace, repository, username), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user permission request: %w", err)
 	}
@@ -145,7 +146,7 @@ func (c *Client) GetUserPermission(namespace, repository, username string) (*Rep
 
 // SetUserPermission sets permission for a user on a repository
 // role should be one of: "read", "write", "admin"
-func (c *Client) SetUserPermission(namespace, repository, username, role string) error {
+func (c *Client) SetUserPermission(ctx context.Context, namespace, repository, username, role string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -159,7 +160,7 @@ func (c *Client) SetUserPermission(namespace, repository, username, role string)
 		return fmt.Errorf("role is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s/permissions/user/%s", namespace, repository, username), SetRepositoryPermissionRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/repository/%s/%s/permissions/user/%s", namespace, repository, username), SetRepositoryPermissionRequest{
 		Role: role,
 	})
 	if err != nil {
@@ -174,7 +175,7 @@ func (c *Client) SetUserPermission(namespace, repository, username, role string)
 }
 
 // DeleteUserPermission removes permission for a user from a repository
-func (c *Client) DeleteUserPermission(namespace, repository, username string) error {
+func (c *Client) DeleteUserPermission(ctx context.Context, namespace, repository, username string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -185,7 +186,7 @@ func (c *Client) DeleteUserPermission(namespace, repository, username string) er
 		return fmt.Errorf("username is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/permissions/user/%s", namespace, repository, username), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/repository/%s/%s/permissions/user/%s", namespace, repository, username), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete user permission request: %w", err)
 	}
@@ -198,7 +199,7 @@ func (c *Client) DeleteUserPermission(namespace, repository, username string) er
 }
 
 // GetUserTransitivePermission gets the transitive permission for a user on a repository
-func (c *Client) GetUserTransitivePermission(namespace, repository, username string) (*RepositoryPermission, error) {
+func (c *Client) GetUserTransitivePermission(ctx context.Context, namespace, repository, username string) (*RepositoryPermission, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -209,7 +210,7 @@ func (c *Client) GetUserTransitivePermission(namespace, repository, username str
 		return nil, fmt.Errorf("username is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/permissions/user/%s/transitive", namespace, repository, username), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/permissions/user/%s/transitive", namespace, repository, username), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user transitive permission request: %w", err)
 	}
@@ -225,7 +226,7 @@ func (c *Client) GetUserTransitivePermission(namespace, repository, username str
 // Team Permission Endpoints (per Quay API spec)
 
 // ListTeamPermissions lists all team permissions for a repository
-func (c *Client) ListTeamPermissions(namespace, repository string) (*RepositoryPermissions, error) {
+func (c *Client) ListTeamPermissions(ctx context.Context, namespace, repository string) (*RepositoryPermissions, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -233,7 +234,7 @@ func (c *Client) ListTeamPermissions(namespace, repository string) (*RepositoryP
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/permissions/team/", namespace, repository), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/permissions/team/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list team permissions request: %w", err)
 	}
@@ -247,7 +248,7 @@ func (c *Client) ListTeamPermissions(namespace, repository string) (*RepositoryP
 }
 
 // GetTeamPermission gets permission for a specific team on a repository
-func (c *Client) GetTeamPermission(namespace, repository, teamname string) (*RepositoryPermission, error) {
+func (c *Client) GetTeamPermission(ctx context.Context, namespace, repository, teamname string) (*RepositoryPermission, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -258,7 +259,7 @@ func (c *Client) GetTeamPermission(namespace, repository, teamname string) (*Rep
 		return nil, fmt.Errorf("teamname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/permissions/team/%s", namespace, repository, teamname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/permissions/team/%s", namespace, repository, teamname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get team permission request: %w", err)
 	}
@@ -273,7 +274,7 @@ func (c *Client) GetTeamPermission(namespace, repository, teamname string) (*Rep
 
 // SetTeamPermission sets permission for a team on a repository
 // role should be one of: "read", "write", "admin"
-func (c *Client) SetTeamPermission(namespace, repository, teamname, role string) error {
+func (c *Client) SetTeamPermission(ctx context.Context, namespace, repository, teamname, role string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -287,7 +288,7 @@ func (c *Client) SetTeamPermission(namespace, repository, teamname, role string)
 		return fmt.Errorf("role is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s/permissions/team/%s", namespace, repository, teamname), SetRepositoryPermissionRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/repository/%s/%s/permissions/team/%s", namespace, repository, teamname), SetRepositoryPermissionRequest{
 		Role: role,
 	})
 	if err != nil {
@@ -302,7 +303,7 @@ func (c *Client) SetTeamPermission(namespace, repository, teamname, role string)
 }
 
 // DeleteTeamPermission removes permission for a team from a repository
-func (c *Client) DeleteTeamPermission(namespace, repository, teamname string) error {
+func (c *Client) DeleteTeamPermission(ctx context.Context, namespace, repository, teamname string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -313,7 +314,7 @@ func (c *Client) DeleteTeamPermission(namespace, repository, teamname string) er
 		return fmt.Errorf("teamname is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/permissions/team/%s", namespace, repository, teamname), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/repository/%s/%s/permissions/team/%s", namespace, repository, teamname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete team permission request: %w", err)
 	}

--- a/lib/permissions_test.go
+++ b/lib/permissions_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -56,7 +57,7 @@ func TestGetRepositoryPermissions(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	permissions, err := client.GetRepositoryPermissions(testNamespace, testRepository)
+	permissions, err := client.GetRepositoryPermissions(context.Background(), testNamespace, testRepository)
 	if err != nil {
 		t.Fatalf("GetRepositoryPermissions failed: %v", err)
 	}
@@ -118,7 +119,7 @@ func TestSetRepositoryPermission(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.SetRepositoryPermission(testNamespace, testRepository, testPermUserName, testRoleWrite)
+	err = client.SetRepositoryPermission(context.Background(), testNamespace, testRepository, testPermUserName, testRoleWrite)
 	if err != nil {
 		t.Fatalf("SetRepositoryPermission failed: %v", err)
 	}
@@ -139,7 +140,7 @@ func TestSetRepositoryPermissionInvalidRole(t *testing.T) {
 	// Test with valid roles
 	validRoles := []string{testRoleRead, testRoleWrite, roleAdmin}
 	for _, role := range validRoles {
-		err = client.SetRepositoryPermission(testNamespace, testRepository, testKindUser, role)
+		err = client.SetRepositoryPermission(context.Background(), testNamespace, testRepository, testKindUser, role)
 		if err != nil {
 			t.Errorf("SetRepositoryPermission failed for valid role '%s': %v", role, err)
 		}
@@ -164,7 +165,7 @@ func TestRemoveRepositoryPermission(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.RemoveRepositoryPermission(testNamespace, testRepository, testPermUserName)
+	err = client.RemoveRepositoryPermission(context.Background(), testNamespace, testRepository, testPermUserName)
 	if err != nil {
 		t.Fatalf("RemoveRepositoryPermission failed: %v", err)
 	}
@@ -196,7 +197,7 @@ func TestListUserPermissions(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	perms, err := client.ListUserPermissions(testNamespace, testRepository)
+	perms, err := client.ListUserPermissions(context.Background(), testNamespace, testRepository)
 	if err != nil {
 		t.Fatalf("ListUserPermissions returned error: %v", err)
 	}
@@ -235,7 +236,7 @@ func TestGetUserPermission(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	perm, err := client.GetUserPermission(testNamespace, testRepository, testPermUserName)
+	perm, err := client.GetUserPermission(context.Background(), testNamespace, testRepository, testPermUserName)
 	if err != nil {
 		t.Fatalf("GetUserPermission returned error: %v", err)
 	}
@@ -263,7 +264,7 @@ func TestSetUserPermission(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.SetUserPermission(testNamespace, testRepository, testPermUserName, testRoleWrite)
+	err = client.SetUserPermission(context.Background(), testNamespace, testRepository, testPermUserName, testRoleWrite)
 	if err != nil {
 		t.Fatalf("SetUserPermission returned error: %v", err)
 	}
@@ -287,7 +288,7 @@ func TestDeleteUserPermission(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteUserPermission(testNamespace, testRepository, testPermUserName)
+	err = client.DeleteUserPermission(context.Background(), testNamespace, testRepository, testPermUserName)
 	if err != nil {
 		t.Fatalf("DeleteUserPermission returned error: %v", err)
 	}
@@ -319,7 +320,7 @@ func TestGetUserTransitivePermission(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	perm, err := client.GetUserTransitivePermission(testNamespace, testRepository, testPermUserName)
+	perm, err := client.GetUserTransitivePermission(context.Background(), testNamespace, testRepository, testPermUserName)
 	if err != nil {
 		t.Fatalf("GetUserTransitivePermission returned error: %v", err)
 	}
@@ -355,7 +356,7 @@ func TestListTeamPermissions(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	perms, err := client.ListTeamPermissions(testNamespace, testRepository)
+	perms, err := client.ListTeamPermissions(context.Background(), testNamespace, testRepository)
 	if err != nil {
 		t.Fatalf("ListTeamPermissions returned error: %v", err)
 	}
@@ -394,7 +395,7 @@ func TestGetTeamPermission(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	perm, err := client.GetTeamPermission(testNamespace, testRepository, testPrototypeTeamName)
+	perm, err := client.GetTeamPermission(context.Background(), testNamespace, testRepository, testPrototypeTeamName)
 	if err != nil {
 		t.Fatalf("GetTeamPermission returned error: %v", err)
 	}
@@ -422,7 +423,7 @@ func TestSetTeamPermission(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.SetTeamPermission(testNamespace, testRepository, testPrototypeTeamName, testRoleWrite)
+	err = client.SetTeamPermission(context.Background(), testNamespace, testRepository, testPrototypeTeamName, testRoleWrite)
 	if err != nil {
 		t.Fatalf("SetTeamPermission returned error: %v", err)
 	}
@@ -446,7 +447,7 @@ func TestDeleteTeamPermission(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteTeamPermission(testNamespace, testRepository, testPrototypeTeamName)
+	err = client.DeleteTeamPermission(context.Background(), testNamespace, testRepository, testPrototypeTeamName)
 	if err != nil {
 		t.Fatalf("DeleteTeamPermission returned error: %v", err)
 	}
@@ -466,73 +467,73 @@ func TestPermissionsErrorHandling(t *testing.T) {
 	}
 
 	// Test GetRepositoryPermissions error
-	_, err = client.GetRepositoryPermissions(testNamespace, "nonexistent")
+	_, err = client.GetRepositoryPermissions(context.Background(), testNamespace, "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent repository, got nil")
 	}
 
 	// Test SetRepositoryPermission error
-	err = client.SetRepositoryPermission(testNamespace, "nonexistent", testKindUser, testRoleRead)
+	err = client.SetRepositoryPermission(context.Background(), testNamespace, "nonexistent", testKindUser, testRoleRead)
 	if err == nil {
 		t.Error("Expected error for non-existent repository, got nil")
 	}
 
 	// Test RemoveRepositoryPermission error
-	err = client.RemoveRepositoryPermission(testNamespace, "nonexistent", testKindUser)
+	err = client.RemoveRepositoryPermission(context.Background(), testNamespace, "nonexistent", testKindUser)
 	if err == nil {
 		t.Error("Expected error for non-existent repository, got nil")
 	}
 
 	// Test ListUserPermissions error
-	_, err = client.ListUserPermissions(testNamespace, "nonexistent")
+	_, err = client.ListUserPermissions(context.Background(), testNamespace, "nonexistent")
 	if err == nil {
 		t.Error("Expected error from ListUserPermissions, got nil")
 	}
 
 	// Test GetUserPermission error
-	_, err = client.GetUserPermission(testNamespace, "nonexistent", testPermUserName)
+	_, err = client.GetUserPermission(context.Background(), testNamespace, "nonexistent", testPermUserName)
 	if err == nil {
 		t.Error("Expected error from GetUserPermission, got nil")
 	}
 
 	// Test SetUserPermission error
-	err = client.SetUserPermission(testNamespace, "nonexistent", testPermUserName, testRoleRead)
+	err = client.SetUserPermission(context.Background(), testNamespace, "nonexistent", testPermUserName, testRoleRead)
 	if err == nil {
 		t.Error("Expected error from SetUserPermission, got nil")
 	}
 
 	// Test DeleteUserPermission error
-	err = client.DeleteUserPermission(testNamespace, "nonexistent", testPermUserName)
+	err = client.DeleteUserPermission(context.Background(), testNamespace, "nonexistent", testPermUserName)
 	if err == nil {
 		t.Error("Expected error from DeleteUserPermission, got nil")
 	}
 
 	// Test GetUserTransitivePermission error
-	_, err = client.GetUserTransitivePermission(testNamespace, "nonexistent", testPermUserName)
+	_, err = client.GetUserTransitivePermission(context.Background(), testNamespace, "nonexistent", testPermUserName)
 	if err == nil {
 		t.Error("Expected error from GetUserTransitivePermission, got nil")
 	}
 
 	// Test ListTeamPermissions error
-	_, err = client.ListTeamPermissions(testNamespace, "nonexistent")
+	_, err = client.ListTeamPermissions(context.Background(), testNamespace, "nonexistent")
 	if err == nil {
 		t.Error("Expected error from ListTeamPermissions, got nil")
 	}
 
 	// Test GetTeamPermission error
-	_, err = client.GetTeamPermission(testNamespace, "nonexistent", testTeamName)
+	_, err = client.GetTeamPermission(context.Background(), testNamespace, "nonexistent", testTeamName)
 	if err == nil {
 		t.Error("Expected error from GetTeamPermission, got nil")
 	}
 
 	// Test SetTeamPermission error
-	err = client.SetTeamPermission(testNamespace, "nonexistent", testTeamName, testRoleRead)
+	err = client.SetTeamPermission(context.Background(), testNamespace, "nonexistent", testTeamName, testRoleRead)
 	if err == nil {
 		t.Error("Expected error from SetTeamPermission, got nil")
 	}
 
 	// Test DeleteTeamPermission error
-	err = client.DeleteTeamPermission(testNamespace, "nonexistent", testTeamName)
+	err = client.DeleteTeamPermission(context.Background(), testNamespace, "nonexistent", testTeamName)
 	if err == nil {
 		t.Error("Expected error from DeleteTeamPermission, got nil")
 	}

--- a/lib/prototype.go
+++ b/lib/prototype.go
@@ -22,17 +22,18 @@ Delegate kinds:
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetPrototypes retrieves all permission prototypes for an organization
-func (c *Client) GetPrototypes(orgname string) (*Prototypes, error) {
+func (c *Client) GetPrototypes(ctx context.Context, orgname string) (*Prototypes, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/prototypes", orgname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/prototypes", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get prototypes request: %w", err)
 	}
@@ -46,12 +47,12 @@ func (c *Client) GetPrototypes(orgname string) (*Prototypes, error) {
 }
 
 // CreatePrototype creates a new permission prototype for an organization
-func (c *Client) CreatePrototype(orgname string, createReq *CreatePrototypeRequest) (*Prototype, error) {
+func (c *Client) CreatePrototype(ctx context.Context, orgname string, createReq *CreatePrototypeRequest) (*Prototype, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/prototypes", orgname), createReq)
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/organization/%s/prototypes", orgname), createReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create prototype request: %w", err)
 	}
@@ -65,7 +66,7 @@ func (c *Client) CreatePrototype(orgname string, createReq *CreatePrototypeReque
 }
 
 // GetPrototype retrieves a specific prototype by UUID
-func (c *Client) GetPrototype(orgname, prototypeUUID string) (*Prototype, error) {
+func (c *Client) GetPrototype(ctx context.Context, orgname, prototypeUUID string) (*Prototype, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -73,7 +74,7 @@ func (c *Client) GetPrototype(orgname, prototypeUUID string) (*Prototype, error)
 		return nil, fmt.Errorf("prototypeUUID is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeUUID), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get prototype request: %w", err)
 	}
@@ -87,7 +88,7 @@ func (c *Client) GetPrototype(orgname, prototypeUUID string) (*Prototype, error)
 }
 
 // UpdatePrototype updates an existing prototype
-func (c *Client) UpdatePrototype(orgname, prototypeUUID string, updateReq *UpdatePrototypeRequest) (*Prototype, error) {
+func (c *Client) UpdatePrototype(ctx context.Context, orgname, prototypeUUID string, updateReq *UpdatePrototypeRequest) (*Prototype, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -95,7 +96,7 @@ func (c *Client) UpdatePrototype(orgname, prototypeUUID string, updateReq *Updat
 		return nil, fmt.Errorf("prototypeUUID is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeUUID), updateReq)
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeUUID), updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update prototype request: %w", err)
 	}
@@ -109,7 +110,7 @@ func (c *Client) UpdatePrototype(orgname, prototypeUUID string, updateReq *Updat
 }
 
 // DeletePrototype deletes a prototype
-func (c *Client) DeletePrototype(orgname, prototypeUUID string) error {
+func (c *Client) DeletePrototype(ctx context.Context, orgname, prototypeUUID string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
@@ -117,7 +118,7 @@ func (c *Client) DeletePrototype(orgname, prototypeUUID string) error {
 		return fmt.Errorf("prototypeUUID is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeUUID), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/organization/%s/prototypes/%s", orgname, prototypeUUID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete prototype request: %w", err)
 	}

--- a/lib/prototype_test.go
+++ b/lib/prototype_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -44,7 +45,7 @@ func TestGetPrototypes(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	prototypes, err := client.GetPrototypes(testNamespace)
+	prototypes, err := client.GetPrototypes(context.Background(), testNamespace)
 	if err != nil {
 		t.Fatalf("GetPrototypes returned error: %v", err)
 	}
@@ -91,7 +92,7 @@ func TestCreatePrototype(t *testing.T) {
 		Role: testRoleRead,
 	}
 
-	prototype, err := client.CreatePrototype(testNamespace, createReq)
+	prototype, err := client.CreatePrototype(context.Background(), testNamespace, createReq)
 	if err != nil {
 		t.Fatalf("CreatePrototype returned error: %v", err)
 	}
@@ -130,7 +131,7 @@ func TestGetPrototype(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	prototype, err := client.GetPrototype(testNamespace, testPrototypeUUID)
+	prototype, err := client.GetPrototype(context.Background(), testNamespace, testPrototypeUUID)
 	if err != nil {
 		t.Fatalf("GetPrototype returned error: %v", err)
 	}
@@ -165,7 +166,7 @@ func TestUpdatePrototype(t *testing.T) {
 		Role: testRoleWrite,
 	}
 
-	prototype, err := client.UpdatePrototype(testNamespace, testPrototypeUUID, updateReq)
+	prototype, err := client.UpdatePrototype(context.Background(), testNamespace, testPrototypeUUID, updateReq)
 	if err != nil {
 		t.Fatalf("UpdatePrototype returned error: %v", err)
 	}
@@ -193,7 +194,7 @@ func TestDeletePrototype(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeletePrototype(testNamespace, testPrototypeUUID)
+	err = client.DeletePrototype(context.Background(), testNamespace, testPrototypeUUID)
 	if err != nil {
 		t.Fatalf("DeletePrototype returned error: %v", err)
 	}
@@ -210,7 +211,7 @@ func TestGetPrototypesError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetPrototypes(testNamespace)
+	_, err = client.GetPrototypes(context.Background(), testNamespace)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -227,7 +228,7 @@ func TestPrototypeHTTPErrors(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.CreatePrototype(testNamespace, &CreatePrototypeRequest{
+	_, err = client.CreatePrototype(context.Background(), testNamespace, &CreatePrototypeRequest{
 		Role: testRoleRead,
 		Delegate: PrototypeDelegateRequest{
 			Name: testPrototypeTeamName,
@@ -238,17 +239,17 @@ func TestPrototypeHTTPErrors(t *testing.T) {
 		t.Error("Expected error from CreatePrototype, got nil")
 	}
 
-	_, err = client.GetPrototype(testNamespace, testPrototypeUUID)
+	_, err = client.GetPrototype(context.Background(), testNamespace, testPrototypeUUID)
 	if err == nil {
 		t.Error("Expected error from GetPrototype, got nil")
 	}
 
-	_, err = client.UpdatePrototype(testNamespace, testPrototypeUUID, &UpdatePrototypeRequest{Role: testRoleWrite})
+	_, err = client.UpdatePrototype(context.Background(), testNamespace, testPrototypeUUID, &UpdatePrototypeRequest{Role: testRoleWrite})
 	if err == nil {
 		t.Error("Expected error from UpdatePrototype, got nil")
 	}
 
-	err = client.DeletePrototype(testNamespace, testPrototypeUUID)
+	err = client.DeletePrototype(context.Background(), testNamespace, testPrototypeUUID)
 	if err == nil {
 		t.Error("Expected error from DeletePrototype, got nil")
 	}

--- a/lib/proxy_cache.go
+++ b/lib/proxy_cache.go
@@ -11,17 +11,18 @@ Proxy Cache Configuration:
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetProxyCacheConfig retrieves proxy cache configuration for an organization
-func (c *Client) GetProxyCacheConfig(orgname string) (*ProxyCacheConfig, error) {
+func (c *Client) GetProxyCacheConfig(ctx context.Context, orgname string) (*ProxyCacheConfig, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/proxycache", orgname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/proxycache", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get proxy cache config request: %w", err)
 	}
@@ -35,7 +36,7 @@ func (c *Client) GetProxyCacheConfig(orgname string) (*ProxyCacheConfig, error) 
 }
 
 // CreateProxyCacheConfig creates proxy cache configuration for an organization
-func (c *Client) CreateProxyCacheConfig(orgname, upstreamRegistry string, insecure bool, expiration int) (*ProxyCacheConfig, error) {
+func (c *Client) CreateProxyCacheConfig(ctx context.Context, orgname, upstreamRegistry string, insecure bool, expiration int) (*ProxyCacheConfig, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
@@ -43,7 +44,7 @@ func (c *Client) CreateProxyCacheConfig(orgname, upstreamRegistry string, insecu
 		return nil, fmt.Errorf("upstreamRegistry is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/proxycache", orgname), CreateProxyCacheConfigRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/organization/%s/proxycache", orgname), CreateProxyCacheConfigRequest{
 		UpstreamRegistry: upstreamRegistry,
 		Insecure:         insecure,
 		Expiration:       expiration,
@@ -61,12 +62,12 @@ func (c *Client) CreateProxyCacheConfig(orgname, upstreamRegistry string, insecu
 }
 
 // DeleteProxyCacheConfig deletes proxy cache configuration for an organization
-func (c *Client) DeleteProxyCacheConfig(orgname string) error {
+func (c *Client) DeleteProxyCacheConfig(ctx context.Context, orgname string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/proxycache", orgname), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/organization/%s/proxycache", orgname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete proxy cache config request: %w", err)
 	}

--- a/lib/proxy_cache_test.go
+++ b/lib/proxy_cache_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -35,7 +36,7 @@ func TestGetProxyCacheConfig(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	config, err := client.GetProxyCacheConfig(testOrgName)
+	config, err := client.GetProxyCacheConfig(context.Background(), testOrgName)
 	if err != nil {
 		t.Fatalf("GetProxyCacheConfig returned error: %v", err)
 	}
@@ -88,7 +89,7 @@ func TestCreateProxyCacheConfig(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	config, err := client.CreateProxyCacheConfig(testOrgName, testUpstreamReg, true, 3600)
+	config, err := client.CreateProxyCacheConfig(context.Background(), testOrgName, testUpstreamReg, true, 3600)
 	if err != nil {
 		t.Fatalf("CreateProxyCacheConfig returned error: %v", err)
 	}
@@ -116,7 +117,7 @@ func TestDeleteProxyCacheConfig(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteProxyCacheConfig(testOrgName)
+	err = client.DeleteProxyCacheConfig(context.Background(), testOrgName)
 	if err != nil {
 		t.Fatalf("DeleteProxyCacheConfig returned error: %v", err)
 	}
@@ -125,17 +126,17 @@ func TestDeleteProxyCacheConfig(t *testing.T) {
 func TestProxyCacheHTTPErrors(t *testing.T) {
 	client := newOrgErrorClient(t)
 
-	_, err := client.GetProxyCacheConfig(testOrgName)
+	_, err := client.GetProxyCacheConfig(context.Background(), testOrgName)
 	if err == nil {
 		t.Error("Expected error from GetProxyCacheConfig, got nil")
 	}
 
-	_, err = client.CreateProxyCacheConfig(testOrgName, testUpstreamReg, false, 86400)
+	_, err = client.CreateProxyCacheConfig(context.Background(), testOrgName, testUpstreamReg, false, 86400)
 	if err == nil {
 		t.Error("Expected error from CreateProxyCacheConfig, got nil")
 	}
 
-	err = client.DeleteProxyCacheConfig(testOrgName)
+	err = client.DeleteProxyCacheConfig(context.Background(), testOrgName)
 	if err == nil {
 		t.Error("Expected error from DeleteProxyCacheConfig, got nil")
 	}

--- a/lib/quota.go
+++ b/lib/quota.go
@@ -12,17 +12,18 @@ Quota Management:
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetQuota retrieves quota information for an organization
-func (c *Client) GetQuota(orgname string) (*Quota, error) {
+func (c *Client) GetQuota(ctx context.Context, orgname string) (*Quota, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/organization/%s/quota", orgname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/organization/%s/quota", orgname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get quota request: %w", err)
 	}
@@ -36,12 +37,12 @@ func (c *Client) GetQuota(orgname string) (*Quota, error) {
 }
 
 // CreateQuota creates a quota for an organization
-func (c *Client) CreateQuota(orgname string, limitBytes int64) (*Quota, error) {
+func (c *Client) CreateQuota(ctx context.Context, orgname string, limitBytes int64) (*Quota, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/organization/%s/quota", orgname), CreateQuotaRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/organization/%s/quota", orgname), CreateQuotaRequest{
 		LimitBytes: limitBytes,
 	})
 	if err != nil {
@@ -57,12 +58,12 @@ func (c *Client) CreateQuota(orgname string, limitBytes int64) (*Quota, error) {
 }
 
 // UpdateQuota updates quota limits for an organization
-func (c *Client) UpdateQuota(orgname string, limitBytes int64) (*Quota, error) {
+func (c *Client) UpdateQuota(ctx context.Context, orgname string, limitBytes int64) (*Quota, error) {
 	if orgname == "" {
 		return nil, fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/organization/%s/quota", orgname), CreateQuotaRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/organization/%s/quota", orgname), CreateQuotaRequest{
 		LimitBytes: limitBytes,
 	})
 	if err != nil {
@@ -78,12 +79,12 @@ func (c *Client) UpdateQuota(orgname string, limitBytes int64) (*Quota, error) {
 }
 
 // DeleteQuota deletes quota for an organization
-func (c *Client) DeleteQuota(orgname string) error {
+func (c *Client) DeleteQuota(ctx context.Context, orgname string) error {
 	if orgname == "" {
 		return fmt.Errorf("orgname is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/organization/%s/quota", orgname), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/organization/%s/quota", orgname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete quota request: %w", err)
 	}

--- a/lib/quota_test.go
+++ b/lib/quota_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -34,7 +35,7 @@ func TestGetQuota(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	quota, err := client.GetQuota(testOrgName)
+	quota, err := client.GetQuota(context.Background(), testOrgName)
 	if err != nil {
 		t.Fatalf("GetQuota returned error: %v", err)
 	}
@@ -80,7 +81,7 @@ func TestCreateQuota(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	quota, err := client.CreateQuota(testOrgName, limitBytes)
+	quota, err := client.CreateQuota(context.Background(), testOrgName, limitBytes)
 	if err != nil {
 		t.Fatalf("CreateQuota returned error: %v", err)
 	}
@@ -116,7 +117,7 @@ func TestUpdateQuota(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	quota, err := client.UpdateQuota(testOrgName, limitBytes)
+	quota, err := client.UpdateQuota(context.Background(), testOrgName, limitBytes)
 	if err != nil {
 		t.Fatalf("UpdateQuota returned error: %v", err)
 	}
@@ -144,7 +145,7 @@ func TestDeleteQuota(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteQuota(testOrgName)
+	err = client.DeleteQuota(context.Background(), testOrgName)
 	if err != nil {
 		t.Fatalf("DeleteQuota returned error: %v", err)
 	}
@@ -153,22 +154,22 @@ func TestDeleteQuota(t *testing.T) {
 func TestQuotaHTTPErrors(t *testing.T) {
 	client := newOrgErrorClient(t)
 
-	_, err := client.GetQuota(testOrgName)
+	_, err := client.GetQuota(context.Background(), testOrgName)
 	if err == nil {
 		t.Error("Expected error from GetQuota, got nil")
 	}
 
-	_, err = client.CreateQuota(testOrgName, 1073741824)
+	_, err = client.CreateQuota(context.Background(), testOrgName, 1073741824)
 	if err == nil {
 		t.Error("Expected error from CreateQuota, got nil")
 	}
 
-	_, err = client.UpdateQuota(testOrgName, 2147483648)
+	_, err = client.UpdateQuota(context.Background(), testOrgName, 2147483648)
 	if err == nil {
 		t.Error("Expected error from UpdateQuota, got nil")
 	}
 
-	err = client.DeleteQuota(testOrgName)
+	err = client.DeleteQuota(context.Background(), testOrgName)
 	if err == nil {
 		t.Error("Expected error from DeleteQuota, got nil")
 	}

--- a/lib/repository.go
+++ b/lib/repository.go
@@ -17,6 +17,7 @@ ListRepositories() supports a popularity flag for pull count data.
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -50,7 +51,7 @@ type RepositoryWithTags struct {
 }
 
 // GetRepository returns a repository with tags information baked in
-func (c *Client) GetRepository(namespace, repository string) (RepositoryWithTags, error) {
+func (c *Client) GetRepository(ctx context.Context, namespace, repository string) (RepositoryWithTags, error) {
 	if namespace == "" {
 		return RepositoryWithTags{}, fmt.Errorf("namespace is required")
 	}
@@ -59,7 +60,7 @@ func (c *Client) GetRepository(namespace, repository string) (RepositoryWithTags
 	}
 
 	repoURL := c.buildURL("/repository/%s/%s", namespace, repository)
-	req, err := newRequest(http.MethodGet, repoURL, nil)
+	req, err := newRequest(ctx, http.MethodGet, repoURL, nil)
 	if err != nil {
 		return RepositoryWithTags{}, fmt.Errorf("failed to create request for repository: %w", err)
 	}
@@ -69,7 +70,7 @@ func (c *Client) GetRepository(namespace, repository string) (RepositoryWithTags
 		return RepositoryWithTags{}, fmt.Errorf("failed to fetch repository details: %w", err)
 	}
 
-	tags, err := c.ListTags(namespace, repository, 0, false)
+	tags, err := c.ListTags(ctx, namespace, repository, 0, false)
 	if err != nil {
 		return RepositoryWithTags{}, fmt.Errorf("failed to fetch repository tags: %w", err)
 	}
@@ -81,7 +82,7 @@ func (c *Client) GetRepository(namespace, repository string) (RepositoryWithTags
 }
 
 // CreateRepository creates a new repository
-func (c *Client) CreateRepository(namespace, repository, visibility, description string) (*Repository, error) {
+func (c *Client) CreateRepository(ctx context.Context, namespace, repository, visibility, description string) (*Repository, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -92,7 +93,7 @@ func (c *Client) CreateRepository(namespace, repository, visibility, description
 		return nil, fmt.Errorf("visibility is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository"), CreateRepositoryRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/repository"), CreateRepositoryRequest{
 		Repository:  repository,
 		Namespace:   namespace,
 		Visibility:  visibility,
@@ -111,7 +112,7 @@ func (c *Client) CreateRepository(namespace, repository, visibility, description
 }
 
 // UpdateRepository updates an existing repository
-func (c *Client) UpdateRepository(namespace, repository, description, visibility string) (*Repository, error) {
+func (c *Client) UpdateRepository(ctx context.Context, namespace, repository, description, visibility string) (*Repository, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -129,7 +130,7 @@ func (c *Client) UpdateRepository(namespace, repository, description, visibility
 		updateReq.Visibility = visibility
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s", namespace, repository), updateReq)
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/repository/%s/%s", namespace, repository), updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update repository request: %w", err)
 	}
@@ -143,7 +144,7 @@ func (c *Client) UpdateRepository(namespace, repository, description, visibility
 }
 
 // DeleteRepository deletes a repository
-func (c *Client) DeleteRepository(namespace, repository string) error {
+func (c *Client) DeleteRepository(ctx context.Context, namespace, repository string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -151,7 +152,7 @@ func (c *Client) DeleteRepository(namespace, repository string) error {
 		return fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s", namespace, repository), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/repository/%s/%s", namespace, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete repository request: %w", err)
 	}
@@ -164,8 +165,8 @@ func (c *Client) DeleteRepository(namespace, repository string) error {
 }
 
 // ListRepositories lists all repositories visible to the user
-func (c *Client) ListRepositories(namespace string, public, starred, popularity bool, page, limit int) (*RepositoryList, error) {
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository"), nil)
+func (c *Client) ListRepositories(ctx context.Context, namespace string, public, starred, popularity bool, page, limit int) (*RepositoryList, error) {
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list repositories request: %w", err)
 	}
@@ -200,13 +201,13 @@ func (c *Client) ListRepositories(namespace string, public, starred, popularity 
 }
 
 // ListAllRepositories fetches all repositories by following pagination automatically.
-func (c *Client) ListAllRepositories(namespace string, public, starred, popularity bool) ([]OrganizationRepository, error) {
+func (c *Client) ListAllRepositories(ctx context.Context, namespace string, public, starred, popularity bool) ([]OrganizationRepository, error) {
 	var all []OrganizationRepository
 	page := 1
 	const pageSize = 100
 
 	for {
-		repos, err := c.ListRepositories(namespace, public, starred, popularity, page, pageSize)
+		repos, err := c.ListRepositories(ctx, namespace, public, starred, popularity, page, pageSize)
 		if err != nil {
 			return nil, err
 		}
@@ -223,7 +224,7 @@ func (c *Client) ListAllRepositories(namespace string, public, starred, populari
 }
 
 // ListAllTags fetches all tags for a repository by following pagination automatically.
-func (c *Client) ListAllTags(namespace, repository string, onlyActive bool) ([]Tag, error) {
+func (c *Client) ListAllTags(ctx context.Context, namespace, repository string, onlyActive bool) ([]Tag, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -236,7 +237,7 @@ func (c *Client) ListAllTags(namespace, repository string, onlyActive bool) ([]T
 	const pageSize = 100
 
 	for {
-		tags, err := c.ListTagsPage(namespace, repository, pageSize, page, onlyActive)
+		tags, err := c.ListTagsPage(ctx, namespace, repository, pageSize, page, onlyActive)
 		if err != nil {
 			return nil, err
 		}
@@ -253,7 +254,7 @@ func (c *Client) ListAllTags(namespace, repository string, onlyActive bool) ([]T
 }
 
 // ChangeRepositoryVisibility changes the visibility (public/private) of a repository
-func (c *Client) ChangeRepositoryVisibility(namespace, repository, visibility string) error {
+func (c *Client) ChangeRepositoryVisibility(ctx context.Context, namespace, repository, visibility string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -269,7 +270,7 @@ func (c *Client) ChangeRepositoryVisibility(namespace, repository, visibility st
 	}{
 		Visibility: visibility,
 	}
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/changevisibility", namespace, repository), body)
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/repository/%s/%s/changevisibility", namespace, repository), body)
 	if err != nil {
 		return fmt.Errorf("failed to create change visibility request: %w", err)
 	}
@@ -282,7 +283,7 @@ func (c *Client) ChangeRepositoryVisibility(namespace, repository, visibility st
 }
 
 // ListTagsPage lists tags for a repository with pagination support.
-func (c *Client) ListTagsPage(namespace, repository string, limit, page int, onlyActive bool) (*RepositoryTags, error) {
+func (c *Client) ListTagsPage(ctx context.Context, namespace, repository string, limit, page int, onlyActive bool) (*RepositoryTags, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -290,7 +291,7 @@ func (c *Client) ListTagsPage(namespace, repository string, limit, page int, onl
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/tag/", namespace, repository), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/tag/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list tags request: %w", err)
 	}
@@ -316,7 +317,7 @@ func (c *Client) ListTagsPage(namespace, repository string, limit, page int, onl
 }
 
 // ListTags lists tags for a repository
-func (c *Client) ListTags(namespace, repository string, limit int, onlyActive bool) (*RepositoryTags, error) {
+func (c *Client) ListTags(ctx context.Context, namespace, repository string, limit int, onlyActive bool) (*RepositoryTags, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -324,7 +325,7 @@ func (c *Client) ListTags(namespace, repository string, limit int, onlyActive bo
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/tag/", namespace, repository), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/tag/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list tags request: %w", err)
 	}

--- a/lib/repository_test.go
+++ b/lib/repository_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -64,7 +65,7 @@ func TestCreateRepository(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	repo, err := client.CreateRepository(testNamespace, testRepository, "private", "Test repository")
+	repo, err := client.CreateRepository(context.Background(), testNamespace, testRepository, "private", "Test repository")
 	if err != nil {
 		t.Fatalf("CreateRepository failed: %v", err)
 	}
@@ -119,7 +120,7 @@ func TestUpdateRepository(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	repo, err := client.UpdateRepository(testNamespace, testRepository, updatedDescription, "public")
+	repo, err := client.UpdateRepository(context.Background(), testNamespace, testRepository, updatedDescription, "public")
 	if err != nil {
 		t.Fatalf("UpdateRepository failed: %v", err)
 	}
@@ -147,7 +148,7 @@ func TestDeleteRepository(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteRepository(testNamespace, testRepository)
+	err = client.DeleteRepository(context.Background(), testNamespace, testRepository)
 	if err != nil {
 		t.Fatalf("DeleteRepository failed: %v", err)
 	}
@@ -187,7 +188,7 @@ func TestListRepositories(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	repos, err := client.ListRepositories(testNamespace, true, false, false, 0, 0)
+	repos, err := client.ListRepositories(context.Background(), testNamespace, true, false, false, 0, 0)
 	if err != nil {
 		t.Fatalf("ListRepositories returned error: %v", err)
 	}
@@ -234,7 +235,7 @@ func TestListTags(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	tags, err := client.ListTags(testNamespace, testRepository, 5, true)
+	tags, err := client.ListTags(context.Background(), testNamespace, testRepository, 5, true)
 	if err != nil {
 		t.Fatalf("ListTags returned error: %v", err)
 	}
@@ -271,7 +272,7 @@ func TestChangeRepositoryVisibility(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.ChangeRepositoryVisibility(testNamespace, testRepository, "public")
+	err = client.ChangeRepositoryVisibility(context.Background(), testNamespace, testRepository, "public")
 	if err != nil {
 		t.Fatalf("ChangeRepositoryVisibility returned error: %v", err)
 	}
@@ -325,7 +326,7 @@ func TestGetRepository(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	repoWithTags, err := client.GetRepository(testNamespace, testRepository)
+	repoWithTags, err := client.GetRepository(context.Background(), testNamespace, testRepository)
 	if err != nil {
 		t.Fatalf("GetRepository failed: %v", err)
 	}
@@ -352,32 +353,32 @@ func TestRepositoryHTTPErrors(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetRepository(testNamespace, testRepository)
+	_, err = client.GetRepository(context.Background(), testNamespace, testRepository)
 	if err == nil {
 		t.Error("Expected error from GetRepository, got nil")
 	}
 
-	_, err = client.CreateRepository(testNamespace, testRepository, "public", testRepoDescription)
+	_, err = client.CreateRepository(context.Background(), testNamespace, testRepository, "public", testRepoDescription)
 	if err == nil {
 		t.Error("Expected error from CreateRepository, got nil")
 	}
 
-	_, err = client.UpdateRepository(testNamespace, testRepository, updatedDescription, "private")
+	_, err = client.UpdateRepository(context.Background(), testNamespace, testRepository, updatedDescription, "private")
 	if err == nil {
 		t.Error("Expected error from UpdateRepository, got nil")
 	}
 
-	err = client.DeleteRepository(testNamespace, testRepository)
+	err = client.DeleteRepository(context.Background(), testNamespace, testRepository)
 	if err == nil {
 		t.Error("Expected error from DeleteRepository, got nil")
 	}
 
-	_, err = client.ListRepositories(testNamespace, false, false, false, 1, 10)
+	_, err = client.ListRepositories(context.Background(), testNamespace, false, false, false, 1, 10)
 	if err == nil {
 		t.Error("Expected error from ListRepositories, got nil")
 	}
 
-	err = client.ChangeRepositoryVisibility(testNamespace, testRepository, "public")
+	err = client.ChangeRepositoryVisibility(context.Background(), testNamespace, testRepository, "public")
 	if err == nil {
 		t.Error("Expected error from ChangeRepositoryVisibility, got nil")
 	}
@@ -406,7 +407,7 @@ func TestListAllRepositories(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	repos, err := client.ListAllRepositories(testNamespace, true, false, false)
+	repos, err := client.ListAllRepositories(context.Background(), testNamespace, true, false, false)
 	if err != nil {
 		t.Fatalf("ListAllRepositories returned error: %v", err)
 	}
@@ -438,7 +439,7 @@ func TestListAllTags(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	tags, err := client.ListAllTags(testNamespace, testRepository, true)
+	tags, err := client.ListAllTags(context.Background(), testNamespace, testRepository, true)
 	if err != nil {
 		t.Fatalf("ListAllTags returned error: %v", err)
 	}

--- a/lib/repotoken.go
+++ b/lib/repotoken.go
@@ -16,6 +16,7 @@ Robot accounts provide better security, auditing, and permission management.
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -23,7 +24,7 @@ import (
 // GetRepoTokens retrieves all tokens for a repository.
 //
 // Deprecated: Use robot accounts instead.
-func (c *Client) GetRepoTokens(namespace, repository string) (*RepoTokens, error) {
+func (c *Client) GetRepoTokens(ctx context.Context, namespace, repository string) (*RepoTokens, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -31,7 +32,7 @@ func (c *Client) GetRepoTokens(namespace, repository string) (*RepoTokens, error
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/tokens", namespace, repository), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/tokens", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repo tokens request: %w", err)
 	}
@@ -47,7 +48,7 @@ func (c *Client) GetRepoTokens(namespace, repository string) (*RepoTokens, error
 // CreateRepoToken creates a new repository token.
 //
 // Deprecated: Use robot accounts instead.
-func (c *Client) CreateRepoToken(namespace, repository string, createReq *CreateRepoTokenRequest) (*RepoToken, error) {
+func (c *Client) CreateRepoToken(ctx context.Context, namespace, repository string, createReq *CreateRepoTokenRequest) (*RepoToken, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -55,7 +56,7 @@ func (c *Client) CreateRepoToken(namespace, repository string, createReq *Create
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/tokens", namespace, repository), createReq)
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/repository/%s/%s/tokens", namespace, repository), createReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create repo token request: %w", err)
 	}
@@ -71,7 +72,7 @@ func (c *Client) CreateRepoToken(namespace, repository string, createReq *Create
 // GetRepoToken retrieves a specific repository token.
 //
 // Deprecated: Use robot accounts instead.
-func (c *Client) GetRepoToken(namespace, repository, code string) (*RepoToken, error) {
+func (c *Client) GetRepoToken(ctx context.Context, namespace, repository, code string) (*RepoToken, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -82,7 +83,7 @@ func (c *Client) GetRepoToken(namespace, repository, code string) (*RepoToken, e
 		return nil, fmt.Errorf("code is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/tokens/%s", namespace, repository, code), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/tokens/%s", namespace, repository, code), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get repo token request: %w", err)
 	}
@@ -98,7 +99,7 @@ func (c *Client) GetRepoToken(namespace, repository, code string) (*RepoToken, e
 // UpdateRepoToken updates a repository token.
 //
 // Deprecated: Use robot accounts instead.
-func (c *Client) UpdateRepoToken(namespace, repository, code string, updateReq *UpdateRepoTokenRequest) (*RepoToken, error) {
+func (c *Client) UpdateRepoToken(ctx context.Context, namespace, repository, code string, updateReq *UpdateRepoTokenRequest) (*RepoToken, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -109,7 +110,7 @@ func (c *Client) UpdateRepoToken(namespace, repository, code string, updateReq *
 		return nil, fmt.Errorf("code is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s/tokens/%s", namespace, repository, code), updateReq)
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/repository/%s/%s/tokens/%s", namespace, repository, code), updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update repo token request: %w", err)
 	}
@@ -125,7 +126,7 @@ func (c *Client) UpdateRepoToken(namespace, repository, code string, updateReq *
 // DeleteRepoToken deletes a repository token.
 //
 // Deprecated: Use robot accounts instead.
-func (c *Client) DeleteRepoToken(namespace, repository, code string) error {
+func (c *Client) DeleteRepoToken(ctx context.Context, namespace, repository, code string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -136,7 +137,7 @@ func (c *Client) DeleteRepoToken(namespace, repository, code string) error {
 		return fmt.Errorf("code is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/tokens/%s", namespace, repository, code), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/repository/%s/%s/tokens/%s", namespace, repository, code), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete repo token request: %w", err)
 	}

--- a/lib/repotoken_test.go
+++ b/lib/repotoken_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -38,7 +39,7 @@ func TestGetRepoTokens(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	tokens, err := client.GetRepoTokens(testNamespace, testRepository)
+	tokens, err := client.GetRepoTokens(context.Background(), testNamespace, testRepository)
 	if err != nil {
 		t.Fatalf("GetRepoTokens returned error: %v", err)
 	}
@@ -78,7 +79,7 @@ func TestCreateRepoToken(t *testing.T) {
 		FriendlyName: "New CI Token",
 	}
 
-	token, err := client.CreateRepoToken(testNamespace, testRepository, createReq)
+	token, err := client.CreateRepoToken(context.Background(), testNamespace, testRepository, createReq)
 	if err != nil {
 		t.Fatalf("CreateRepoToken returned error: %v", err)
 	}
@@ -114,7 +115,7 @@ func TestGetRepoToken(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	token, err := client.GetRepoToken(testNamespace, testRepository, testTokenCode)
+	token, err := client.GetRepoToken(context.Background(), testNamespace, testRepository, testTokenCode)
 	if err != nil {
 		t.Fatalf("GetRepoToken returned error: %v", err)
 	}
@@ -150,7 +151,7 @@ func TestUpdateRepoToken(t *testing.T) {
 		Role: testRoleWrite,
 	}
 
-	token, err := client.UpdateRepoToken(testNamespace, testRepository, testTokenCode, updateReq)
+	token, err := client.UpdateRepoToken(context.Background(), testNamespace, testRepository, testTokenCode, updateReq)
 	if err != nil {
 		t.Fatalf("UpdateRepoToken returned error: %v", err)
 	}
@@ -178,7 +179,7 @@ func TestDeleteRepoToken(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteRepoToken(testNamespace, testRepository, testTokenCode)
+	err = client.DeleteRepoToken(context.Background(), testNamespace, testRepository, testTokenCode)
 	if err != nil {
 		t.Fatalf("DeleteRepoToken returned error: %v", err)
 	}
@@ -195,7 +196,7 @@ func TestGetRepoTokensError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetRepoTokens(testNamespace, testRepository)
+	_, err = client.GetRepoTokens(context.Background(), testNamespace, testRepository)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -212,22 +213,22 @@ func TestRepoTokenHTTPErrors(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.CreateRepoToken(testNamespace, testRepository, &CreateRepoTokenRequest{FriendlyName: testPlaceholder})
+	_, err = client.CreateRepoToken(context.Background(), testNamespace, testRepository, &CreateRepoTokenRequest{FriendlyName: testPlaceholder})
 	if err == nil {
 		t.Error("Expected error from CreateRepoToken, got nil")
 	}
 
-	_, err = client.GetRepoToken(testNamespace, testRepository, testTokenCode)
+	_, err = client.GetRepoToken(context.Background(), testNamespace, testRepository, testTokenCode)
 	if err == nil {
 		t.Error("Expected error from GetRepoToken, got nil")
 	}
 
-	_, err = client.UpdateRepoToken(testNamespace, testRepository, testTokenCode, &UpdateRepoTokenRequest{Role: testRoleWrite})
+	_, err = client.UpdateRepoToken(context.Background(), testNamespace, testRepository, testTokenCode, &UpdateRepoTokenRequest{Role: testRoleWrite})
 	if err == nil {
 		t.Error("Expected error from UpdateRepoToken, got nil")
 	}
 
-	err = client.DeleteRepoToken(testNamespace, testRepository, testTokenCode)
+	err = client.DeleteRepoToken(context.Background(), testNamespace, testRepository, testTokenCode)
 	if err == nil {
 		t.Error("Expected error from DeleteRepoToken, got nil")
 	}

--- a/lib/robot.go
+++ b/lib/robot.go
@@ -17,13 +17,14 @@ Robot Account Management:
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetUserRobotAccounts retrieves all robot accounts for the authenticated user
-func (c *Client) GetUserRobotAccounts() (*RobotAccounts, error) {
-	req, err := newRequest(http.MethodGet, c.buildURL("/user/robots"), nil)
+func (c *Client) GetUserRobotAccounts(ctx context.Context) (*RobotAccounts, error) {
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/user/robots"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user robots request: %w", err)
 	}
@@ -37,12 +38,12 @@ func (c *Client) GetUserRobotAccounts() (*RobotAccounts, error) {
 }
 
 // GetUserRobotAccount retrieves a specific robot account for the authenticated user
-func (c *Client) GetUserRobotAccount(robotShortname string) (*RobotAccount, error) {
+func (c *Client) GetUserRobotAccount(ctx context.Context, robotShortname string) (*RobotAccount, error) {
 	if robotShortname == "" {
 		return nil, fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/user/robots/%s", robotShortname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/user/robots/%s", robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user robot request: %w", err)
 	}
@@ -56,7 +57,7 @@ func (c *Client) GetUserRobotAccount(robotShortname string) (*RobotAccount, erro
 }
 
 // CreateUserRobotAccount creates a new robot account for the authenticated user
-func (c *Client) CreateUserRobotAccount(robotShortname, description string, unstructured map[string]interface{}) (*RobotAccount, error) {
+func (c *Client) CreateUserRobotAccount(ctx context.Context, robotShortname, description string, unstructured map[string]interface{}) (*RobotAccount, error) {
 	if robotShortname == "" {
 		return nil, fmt.Errorf("robotShortname is required")
 	}
@@ -66,7 +67,7 @@ func (c *Client) CreateUserRobotAccount(robotShortname, description string, unst
 		Unstructured: unstructured,
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/user/robots/%s", robotShortname), createReq)
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/user/robots/%s", robotShortname), createReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user robot request: %w", err)
 	}
@@ -80,12 +81,12 @@ func (c *Client) CreateUserRobotAccount(robotShortname, description string, unst
 }
 
 // DeleteUserRobotAccount deletes a robot account for the authenticated user
-func (c *Client) DeleteUserRobotAccount(robotShortname string) error {
+func (c *Client) DeleteUserRobotAccount(ctx context.Context, robotShortname string) error {
 	if robotShortname == "" {
 		return fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/user/robots/%s", robotShortname), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/user/robots/%s", robotShortname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete user robot request: %w", err)
 	}
@@ -98,12 +99,12 @@ func (c *Client) DeleteUserRobotAccount(robotShortname string) error {
 }
 
 // RegenerateUserRobotToken regenerates the token for a user's robot account
-func (c *Client) RegenerateUserRobotToken(robotShortname string) (*RobotAccount, error) {
+func (c *Client) RegenerateUserRobotToken(ctx context.Context, robotShortname string) (*RobotAccount, error) {
 	if robotShortname == "" {
 		return nil, fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest(http.MethodPost, c.buildURL("/user/robots/%s/regenerate", robotShortname), nil)
+	req, err := newRequest(ctx, http.MethodPost, c.buildURL("/user/robots/%s/regenerate", robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create regenerate user robot token request: %w", err)
 	}
@@ -117,12 +118,12 @@ func (c *Client) RegenerateUserRobotToken(robotShortname string) (*RobotAccount,
 }
 
 // GetUserRobotPermissions retrieves the repository permissions for a user's robot account
-func (c *Client) GetUserRobotPermissions(robotShortname string) (*RobotPermissions, error) {
+func (c *Client) GetUserRobotPermissions(ctx context.Context, robotShortname string) (*RobotPermissions, error) {
 	if robotShortname == "" {
 		return nil, fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/user/robots/%s/permissions", robotShortname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/user/robots/%s/permissions", robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user robot permissions request: %w", err)
 	}
@@ -136,12 +137,12 @@ func (c *Client) GetUserRobotPermissions(robotShortname string) (*RobotPermissio
 }
 
 // GetUserRobotFederation retrieves the federation configuration for a user's robot account
-func (c *Client) GetUserRobotFederation(robotShortname string) (*RobotFederation, error) {
+func (c *Client) GetUserRobotFederation(ctx context.Context, robotShortname string) (*RobotFederation, error) {
 	if robotShortname == "" {
 		return nil, fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/user/robots/%s/federation", robotShortname), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/user/robots/%s/federation", robotShortname), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user robot federation request: %w", err)
 	}
@@ -155,12 +156,12 @@ func (c *Client) GetUserRobotFederation(robotShortname string) (*RobotFederation
 }
 
 // CreateUserRobotFederation creates or updates the federation configuration for a user's robot account
-func (c *Client) CreateUserRobotFederation(robotShortname string, configs []RobotFederationConfig) error {
+func (c *Client) CreateUserRobotFederation(ctx context.Context, robotShortname string, configs []RobotFederationConfig) error {
 	if robotShortname == "" {
 		return fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/user/robots/%s/federation", robotShortname), configs)
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/user/robots/%s/federation", robotShortname), configs)
 	if err != nil {
 		return fmt.Errorf("failed to create user robot federation request: %w", err)
 	}
@@ -173,12 +174,12 @@ func (c *Client) CreateUserRobotFederation(robotShortname string, configs []Robo
 }
 
 // DeleteUserRobotFederation deletes the federation configuration for a user's robot account
-func (c *Client) DeleteUserRobotFederation(robotShortname string) error {
+func (c *Client) DeleteUserRobotFederation(ctx context.Context, robotShortname string) error {
 	if robotShortname == "" {
 		return fmt.Errorf("robotShortname is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/user/robots/%s/federation", robotShortname), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/user/robots/%s/federation", robotShortname), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete user robot federation request: %w", err)
 	}

--- a/lib/robot_test.go
+++ b/lib/robot_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -50,7 +51,7 @@ func TestGetUserRobotAccounts(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	robots, err := client.GetUserRobotAccounts()
+	robots, err := client.GetUserRobotAccounts(context.Background())
 	if err != nil {
 		t.Fatalf("GetUserRobotAccounts failed: %v", err)
 	}
@@ -93,7 +94,7 @@ func TestGetUserRobotAccount(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	robot, err := client.GetUserRobotAccount(testRobotShortname)
+	robot, err := client.GetUserRobotAccount(context.Background(), testRobotShortname)
 	if err != nil {
 		t.Fatalf("GetUserRobotAccount failed: %v", err)
 	}
@@ -144,7 +145,7 @@ func TestCreateUserRobotAccount(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	robot, err := client.CreateUserRobotAccount("newbot", "New automation robot", nil)
+	robot, err := client.CreateUserRobotAccount(context.Background(), "newbot", "New automation robot", nil)
 	if err != nil {
 		t.Fatalf("CreateUserRobotAccount failed: %v", err)
 	}
@@ -176,7 +177,7 @@ func TestDeleteUserRobotAccount(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteUserRobotAccount(testRobotShortname)
+	err = client.DeleteUserRobotAccount(context.Background(), testRobotShortname)
 	if err != nil {
 		t.Fatalf("DeleteUserRobotAccount failed: %v", err)
 	}
@@ -212,7 +213,7 @@ func TestRegenerateUserRobotToken(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	robot, err := client.RegenerateUserRobotToken(testRobotShortname)
+	robot, err := client.RegenerateUserRobotToken(context.Background(), testRobotShortname)
 	if err != nil {
 		t.Fatalf("RegenerateUserRobotToken failed: %v", err)
 	}
@@ -258,7 +259,7 @@ func TestGetUserRobotPermissions(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	permissions, err := client.GetUserRobotPermissions(testRobotShortname)
+	permissions, err := client.GetUserRobotPermissions(context.Background(), testRobotShortname)
 	if err != nil {
 		t.Fatalf("GetUserRobotPermissions failed: %v", err)
 	}
@@ -284,37 +285,37 @@ func TestUserRobotErrorHandling(t *testing.T) {
 	}
 
 	// Test GetUserRobotAccounts error
-	_, err = client.GetUserRobotAccounts()
+	_, err = client.GetUserRobotAccounts(context.Background())
 	if err == nil {
 		t.Error("Expected error for failed request, got nil")
 	}
 
 	// Test GetUserRobotAccount error
-	_, err = client.GetUserRobotAccount("nonexistent")
+	_, err = client.GetUserRobotAccount(context.Background(), "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent robot, got nil")
 	}
 
 	// Test CreateUserRobotAccount error
-	_, err = client.CreateUserRobotAccount("badbot", "desc", nil)
+	_, err = client.CreateUserRobotAccount(context.Background(), "badbot", "desc", nil)
 	if err == nil {
 		t.Error("Expected error for failed create, got nil")
 	}
 
 	// Test DeleteUserRobotAccount error
-	err = client.DeleteUserRobotAccount("nonexistent")
+	err = client.DeleteUserRobotAccount(context.Background(), "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent robot, got nil")
 	}
 
 	// Test RegenerateUserRobotToken error
-	_, err = client.RegenerateUserRobotToken("nonexistent")
+	_, err = client.RegenerateUserRobotToken(context.Background(), "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent robot, got nil")
 	}
 
 	// Test GetUserRobotPermissions error
-	_, err = client.GetUserRobotPermissions("nonexistent")
+	_, err = client.GetUserRobotPermissions(context.Background(), "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent robot, got nil")
 	}
@@ -346,7 +347,7 @@ func TestGetUserRobotFederation(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	federation, err := client.GetUserRobotFederation(testRobotShortname)
+	federation, err := client.GetUserRobotFederation(context.Background(), testRobotShortname)
 	if err != nil {
 		t.Fatalf("GetUserRobotFederation returned error: %v", err)
 	}
@@ -381,7 +382,7 @@ func TestCreateUserRobotFederation(t *testing.T) {
 		{Issuer: testFederationIssuer, Subject: testFederationSubject},
 	}
 
-	err = client.CreateUserRobotFederation(testRobotShortname, configs)
+	err = client.CreateUserRobotFederation(context.Background(), testRobotShortname, configs)
 	if err != nil {
 		t.Fatalf("CreateUserRobotFederation returned error: %v", err)
 	}
@@ -405,7 +406,7 @@ func TestDeleteUserRobotFederation(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteUserRobotFederation(testRobotShortname)
+	err = client.DeleteUserRobotFederation(context.Background(), testRobotShortname)
 	if err != nil {
 		t.Fatalf("DeleteUserRobotFederation returned error: %v", err)
 	}
@@ -422,19 +423,19 @@ func TestRobotHTTPErrors(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetUserRobotFederation(testRobotShortname)
+	_, err = client.GetUserRobotFederation(context.Background(), testRobotShortname)
 	if err == nil {
 		t.Error("Expected error from GetUserRobotFederation, got nil")
 	}
 
-	err = client.CreateUserRobotFederation(testRobotShortname, []RobotFederationConfig{
+	err = client.CreateUserRobotFederation(context.Background(), testRobotShortname, []RobotFederationConfig{
 		{Issuer: testFederationIssuer, Subject: testFederationSubject},
 	})
 	if err == nil {
 		t.Error("Expected error from CreateUserRobotFederation, got nil")
 	}
 
-	err = client.DeleteUserRobotFederation(testRobotShortname)
+	err = client.DeleteUserRobotFederation(context.Background(), testRobotShortname)
 	if err == nil {
 		t.Error("Expected error from DeleteUserRobotFederation, got nil")
 	}

--- a/lib/search.go
+++ b/lib/search.go
@@ -13,17 +13,18 @@ users, organizations, teams, and robots across Quay.io.
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // SearchRepositories searches for repositories matching the query
-func (c *Client) SearchRepositories(query string, page int) (*SearchRepositoryResult, error) {
+func (c *Client) SearchRepositories(ctx context.Context, query string, page int) (*SearchRepositoryResult, error) {
 	if query == "" {
 		return nil, fmt.Errorf("query is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/find/repositories"), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/find/repositories"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create search repositories request: %w", err)
 	}
@@ -43,12 +44,12 @@ func (c *Client) SearchRepositories(query string, page int) (*SearchRepositoryRe
 }
 
 // SearchAll searches for all entity types (repositories, users, organizations, teams, robots)
-func (c *Client) SearchAll(query string) (*SearchAllResult, error) {
+func (c *Client) SearchAll(ctx context.Context, query string) (*SearchAllResult, error) {
 	if query == "" {
 		return nil, fmt.Errorf("query is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/find/all"), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/find/all"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create search all request: %w", err)
 	}

--- a/lib/search_test.go
+++ b/lib/search_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -58,7 +59,7 @@ func TestSearchRepositories(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	result, err := client.SearchRepositories(testSearchQueryValue, 0)
+	result, err := client.SearchRepositories(context.Background(), testSearchQueryValue, 0)
 	if err != nil {
 		t.Fatalf("SearchRepositories failed: %v", err)
 	}
@@ -103,7 +104,7 @@ func TestSearchRepositoriesWithPage(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	result, err := client.SearchRepositories("test", 2)
+	result, err := client.SearchRepositories(context.Background(), "test", 2)
 	if err != nil {
 		t.Fatalf("SearchRepositories failed: %v", err)
 	}
@@ -167,7 +168,7 @@ func TestSearchAll(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	result, err := client.SearchAll(testSearchQueryValue)
+	result, err := client.SearchAll(context.Background(), testSearchQueryValue)
 	if err != nil {
 		t.Fatalf("SearchAll failed: %v", err)
 	}
@@ -205,13 +206,13 @@ func TestSearchErrorHandling(t *testing.T) {
 	}
 
 	// Test SearchRepositories error
-	_, err = client.SearchRepositories("test", 0)
+	_, err = client.SearchRepositories(context.Background(), "test", 0)
 	if err == nil {
 		t.Error("Expected error for failed request, got nil")
 	}
 
 	// Test SearchAll error
-	_, err = client.SearchAll("test")
+	_, err = client.SearchAll(context.Background(), "test")
 	if err == nil {
 		t.Error("Expected error for failed request, got nil")
 	}
@@ -239,7 +240,7 @@ func TestSearchEmptyResults(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	result, err := client.SearchRepositories("nonexistent-repo-xyz", 0)
+	result, err := client.SearchRepositories(context.Background(), "nonexistent-repo-xyz", 0)
 	if err != nil {
 		t.Fatalf("SearchRepositories failed: %v", err)
 	}

--- a/lib/secscan.go
+++ b/lib/secscan.go
@@ -12,12 +12,13 @@ container images, including CVE details, severity levels, and fix versions.
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetManifestSecurity retrieves security scan information for a specific manifest
-func (c *Client) GetManifestSecurity(namespace, repository, manifestRef string, vulnerabilities bool) (*SecurityScan, error) {
+func (c *Client) GetManifestSecurity(ctx context.Context, namespace, repository, manifestRef string, vulnerabilities bool) (*SecurityScan, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -28,7 +29,7 @@ func (c *Client) GetManifestSecurity(namespace, repository, manifestRef string, 
 		return nil, fmt.Errorf("manifestRef is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/manifest/%s/security", namespace, repository, manifestRef), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/manifest/%s/security", namespace, repository, manifestRef), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get manifest security request: %w", err)
 	}

--- a/lib/secscan_test.go
+++ b/lib/secscan_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -76,7 +77,7 @@ func TestGetManifestSecurity(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	securityScan, err := client.GetManifestSecurity(testNamespace, testRepository, testSecScanManifestRef, true)
+	securityScan, err := client.GetManifestSecurity(context.Background(), testNamespace, testRepository, testSecScanManifestRef, true)
 	if err != nil {
 		t.Fatalf("GetManifestSecurity failed: %v", err)
 	}
@@ -144,7 +145,7 @@ func TestGetManifestSecurityWithoutVulnerabilities(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	securityScan, err := client.GetManifestSecurity(testNamespace, testRepository, testSecScanManifestRef, false)
+	securityScan, err := client.GetManifestSecurity(context.Background(), testNamespace, testRepository, testSecScanManifestRef, false)
 	if err != nil {
 		t.Fatalf("GetManifestSecurity failed: %v", err)
 	}
@@ -174,7 +175,7 @@ func TestGetManifestSecurityQueued(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	securityScan, err := client.GetManifestSecurity(testNamespace, testRepository, testSecScanManifestRef, true)
+	securityScan, err := client.GetManifestSecurity(context.Background(), testNamespace, testRepository, testSecScanManifestRef, true)
 	if err != nil {
 		t.Fatalf("GetManifestSecurity failed: %v", err)
 	}
@@ -200,7 +201,7 @@ func TestGetManifestSecurityErrorHandling(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetManifestSecurity(testNamespace, testRepository, "nonexistent", true)
+	_, err = client.GetManifestSecurity(context.Background(), testNamespace, testRepository, "nonexistent", true)
 	if err == nil {
 		t.Error("Expected error for non-existent manifest, got nil")
 	}
@@ -226,7 +227,7 @@ func TestGetManifestSecurityUnsupported(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	securityScan, err := client.GetManifestSecurity(testNamespace, testRepository, testSecScanManifestRef, true)
+	securityScan, err := client.GetManifestSecurity(context.Background(), testNamespace, testRepository, testSecScanManifestRef, true)
 	if err != nil {
 		t.Fatalf("GetManifestSecurity failed: %v", err)
 	}

--- a/lib/tag.go
+++ b/lib/tag.go
@@ -16,12 +16,13 @@ expiration management for individual tags.
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetTag retrieves detailed information about a specific tag
-func (c *Client) GetTag(namespace, repository, tag string) (*Tag, error) {
+func (c *Client) GetTag(ctx context.Context, namespace, repository, tag string) (*Tag, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -32,7 +33,7 @@ func (c *Client) GetTag(namespace, repository, tag string) (*Tag, error) {
 		return nil, fmt.Errorf("tag is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get tag request: %w", err)
 	}
@@ -46,7 +47,7 @@ func (c *Client) GetTag(namespace, repository, tag string) (*Tag, error) {
 }
 
 // UpdateTag updates tag metadata (currently supports expiration)
-func (c *Client) UpdateTag(namespace, repository, tag, expiration string) (*Tag, error) {
+func (c *Client) UpdateTag(ctx context.Context, namespace, repository, tag, expiration string) (*Tag, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -63,7 +64,7 @@ func (c *Client) UpdateTag(namespace, repository, tag, expiration string) (*Tag,
 		updateReq.Expiration = expiration
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), updateReq)
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update tag request: %w", err)
 	}
@@ -77,7 +78,7 @@ func (c *Client) UpdateTag(namespace, repository, tag, expiration string) (*Tag,
 }
 
 // DeleteTag deletes a specific tag from a repository
-func (c *Client) DeleteTag(namespace, repository, tag string) error {
+func (c *Client) DeleteTag(ctx context.Context, namespace, repository, tag string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -88,7 +89,7 @@ func (c *Client) DeleteTag(namespace, repository, tag string) error {
 		return fmt.Errorf("tag is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete tag request: %w", err)
 	}
@@ -101,7 +102,7 @@ func (c *Client) DeleteTag(namespace, repository, tag string) error {
 }
 
 // GetTagHistory retrieves the history of changes for a specific tag
-func (c *Client) GetTagHistory(namespace, repository, tag string) (*TagHistory, error) {
+func (c *Client) GetTagHistory(ctx context.Context, namespace, repository, tag string) (*TagHistory, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -112,7 +113,7 @@ func (c *Client) GetTagHistory(namespace, repository, tag string) (*TagHistory, 
 		return nil, fmt.Errorf("tag is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/tag/%s/history", namespace, repository, tag), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/tag/%s/history", namespace, repository, tag), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get tag history request: %w", err)
 	}
@@ -126,7 +127,7 @@ func (c *Client) GetTagHistory(namespace, repository, tag string) (*TagHistory, 
 }
 
 // RevertTag reverts a tag to a previous state by manifest digest
-func (c *Client) RevertTag(namespace, repository, tag, manifestDigest string) (*Tag, error) {
+func (c *Client) RevertTag(ctx context.Context, namespace, repository, tag, manifestDigest string) (*Tag, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -140,7 +141,7 @@ func (c *Client) RevertTag(namespace, repository, tag, manifestDigest string) (*
 		return nil, fmt.Errorf("manifestDigest is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/tag/%s/revert", namespace, repository, tag), RevertTagRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/repository/%s/%s/tag/%s/revert", namespace, repository, tag), RevertTagRequest{
 		ManifestDigest: manifestDigest,
 	})
 	if err != nil {
@@ -156,7 +157,7 @@ func (c *Client) RevertTag(namespace, repository, tag, manifestDigest string) (*
 }
 
 // ChangeTag creates or moves a tag to point at a specific manifest digest
-func (c *Client) ChangeTag(namespace, repository, tag, manifestDigest string) error {
+func (c *Client) ChangeTag(ctx context.Context, namespace, repository, tag, manifestDigest string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -175,7 +176,7 @@ func (c *Client) ChangeTag(namespace, repository, tag, manifestDigest string) er
 	}{
 		ManifestDigest: manifestDigest,
 	}
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), body)
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/repository/%s/%s/tag/%s", namespace, repository, tag), body)
 	if err != nil {
 		return fmt.Errorf("failed to create change tag request: %w", err)
 	}
@@ -188,7 +189,7 @@ func (c *Client) ChangeTag(namespace, repository, tag, manifestDigest string) er
 }
 
 // RestoreTag restores a tag to a previous image
-func (c *Client) RestoreTag(namespace, repository, tag, manifestDigest string) error {
+func (c *Client) RestoreTag(ctx context.Context, namespace, repository, tag, manifestDigest string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -207,7 +208,7 @@ func (c *Client) RestoreTag(namespace, repository, tag, manifestDigest string) e
 	}{
 		ManifestDigest: manifestDigest,
 	}
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/tag/%s/restore", namespace, repository, tag), body)
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/repository/%s/%s/tag/%s/restore", namespace, repository, tag), body)
 	if err != nil {
 		return fmt.Errorf("failed to create restore tag request: %w", err)
 	}

--- a/lib/tag_test.go
+++ b/lib/tag_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -47,7 +48,7 @@ func TestGetTag(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	tag, err := client.GetTag(testNamespace, testRepository, testTagNameV1)
+	tag, err := client.GetTag(context.Background(), testNamespace, testRepository, testTagNameV1)
 	if err != nil {
 		t.Fatalf("GetTag failed: %v", err)
 	}
@@ -104,7 +105,7 @@ func TestUpdateTag(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	tag, err := client.UpdateTag(testNamespace, testRepository, testTagNameV1, testExpirationTime)
+	tag, err := client.UpdateTag(context.Background(), testNamespace, testRepository, testTagNameV1, testExpirationTime)
 	if err != nil {
 		t.Fatalf("UpdateTag failed: %v", err)
 	}
@@ -132,7 +133,7 @@ func TestDeleteTag(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteTag(testNamespace, testRepository, "old-version")
+	err = client.DeleteTag(context.Background(), testNamespace, testRepository, "old-version")
 	if err != nil {
 		t.Fatalf("DeleteTag failed: %v", err)
 	}
@@ -177,7 +178,7 @@ func TestGetTagHistory(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	history, err := client.GetTagHistory(testNamespace, testRepository, testTagNameLatest)
+	history, err := client.GetTagHistory(context.Background(), testNamespace, testRepository, testTagNameLatest)
 	if err != nil {
 		t.Fatalf("GetTagHistory failed: %v", err)
 	}
@@ -235,7 +236,7 @@ func TestRevertTag(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	tag, err := client.RevertTag(testNamespace, testRepository, testTagNameLatest, testManifestDigest)
+	tag, err := client.RevertTag(context.Background(), testNamespace, testRepository, testTagNameLatest, testManifestDigest)
 	if err != nil {
 		t.Fatalf("RevertTag failed: %v", err)
 	}
@@ -273,7 +274,7 @@ func TestChangeTag(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.ChangeTag(testNamespace, testRepository, testTagNameLatest, testManifestDigest)
+	err = client.ChangeTag(context.Background(), testNamespace, testRepository, testTagNameLatest, testManifestDigest)
 	if err != nil {
 		t.Fatalf("ChangeTag returned error: %v", err)
 	}
@@ -307,7 +308,7 @@ func TestRestoreTag(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.RestoreTag(testNamespace, testRepository, testTagNameLatest, testManifestDigest)
+	err = client.RestoreTag(context.Background(), testNamespace, testRepository, testTagNameLatest, testManifestDigest)
 	if err != nil {
 		t.Fatalf("RestoreTag returned error: %v", err)
 	}
@@ -327,43 +328,43 @@ func TestTagErrorHandling(t *testing.T) {
 	}
 
 	// Test GetTag error
-	_, err = client.GetTag(testNamespace, testRepository, "nonexistent")
+	_, err = client.GetTag(context.Background(), testNamespace, testRepository, "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent tag, got nil")
 	}
 
 	// Test UpdateTag error
-	_, err = client.UpdateTag(testNamespace, testRepository, "nonexistent", testExpirationTime)
+	_, err = client.UpdateTag(context.Background(), testNamespace, testRepository, "nonexistent", testExpirationTime)
 	if err == nil {
 		t.Error("Expected error for non-existent tag, got nil")
 	}
 
 	// Test DeleteTag error
-	err = client.DeleteTag(testNamespace, testRepository, "nonexistent")
+	err = client.DeleteTag(context.Background(), testNamespace, testRepository, "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent tag, got nil")
 	}
 
 	// Test GetTagHistory error
-	_, err = client.GetTagHistory(testNamespace, testRepository, "nonexistent")
+	_, err = client.GetTagHistory(context.Background(), testNamespace, testRepository, "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent tag, got nil")
 	}
 
 	// Test RevertTag error
-	_, err = client.RevertTag(testNamespace, testRepository, "nonexistent", testDigestSHA256)
+	_, err = client.RevertTag(context.Background(), testNamespace, testRepository, "nonexistent", testDigestSHA256)
 	if err == nil {
 		t.Error("Expected error for non-existent tag, got nil")
 	}
 
 	// Test ChangeTag error
-	err = client.ChangeTag(testNamespace, testRepository, "nonexistent", testDigestSHA256)
+	err = client.ChangeTag(context.Background(), testNamespace, testRepository, "nonexistent", testDigestSHA256)
 	if err == nil {
 		t.Error("Expected error from ChangeTag, got nil")
 	}
 
 	// Test RestoreTag error
-	err = client.RestoreTag(testNamespace, testRepository, "nonexistent", testDigestSHA256)
+	err = client.RestoreTag(context.Background(), testNamespace, testRepository, "nonexistent", testDigestSHA256)
 	if err == nil {
 		t.Error("Expected error from RestoreTag, got nil")
 	}

--- a/lib/trigger.go
+++ b/lib/trigger.go
@@ -23,12 +23,13 @@ Supported trigger services:
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetTriggers retrieves all build triggers for a repository
-func (c *Client) GetTriggers(namespace, repository string) (*BuildTriggers, error) {
+func (c *Client) GetTriggers(ctx context.Context, namespace, repository string) (*BuildTriggers, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -36,7 +37,7 @@ func (c *Client) GetTriggers(namespace, repository string) (*BuildTriggers, erro
 		return nil, fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/trigger/", namespace, repository), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/trigger/", namespace, repository), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get triggers request: %w", err)
 	}
@@ -50,7 +51,7 @@ func (c *Client) GetTriggers(namespace, repository string) (*BuildTriggers, erro
 }
 
 // GetTrigger retrieves a specific build trigger by UUID
-func (c *Client) GetTrigger(namespace, repository, triggerUUID string) (*BuildTrigger, error) {
+func (c *Client) GetTrigger(ctx context.Context, namespace, repository, triggerUUID string) (*BuildTrigger, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -61,7 +62,7 @@ func (c *Client) GetTrigger(namespace, repository, triggerUUID string) (*BuildTr
 		return nil, fmt.Errorf("triggerUUID is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get trigger request: %w", err)
 	}
@@ -75,7 +76,7 @@ func (c *Client) GetTrigger(namespace, repository, triggerUUID string) (*BuildTr
 }
 
 // DeleteTrigger deletes a build trigger
-func (c *Client) DeleteTrigger(namespace, repository, triggerUUID string) error {
+func (c *Client) DeleteTrigger(ctx context.Context, namespace, repository, triggerUUID string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -86,7 +87,7 @@ func (c *Client) DeleteTrigger(namespace, repository, triggerUUID string) error 
 		return fmt.Errorf("triggerUUID is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete trigger request: %w", err)
 	}
@@ -99,7 +100,7 @@ func (c *Client) DeleteTrigger(namespace, repository, triggerUUID string) error 
 }
 
 // UpdateTrigger updates a build trigger (enable/disable)
-func (c *Client) UpdateTrigger(namespace, repository, triggerUUID string, enabled bool) (*BuildTrigger, error) {
+func (c *Client) UpdateTrigger(ctx context.Context, namespace, repository, triggerUUID string, enabled bool) (*BuildTrigger, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -110,7 +111,7 @@ func (c *Client) UpdateTrigger(namespace, repository, triggerUUID string, enable
 		return nil, fmt.Errorf("triggerUUID is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPut, c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), UpdateTriggerRequest{
+	req, err := newRequestWithBody(ctx, http.MethodPut, c.buildURL("/repository/%s/%s/trigger/%s", namespace, repository, triggerUUID), UpdateTriggerRequest{
 		Enabled: enabled,
 	})
 	if err != nil {
@@ -126,7 +127,7 @@ func (c *Client) UpdateTrigger(namespace, repository, triggerUUID string, enable
 }
 
 // StartTriggerBuild manually starts a build from a trigger
-func (c *Client) StartTriggerBuild(namespace, repository, triggerUUID string, triggerReq *ManualTriggerRequest) (*Build, error) {
+func (c *Client) StartTriggerBuild(ctx context.Context, namespace, repository, triggerUUID string, triggerReq *ManualTriggerRequest) (*Build, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -142,7 +143,7 @@ func (c *Client) StartTriggerBuild(namespace, repository, triggerUUID string, tr
 		body = triggerReq
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/trigger/%s/start", namespace, repository, triggerUUID), body)
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/repository/%s/%s/trigger/%s/start", namespace, repository, triggerUUID), body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create start trigger build request: %w", err)
 	}
@@ -156,7 +157,7 @@ func (c *Client) StartTriggerBuild(namespace, repository, triggerUUID string, tr
 }
 
 // ActivateTrigger activates a build trigger with configuration
-func (c *Client) ActivateTrigger(namespace, repository, triggerUUID string, activateReq *ActivateTriggerRequest) (*BuildTrigger, error) {
+func (c *Client) ActivateTrigger(ctx context.Context, namespace, repository, triggerUUID string, activateReq *ActivateTriggerRequest) (*BuildTrigger, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -167,7 +168,7 @@ func (c *Client) ActivateTrigger(namespace, repository, triggerUUID string, acti
 		return nil, fmt.Errorf("triggerUUID is required")
 	}
 
-	req, err := newRequestWithBody(http.MethodPost, c.buildURL("/repository/%s/%s/trigger/%s/activate", namespace, repository, triggerUUID), activateReq)
+	req, err := newRequestWithBody(ctx, http.MethodPost, c.buildURL("/repository/%s/%s/trigger/%s/activate", namespace, repository, triggerUUID), activateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create activate trigger request: %w", err)
 	}
@@ -181,7 +182,7 @@ func (c *Client) ActivateTrigger(namespace, repository, triggerUUID string, acti
 }
 
 // GetTriggerBuilds gets the builds started by a specific trigger
-func (c *Client) GetTriggerBuilds(namespace, repository, triggerUUID string, limit int) (*Builds, error) {
+func (c *Client) GetTriggerBuilds(ctx context.Context, namespace, repository, triggerUUID string, limit int) (*Builds, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -192,7 +193,7 @@ func (c *Client) GetTriggerBuilds(namespace, repository, triggerUUID string, lim
 		return nil, fmt.Errorf("triggerUUID is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/repository/%s/%s/trigger/%s/builds", namespace, repository, triggerUUID), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/repository/%s/%s/trigger/%s/builds", namespace, repository, triggerUUID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get trigger builds request: %w", err)
 	}

--- a/lib/trigger_test.go
+++ b/lib/trigger_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -39,7 +40,7 @@ func TestGetTriggers(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	triggers, err := client.GetTriggers(testNamespace, testRepository)
+	triggers, err := client.GetTriggers(context.Background(), testNamespace, testRepository)
 	if err != nil {
 		t.Fatalf("GetTriggers returned error: %v", err)
 	}
@@ -85,7 +86,7 @@ func TestGetTrigger(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	trigger, err := client.GetTrigger(testNamespace, testRepository, testTriggerUUID)
+	trigger, err := client.GetTrigger(context.Background(), testNamespace, testRepository, testTriggerUUID)
 	if err != nil {
 		t.Fatalf("GetTrigger returned error: %v", err)
 	}
@@ -119,7 +120,7 @@ func TestDeleteTrigger(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteTrigger(testNamespace, testRepository, testTriggerUUID)
+	err = client.DeleteTrigger(context.Background(), testNamespace, testRepository, testTriggerUUID)
 	if err != nil {
 		t.Fatalf("DeleteTrigger returned error: %v", err)
 	}
@@ -159,7 +160,7 @@ func TestUpdateTrigger(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	trigger, err := client.UpdateTrigger(testNamespace, testRepository, testTriggerUUID, false)
+	trigger, err := client.UpdateTrigger(context.Background(), testNamespace, testRepository, testTriggerUUID, false)
 	if err != nil {
 		t.Fatalf("UpdateTrigger returned error: %v", err)
 	}
@@ -199,7 +200,7 @@ func TestStartTriggerBuild(t *testing.T) {
 		CommitSHA: "abc123def456",
 	}
 
-	build, err := client.StartTriggerBuild(testNamespace, testRepository, testTriggerUUID, triggerReq)
+	build, err := client.StartTriggerBuild(context.Background(), testNamespace, testRepository, testTriggerUUID, triggerReq)
 	if err != nil {
 		t.Fatalf("StartTriggerBuild returned error: %v", err)
 	}
@@ -243,7 +244,7 @@ func TestActivateTrigger(t *testing.T) {
 		},
 	}
 
-	trigger, err := client.ActivateTrigger(testNamespace, testRepository, testTriggerUUID, activateReq)
+	trigger, err := client.ActivateTrigger(context.Background(), testNamespace, testRepository, testTriggerUUID, activateReq)
 	if err != nil {
 		t.Fatalf("ActivateTrigger returned error: %v", err)
 	}
@@ -283,7 +284,7 @@ func TestGetTriggerBuilds(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	builds, err := client.GetTriggerBuilds(testNamespace, testRepository, testTriggerUUID, 0)
+	builds, err := client.GetTriggerBuilds(context.Background(), testNamespace, testRepository, testTriggerUUID, 0)
 	if err != nil {
 		t.Fatalf("GetTriggerBuilds returned error: %v", err)
 	}
@@ -307,7 +308,7 @@ func TestGetTriggersError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetTriggers(testNamespace, testRepository)
+	_, err = client.GetTriggers(context.Background(), testNamespace, testRepository)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -324,7 +325,7 @@ func TestGetTriggerError(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetTrigger(testNamespace, testRepository, "nonexistent-uuid")
+	_, err = client.GetTrigger(context.Background(), testNamespace, testRepository, "nonexistent-uuid")
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -341,27 +342,27 @@ func TestTriggerHTTPErrors(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.DeleteTrigger(testNamespace, testRepository, testTriggerUUID)
+	err = client.DeleteTrigger(context.Background(), testNamespace, testRepository, testTriggerUUID)
 	if err == nil {
 		t.Error("Expected error from DeleteTrigger, got nil")
 	}
 
-	_, err = client.UpdateTrigger(testNamespace, testRepository, testTriggerUUID, true)
+	_, err = client.UpdateTrigger(context.Background(), testNamespace, testRepository, testTriggerUUID, true)
 	if err == nil {
 		t.Error("Expected error from UpdateTrigger, got nil")
 	}
 
-	_, err = client.StartTriggerBuild(testNamespace, testRepository, testTriggerUUID, &ManualTriggerRequest{CommitSHA: testHashABC123})
+	_, err = client.StartTriggerBuild(context.Background(), testNamespace, testRepository, testTriggerUUID, &ManualTriggerRequest{CommitSHA: testHashABC123})
 	if err == nil {
 		t.Error("Expected error from StartTriggerBuild, got nil")
 	}
 
-	_, err = client.ActivateTrigger(testNamespace, testRepository, testTriggerUUID, &ActivateTriggerRequest{})
+	_, err = client.ActivateTrigger(context.Background(), testNamespace, testRepository, testTriggerUUID, &ActivateTriggerRequest{})
 	if err == nil {
 		t.Error("Expected error from ActivateTrigger, got nil")
 	}
 
-	_, err = client.GetTriggerBuilds(testNamespace, testRepository, testTriggerUUID, 10)
+	_, err = client.GetTriggerBuilds(context.Background(), testNamespace, testRepository, testTriggerUUID, 10)
 	if err == nil {
 		t.Error("Expected error from GetTriggerBuilds, got nil")
 	}

--- a/lib/user.go
+++ b/lib/user.go
@@ -17,13 +17,14 @@ and the ability to star/unstar repositories for easy discovery.
 package lib
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // GetUser retrieves information about the current authenticated user
-func (c *Client) GetUser() (*UserDetails, error) {
-	req, err := newRequest(http.MethodGet, c.buildURL("/user"), nil)
+func (c *Client) GetUser(ctx context.Context) (*UserDetails, error) {
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/user"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user request: %w", err)
 	}
@@ -37,8 +38,8 @@ func (c *Client) GetUser() (*UserDetails, error) {
 }
 
 // GetStarredRepositories retrieves repositories starred by the current user
-func (c *Client) GetStarredRepositories() (*StarredRepositories, error) {
-	req, err := newRequest(http.MethodGet, c.buildURL("/user/starred"), nil)
+func (c *Client) GetStarredRepositories(ctx context.Context) (*StarredRepositories, error) {
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/user/starred"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get starred repositories request: %w", err)
 	}
@@ -52,7 +53,7 @@ func (c *Client) GetStarredRepositories() (*StarredRepositories, error) {
 }
 
 // StarRepository adds a repository to the user's starred list
-func (c *Client) StarRepository(namespace, repository string) error {
+func (c *Client) StarRepository(ctx context.Context, namespace, repository string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -60,7 +61,7 @@ func (c *Client) StarRepository(namespace, repository string) error {
 		return fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest(http.MethodPut, c.buildURL("/repository/%s/%s/star", namespace, repository), nil)
+	req, err := newRequest(ctx, http.MethodPut, c.buildURL("/repository/%s/%s/star", namespace, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create star repository request: %w", err)
 	}
@@ -73,7 +74,7 @@ func (c *Client) StarRepository(namespace, repository string) error {
 }
 
 // UnstarRepository removes a repository from the user's starred list
-func (c *Client) UnstarRepository(namespace, repository string) error {
+func (c *Client) UnstarRepository(ctx context.Context, namespace, repository string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -81,7 +82,7 @@ func (c *Client) UnstarRepository(namespace, repository string) error {
 		return fmt.Errorf("repository is required")
 	}
 
-	req, err := newRequest(http.MethodDelete, c.buildURL("/repository/%s/%s/star", namespace, repository), nil)
+	req, err := newRequest(ctx, http.MethodDelete, c.buildURL("/repository/%s/%s/star", namespace, repository), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create unstar repository request: %w", err)
 	}
@@ -94,12 +95,12 @@ func (c *Client) UnstarRepository(namespace, repository string) error {
 }
 
 // GetUserByUsername retrieves information about a specific user
-func (c *Client) GetUserByUsername(username string) (*UserDetails, error) {
+func (c *Client) GetUserByUsername(ctx context.Context, username string) (*UserDetails, error) {
 	if username == "" {
 		return nil, fmt.Errorf("username is required")
 	}
 
-	req, err := newRequest(http.MethodGet, c.buildURL("/users/%s", username), nil)
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/users/%s", username), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user by username request: %w", err)
 	}
@@ -113,8 +114,8 @@ func (c *Client) GetUserByUsername(username string) (*UserDetails, error) {
 }
 
 // GetUserMarketplace retrieves marketplace information for the current user
-func (c *Client) GetUserMarketplace() (*MarketplaceInfo, error) {
-	req, err := newRequest(http.MethodGet, c.buildURL("/user/marketplace"), nil)
+func (c *Client) GetUserMarketplace(ctx context.Context) (*MarketplaceInfo, error) {
+	req, err := newRequest(ctx, http.MethodGet, c.buildURL("/user/marketplace"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get user marketplace request: %w", err)
 	}

--- a/lib/user_test.go
+++ b/lib/user_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -56,7 +57,7 @@ func TestGetUser(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	user, err := client.GetUser()
+	user, err := client.GetUser(context.Background())
 	if err != nil {
 		t.Fatalf("GetUser failed: %v", err)
 	}
@@ -129,7 +130,7 @@ func TestGetStarredRepositories(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	starred, err := client.GetStarredRepositories()
+	starred, err := client.GetStarredRepositories(context.Background())
 	if err != nil {
 		t.Fatalf("GetStarredRepositories failed: %v", err)
 	}
@@ -178,7 +179,7 @@ func TestStarRepository(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.StarRepository(testSearchQueryValue, testSearchQueryValue)
+	err = client.StarRepository(context.Background(), testSearchQueryValue, testSearchQueryValue)
 	if err != nil {
 		t.Fatalf("StarRepository failed: %v", err)
 	}
@@ -202,7 +203,7 @@ func TestUnstarRepository(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.UnstarRepository(testSearchQueryValue, testSearchQueryValue)
+	err = client.UnstarRepository(context.Background(), testSearchQueryValue, testSearchQueryValue)
 	if err != nil {
 		t.Fatalf("UnstarRepository failed: %v", err)
 	}
@@ -235,7 +236,7 @@ func TestGetUserByUsername(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	user, err := client.GetUserByUsername(testUserName)
+	user, err := client.GetUserByUsername(context.Background(), testUserName)
 	if err != nil {
 		t.Fatalf("GetUserByUsername returned error: %v", err)
 	}
@@ -275,7 +276,7 @@ func TestGetUserMarketplace(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	marketplace, err := client.GetUserMarketplace()
+	marketplace, err := client.GetUserMarketplace(context.Background())
 	if err != nil {
 		t.Fatalf("GetUserMarketplace returned error: %v", err)
 	}
@@ -305,25 +306,25 @@ func TestUserErrorHandling(t *testing.T) {
 	}
 
 	// Test GetUser error
-	_, err = client.GetUser()
+	_, err = client.GetUser(context.Background())
 	if err == nil {
 		t.Error("Expected error for invalid token, got nil")
 	}
 
 	// Test GetStarredRepositories error
-	_, err = client.GetStarredRepositories()
+	_, err = client.GetStarredRepositories(context.Background())
 	if err == nil {
 		t.Error("Expected error for invalid token, got nil")
 	}
 
 	// Test StarRepository error
-	err = client.StarRepository(testSearchQueryValue, testSearchQueryValue)
+	err = client.StarRepository(context.Background(), testSearchQueryValue, testSearchQueryValue)
 	if err == nil {
 		t.Error("Expected error for invalid token, got nil")
 	}
 
 	// Test UnstarRepository error
-	err = client.UnstarRepository(testSearchQueryValue, testSearchQueryValue)
+	err = client.UnstarRepository(context.Background(), testSearchQueryValue, testSearchQueryValue)
 	if err == nil {
 		t.Error("Expected error for invalid token, got nil")
 	}
@@ -342,12 +343,12 @@ func TestUserStarRepositoryNotFound(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.StarRepository("nonexistent", "repository")
+	err = client.StarRepository(context.Background(), "nonexistent", "repository")
 	if err == nil {
 		t.Error("Expected error for non-existent repository, got nil")
 	}
 
-	err = client.UnstarRepository("nonexistent", "repository")
+	err = client.UnstarRepository(context.Background(), "nonexistent", "repository")
 	if err == nil {
 		t.Error("Expected error for non-existent repository, got nil")
 	}
@@ -364,12 +365,12 @@ func TestUserHTTPErrors(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.GetUserByUsername(testUserName)
+	_, err = client.GetUserByUsername(context.Background(), testUserName)
 	if err == nil {
 		t.Error("Expected error from GetUserByUsername, got nil")
 	}
 
-	_, err = client.GetUserMarketplace()
+	_, err = client.GetUserMarketplace(context.Background())
 	if err == nil {
 		t.Error("Expected error from GetUserMarketplace, got nil")
 	}


### PR DESCRIPTION
## Summary
- Add `context.Context` as the first argument to every exported `Client` method and build requests with `http.NewRequestWithContext`
- Honor cancellation during retry backoff; do not retry `context.Canceled` / `DeadlineExceeded`
- CLI passes `cmd.Context()` and cancels in-flight HTTP on SIGINT/SIGTERM

Closes #128

## Test plan
- [x] `make test`
- [x] `make lint`
- [ ] Confirm a canceled context does not hit the mock server (`TestCanceledContextBeforeDo`)
- [ ] Confirm Ctrl+C / SIGTERM aborts an in-flight CLI request


Made with [Cursor](https://cursor.com)